### PR TITLE
CLT Hebrew subtitles update

### DIFF
--- a/2023/clt/hebrew/sentence_translations.json
+++ b/2023/clt/hebrew/sentence_translations.json
@@ -28,7 +28,7 @@
  },
  {
   "input": "There's a very specific function to describe this distribution, it's very pretty, we'll get into it later, but right now I just want to emphasize how the normal distribution is, as the name suggests, very common, it shows up in a lot of seemingly unrelated contexts. ",
-  "translatedText": "יש פונקציה מאוד ספציפית לתאר את ההתפלגות הזו, היא מאוד יפה, ניכנס אליה מאוחר יותר, אבל כרגע אני רק רוצה להדגיש איך ההתפלגות הנורמלית, כפי שהשם מרמז, מאוד נפוצה, היא מופיעה בהרבה של הקשרים לכאורה לא קשורים. ",
+  "translatedText": "יש פונקציה מאוד ספציפית לתאר את ההתפלגות הזו, היא מאוד יפה, ניכנס אליה מאוחר יותר, אבל כרגע אני רק רוצה להדגיש איך ההתפלגות הנורמלית, כפי שהשם מרמז, מאוד נפוצה, היא מופיעה בהרבה הקשרים שלכאורה לא קשורים. ",
   "model": "nmt",
   "time_range": [
    32.5,
@@ -37,7 +37,7 @@
  },
  {
   "input": "If you were to take a large number of people who sit in a similar demographic and plot their heights, those heights tend to follow a normal distribution. ",
-  "translatedText": "אם הייתם לוקחים מספר רב של אנשים שיושבים בדמוגרפיה דומה ומתכננים את הגבהים שלהם, הגבהים האלה נוטים להתפלגות נורמלית. ",
+  "translatedText": "אם הייתם לוקחים מספר רב של אנשים מאוכלוסיה דמוגרפית דומה ומשרטטים את הגבהים שלהם, הגבהים האלה נוטים להתפלגות נורמלית. ",
   "model": "nmt",
   "time_range": [
    46.02,
@@ -46,7 +46,7 @@
  },
  {
   "input": "If you look at a large swath of very big natural numbers and you ask how many distinct prime factors does each one of those numbers have, the answers will very closely track with a certain normal distribution. ",
-  "translatedText": "אם תסתכל על חלק גדול של מספרים טבעיים גדולים מאוד ותשאל כמה גורמים ראשוניים ברורים יש לכל אחד מאותם מספרים, התשובות יתבצעו מקרוב עם התפלגות נורמלית מסוימת. ",
+  "translatedText": "אם תסתכלו על אוסף גדול של מספרים טבעיים גדולים מאוד ותשאלו כמה גורמים ראשוניים נפרדים יש לכל אחד מאותם מספרים, התשובות יהיו קרובות מאד להתפלגות נורמלית מסוימת. ",
   "model": "nmt",
   "time_range": [
    53.66,
@@ -55,7 +55,7 @@
  },
  {
   "input": "Now our topic for today is one of the crown jewels in all of probability theory, it's one of the key facts that explains why this distribution is as common as it is, known as the central limit theorem. ",
-  "translatedText": "עכשיו הנושא שלנו להיום הוא אחד מתכשיטי הכתר בכל תורת ההסתברות, זו אחת העובדות המרכזיות שמסבירות מדוע ההתפלגות הזו נפוצה כמו שהיא, המכונה משפט הגבול המרכזי. ",
+  "translatedText": "עכשיו הנושא שלנו להיום הוא אחד מיהלומי הכתר בכל תורת ההסתברות, זו אחת העובדות המרכזיות שמסבירות מדוע ההתפלגות הזו נפוצה כמו שהיא, ומכונה משפט הגבול המרכזי. ",
   "model": "nmt",
   "time_range": [
    65.58,
@@ -64,7 +64,7 @@
  },
  {
   "input": "This lesson is meant to go back to the basics, giving you the fundamentals on what the central limit theorem is saying, what normal distributions are, and I want to assume minimal background. ",
-  "translatedText": "השיעור הזה נועד לחזור ליסודות, לתת לך את היסודות על מה שמשפט הגבול המרכזי אומר, מהן התפלגויות נורמליות, ואני רוצה להניח רקע מינימלי. ",
+  "translatedText": "השיעור הזה נועד לחזור ליסודות, לתת לכם את היסודות על מה שמשפט הגבול המרכזי אומר, מהן התפלגויות נורמליות, ואני רוצה להניח רקע מינימלי. ",
   "model": "nmt",
   "time_range": [
    76.64,
@@ -73,7 +73,7 @@
  },
  {
   "input": "We're going to go decently deep into it, but after this I'd still like to go deeper and explain why the theorem is true, why the function underlying the normal distribution has the very specific form that it does, why that formula has a pi in it, and, most fun, why those last two facts are actually more related than a lot of traditional explanations would suggest. ",
-  "translatedText": "אנחנו הולכים להעמיק בזה בצורה הגונה, אבל אחרי זה אני עדיין רוצה להעמיק ולהסביר למה המשפט נכון, למה לפונקציה שבבסיס ההתפלגות הנורמלית יש את הצורה הספציפית מאוד שהיא עושה, למה לנוסחה הזו יש פאי בו, והכי כיף, מדוע שתי העובדות האחרונות הללו קשורות למעשה יותר ממה שהרבה הסברים מסורתיים מרמזים. ",
+  "translatedText": "אנחנו הולכים להעמיק בזה, אבל אחרי כן אני עדיין רוצה להעמיק ולהסביר למה המשפט נכון, למה לפונקציה שבבסיס ההתפלגות הנורמלית יש את הצורה הספציפית מאוד שלה, למה מופיע פאי בנוסחה הזו, והכי מהנה, מדוע שתי העובדות האחרונות הללו קשורות למעשה יותר ממה שהרבה הסברים מסורתיים מרמזים. ",
   "model": "nmt",
   "time_range": [
    88.58,
@@ -82,7 +82,7 @@
  },
  {
   "input": "That second lesson is also meant to be the follow-on to the convolutions video that I promised, so there's a lot of interrelated topics here. ",
-  "translatedText": "השיעור השני אמור להיות גם ההמשך לסרטון הפיתולים שהבטחתי, אז יש כאן הרבה נושאים הקשורים זה בזה. ",
+  "translatedText": "השיעור השני אמור להיות גם ההמשך לסרטון הקונבולוציות שהבטחתי, אז יש כאן הרבה נושאים הקשורים זה בזה. ",
   "model": "nmt",
   "time_range": [
    108.84,
@@ -91,7 +91,7 @@
  },
  {
   "input": "But right now, back to the fundamentals, I'd like to kick things off with a overly simplified model of the Galton board. ",
-  "translatedText": "אבל כרגע, בחזרה ליסודות, אני רוצה להתחיל את העניינים עם דגם פשוט מדי של לוח גלטון. ",
+  "translatedText": "אבל כרגע, בחזרה ליסודות, אני רוצה להתחיל עם דגם פשוט מדי של לוח גלטון. ",
   "model": "nmt",
   "time_range": [
    114.59,
@@ -100,7 +100,7 @@
  },
  {
   "input": "In this model we will assume that each ball falls directly onto a certain central peg and that it has a 50-50 probability of bouncing to the left or to the right, and we'll think of each of those outcomes as either adding one or subtracting one from its position. ",
-  "translatedText": "במודל זה נניח שכל כדור נופל ישירות על יתד מרכזי מסוים ושיש לו סבירות של 50-50 לקפוץ שמאלה או ימינה, ונחשוב על כל אחת מהתוצאות האלה כעל הוספת אחת או הפחתת אחד מהמיקום שלו. ",
+  "translatedText": "במודל זה נניח שכל כדור נופל ישירות על יתד מרכזי מסוים ושיש לו סבירות של 50-50 לקפוץ שמאלה או ימינה, ונחשוב על כל אחת מהתוצאות האלה כעל הוספת אחד או הפחתת אחד מהמיקום שלו. ",
   "model": "nmt",
   "time_range": [
    121.49,
@@ -109,7 +109,7 @@
  },
  {
   "input": "Once one of those is chosen, we make the highly unrealistic assumption that it happens to land dead on in the middle of the peg adjacent below it, where again it'll be faced with the same 50-50 choice of bouncing to the left or to the right. ",
-  "translatedText": "ברגע שאחד מאלה נבחר, אנו מניחים את ההנחה המאוד לא מציאותית שהוא במקרה נוחת מת באמצע היתד הסמוך מתחתיו, שם שוב הוא יעמוד בפני אותה בחירה של 50-50 של הקפצה שמאלה או לימין. ",
+  "translatedText": "ברגע שאחת מהאפשרויות נבחרה, אנו מניחים את ההנחה המאוד לא מציאותית שהוא במקרה נוחת בדיוק באמצע היתד הסמוך מתחתיו, שם שוב הוא יעמוד בפני אותה בחירה של 50-50 של הקפצה שמאלה או לימין. ",
   "model": "nmt",
   "time_range": [
    134.67,
@@ -118,7 +118,7 @@
  },
  {
   "input": "For the one I'm showing on screen, there are five different rows of pegs, so our little hopping ball makes five different random choices between plus one and minus one, and we can think of its final position as basically being the sum of all of those different numbers, which in this case happens to be one, and we might label all of the different buckets with the sum that they represent. ",
-  "translatedText": "עבור זה שאני מראה על המסך, יש חמש שורות שונות של יתדות, כך שהכדור הקפיצה הקטן שלנו עושה חמש בחירות אקראיות שונות בין פלוס אחד למינוס אחד, ואנחנו יכולים לחשוב על מיקומו הסופי שהוא בעצם הסכום של כולם של המספרים השונים האלה, שבמקרה זה במקרה זה אחד, ואנחנו עשויים לתייג את כל הדליים השונים עם הסכום שהם מייצגים. ",
+  "translatedText": "עבור זה שאני מראה על המסך, יש חמש שורות שונות של יתדות, כך שכדור הקפיצה הקטן שלנו עושה חמש בחירות אקראיות שונות בין פלוס אחד למינוס אחד, ואנחנו יכולים לחשוב על מיקומו הסופי שהוא בעצם הסכום של כל המספרים השונים האלה, שבמקרה זה הוא אחד, ואנחנו יכולים לתייג את כל המיכלים השונים עם הסכום שהם מייצגים. ",
   "model": "nmt",
   "time_range": [
    147.43,
@@ -127,7 +127,7 @@
  },
  {
   "input": "As we repeat this, we're looking at different possible sums for those five random numbers. ",
-  "translatedText": "כשאנחנו חוזרים על זה, אנחנו מסתכלים על סכומים אפשריים שונים עבור חמשת המספרים האקראיים האלה. ",
+  "translatedText": "ככל שאנחנו חוזרים על זה, אנחנו מסתכלים על סכומים אפשריים שונים עבור חמשת המספרים האקראיים האלה. ",
   "model": "nmt",
   "time_range": [
    166.35,
@@ -136,7 +136,7 @@
  },
  {
   "input": "And for those of you who are inclined to complain that this is a highly unrealistic model for the true Galton board, let me emphasize the goal right now is not to accurately model physics. ",
-  "translatedText": "ולמי מכם שנוטה להתלונן שזהו מודל מאוד לא מציאותי ללוח של גלטון האמיתי, הרשו לי להדגיש שהמטרה כרגע היא לא לדגלם פיזיקה במדויק. ",
+  "translatedText": "ולמי מכם שנוטה להתלונן שזהו מודל מאוד לא מציאותי של לוח גלטון האמיתי, הרשו לי להדגיש שהמטרה כרגע היא לא להציג דגם פיזיקלי מדויק. ",
   "model": "nmt",
   "time_range": [
    173.05,
@@ -145,7 +145,7 @@
  },
  {
   "input": "The goal is to give a simple example to illustrate the central limit theorem, and for that, idealized though this might be, it actually gives us a really good example. ",
-  "translatedText": "המטרה היא לתת דוגמה פשוטה כדי להמחיש את משפט הגבול המרכזי, ולשם כך, למרות שזה יכול להיות אידיאלי, הוא למעשה נותן לנו דוגמה ממש טובה. ",
+  "translatedText": "המטרה היא לתת דוגמה פשוטה כדי להמחיש את משפט הגבול המרכזי, ולשם כך, למרות שזו יכולה להיות אידיאליזציה, היא למעשה נותנת לנו דוגמה ממש טובה. ",
   "model": "nmt",
   "time_range": [
    181.83,
@@ -154,7 +154,7 @@
  },
  {
   "input": "If we let many different balls fall, making yet another unrealistic assumption that they don't influence each other as if they're all ghosts, then the number of balls that fall into each different bucket gives us some loose sense for how likely each one of those buckets is. ",
-  "translatedText": "אם אנו נותנים לכדורים רבים ושונים ליפול, תוך הנחה לא מציאותית נוספת שהם לא משפיעים זה על זה כאילו כולם רוחות רפאים, אז מספר הכדורים שנופלים לכל דלי אחר נותן לנו איזו תחושה רופפת לגבי הסבירות שכל אחד מהם מהדליים האלה הוא. ",
+  "translatedText": "אם אנו נותנים לכדורים רבים ליפול, תוך הנחה לא מציאותית נוספת שהם לא משפיעים זה על זה כאילו כולם רוחות רפאים, אז מספר הכדורים שנופלים לכל מיכל אחר נותן לנו תחושה כלשהי לגבי הסבירות של מהו כל אחד מהמיכלים האלה. ",
   "model": "nmt",
   "time_range": [
    190.57,
@@ -163,7 +163,7 @@
  },
  {
   "input": "In this example, the numbers are simple enough that it's not too hard to explicitly calculate what the probability is for falling into each bucket. ",
-  "translatedText": "בדוגמה זו, המספרים פשוטים מספיק כדי שלא קשה מדי לחשב במפורש מה ההסתברות ליפול לכל דלי. ",
+  "translatedText": "בדוגמה זו, המספרים פשוטים מספיק כך שלא קשה מדי לחשב במפורש מה ההסתברות ליפול לכל מיכל. ",
   "model": "nmt",
   "time_range": [
    203.83,
@@ -172,7 +172,7 @@
  },
  {
   "input": "If you do want to think that through, you'll find it very reminiscent of Pascal's triangle. ",
-  "translatedText": "אם אתה כן רוצה לחשוב על זה, תמצא שזה מאוד מזכיר את המשולש של פסקל. ",
+  "translatedText": "אם אתם רוצים לחשוב על זה, תמצאו שזה מאוד מזכיר את המשולש של פסקל. ",
   "model": "nmt",
   "time_range": [
    210.27,
@@ -181,7 +181,7 @@
  },
  {
   "input": "But the neat thing about our theorem is how far it goes beyond the simple examples. ",
-  "translatedText": "אבל הדבר המסודר במשפט שלנו הוא עד כמה הוא הולך מעבר לדוגמאות הפשוטות. ",
+  "translatedText": "אבל הדבר היפה במשפט שלנו הוא עד כמה הוא הולך מעבר לדוגמאות הפשוטות. ",
   "model": "nmt",
   "time_range": [
    213.95,
@@ -190,7 +190,7 @@
  },
  {
   "input": "So to start off at least, rather than making explicit calculations, let's just simulate things by running a large number of samples and letting the total number of results in each different outcome give us some sense for what that distribution looks like. ",
-  "translatedText": "אז כדי להתחיל לפחות, במקום לבצע חישובים מפורשים, בואו פשוט נדמה דברים על ידי הפעלת מספר רב של דגימות וניתן למספר הכולל של התוצאות בכל תוצאה שונה לתת לנו תחושה של איך נראית ההתפלגות. ",
+  "translatedText": "אז כדי להתחיל לפחות, במקום לבצע חישובים מפורשים, בואו פשוט נדמה דברים על ידי הפעלת מספר רב של דגימות וניתן למספר הכולל של התוצאות לכל ערך שונה לתת לנו תחושה של איך נראית ההתפלגות. ",
   "model": "nmt",
   "time_range": [
    218.67,
@@ -208,7 +208,7 @@
  },
  {
   "input": "The basic idea of the central limit theorem is that if you increase the size of that sum, for example here that would mean increasing the number of rows of pegs for each ball to bounce off, then the distribution that describes where that sum is going to fall looks more and more like a bell curve. ",
-  "translatedText": "הרעיון הבסיסי של משפט הגבול המרכזי הוא שאם תגדיל את גודל הסכום הזה, למשל כאן זה אומר הגדלת מספר שורות היתדות עבור כל כדור שיקפוץ, אז ההתפלגות המתארת לאן הסכום הזה הולך. הסתיו נראה יותר ויותר כמו עקומת פעמון. ",
+  "translatedText": "הרעיון הבסיסי של משפט הגבול המרכזי הוא שאם תגדילו את גודל הסכום הזה, למשל כאן זה אומר הגדלת מספר שורות היתדות עבור כל כדור שיקפוץ, אז ההתפלגות המתארת לאן הסכום הזה הולך נראה יותר ויותר כמו עקומת פעמון. ",
   "model": "nmt",
   "time_range": [
    236.81,
@@ -217,7 +217,7 @@
  },
  {
   "input": "Here, it's actually worth taking a moment to write down that general idea. ",
-  "translatedText": "כאן, בעצם שווה להקדיש רגע לרשום את הרעיון הכללי הזה. ",
+  "translatedText": "כאן, בעצם שווה להקדיש רגע כדי לרשום את הרעיון הכללי הזה. ",
   "model": "nmt",
   "time_range": [
    255.47,
@@ -253,7 +253,7 @@
  },
  {
   "input": "Those outcomes are associated with the numbers negative one and positive one. ",
-  "translatedText": "תוצאות אלו קשורות למספרים שלילי אחד וחיובי. ",
+  "translatedText": "תוצאות אלו קשורות למספרים אחד שלילי אחד וחיובי. ",
   "model": "nmt",
   "time_range": [
    274.85,
@@ -262,7 +262,7 @@
  },
  {
   "input": "Another example of a random variable would be rolling a die, where you have six different outcomes, each one associated with a number. ",
-  "translatedText": "דוגמה נוספת למשתנה אקראי תהיה הטלת קובייה, שבה יש לך שש תוצאות שונות, שכל אחת מהן קשורה למספר. ",
+  "translatedText": "דוגמה נוספת למשתנה אקראי תהיה הטלת קובייה, שבה יש לכם שש תוצאות שונות, שכל אחת מהן קשורה למספר. ",
   "model": "nmt",
   "time_range": [
    278.53,
@@ -271,7 +271,7 @@
  },
  {
   "input": "What we're doing is taking multiple different samples of that variable and adding them all together. ",
-  "translatedText": "מה שאנחנו עושים זה לקחת מספר דוגמאות שונות של המשתנה הזה ולצרף את כולם ביחד. ",
+  "translatedText": "מה שאנחנו עושים זה לקחת מספר דוגמאות שונות של המשתנה הזה ולצרף את כולן ביחד. ",
   "model": "nmt",
   "time_range": [
    285.47,
@@ -280,7 +280,7 @@
  },
  {
   "input": "On our Galton board, that looks like letting the ball bounce off multiple different pegs on its way down to the bottom, and in the case of a die, you might imagine rolling many different dice and adding up the results. ",
-  "translatedText": "על לוח הגלטון שלנו, זה נראה כמו לתת לכדור לקפוץ ממספר יתדות שונות בדרכו למטה, ובמקרה של קובייה, אתה עשוי לדמיין לזרוק קוביות רבות ושונות ולצרף את התוצאות. ",
+  "translatedText": "על לוח הגלטון שלנו, זה נראה כמו לתת לכדור לקפוץ ממספר יתדות שונות בדרכו למטה, ובמקרה של קובייה, אתם עשויים לדמיין זריקה של קוביות רבות ושונות וחיבור התוצאות. ",
   "model": "nmt",
   "time_range": [
    290.77,
@@ -316,7 +316,7 @@
  },
  {
   "input": "We're going to put some numbers to it, put some formulas to it, show how you can use it to make predictions. ",
-  "translatedText": "אנחנו הולכים לשים לזה כמה מספרים, לשים לזה כמה נוסחאות, להראות איך אתה יכול להשתמש בזה כדי ליצור תחזיות. ",
+  "translatedText": "אנחנו הולכים לשים לזה כמה מספרים, לשים לזה כמה נוסחאות, להראות איך אתם יכולים להשתמש בזה כדי ליצור תחזיות. ",
   "model": "nmt",
   "time_range": [
    322.07,
@@ -334,7 +334,7 @@
  },
  {
   "input": "Suppose you rolled the die 100 times and you added together the results. ",
-  "translatedText": "נניח שהטלת את הקוביה 100 פעמים וצירפת את התוצאות. ",
+  "translatedText": "נניח שהטלתם את הקוביה 100 פעמים וצירפתם את התוצאות. ",
   "model": "nmt",
   "time_range": [
    332.19,
@@ -343,7 +343,7 @@
  },
  {
   "input": "Could you find a range of values such that you're 95% sure that the sum will fall within that range? ",
-  "translatedText": "האם תוכל למצוא טווח של ערכים כך שאתה בטוח ב-95% שהסכום ייפול בטווח הזה? ",
+  "translatedText": "האם תוכלו למצוא טווח של ערכים כך שאתם בטוחים ב-95% שהסכום ייפול בטווח הזה? ",
   "model": "nmt",
   "time_range": [
    336.63,
@@ -361,7 +361,7 @@
  },
  {
   "input": "The neat thing is you'll be able to answer this question whether it's a fair die or if it's a weighted die. ",
-  "translatedText": "הדבר המסודר הוא שתוכלו לענות על השאלה הזו בין אם מדובר בקובייה הוגנת ובין אם מדובר בקובייה משוקללת. ",
+  "translatedText": "הדבר היפה הוא שתוכלו לענות על השאלה הזו בין אם מדובר בקובייה הוגנת ובין אם מדובר בקובייה משוקללת. ",
   "model": "nmt",
   "time_range": [
    347.39,
@@ -370,7 +370,7 @@
  },
  {
   "input": "Now let me say at the top that this theorem has three different assumptions that go into it, three things that have to be true before the theorem follows. ",
-  "translatedText": "עכשיו הרשו לי לומר למעלה שלמשפט הזה יש שלוש הנחות שונות שנכנסות לתוכו, שלושה דברים שצריכים להיות נכונים לפני שהמשפט יבוא אחריו. ",
+  "translatedText": "עכשיו הרשו לי להתחיל בכך שלמשפט הזה יש שלוש הנחות שונות שמובלעות בתוכו, שלושה דברים שצריכים להיות נכונים לפני שהמשפט יבוא אחריהם. ",
   "model": "nmt",
   "time_range": [
    353.45,
@@ -388,7 +388,7 @@
  },
  {
   "input": "Instead I want you to keep your eye out and see if you can notice and maybe predict what those three assumptions are going to be. ",
-  "translatedText": "במקום זאת, אני רוצה שתשאיר עין ותראה אם אתה יכול לשים לב ואולי לחזות מה יהיו שלוש ההנחות האלה. ",
+  "translatedText": "במקום זאת, אני רוצה שתפקחו עין ותראו אם אתם יכולים לשים לב ואולי לחזות מה יהיו שלוש ההנחות האלה. ",
   "model": "nmt",
   "time_range": [
    364.27,
@@ -397,7 +397,7 @@
  },
  {
   "input": "As a next step, to better illustrate just how general this theorem is, I want to run a couple more simulations for you focused on the dice example. ",
-  "translatedText": "כשלב הבא, כדי להמחיש טוב יותר עד כמה המשפט הזה כללי, אני רוצה להריץ עבורך עוד כמה סימולציות המתמקדות בדוגמה של הקוביות. ",
+  "translatedText": "כשלב הבא, כדי להמחיש טוב יותר עד כמה המשפט הזה כללי, אני רוצה להריץ עבורכם עוד כמה סימולציות המתמקדות בדוגמה של הקוביות. ",
   "model": "nmt",
   "time_range": [
    370.71,
@@ -406,7 +406,7 @@
  },
  {
   "input": "Usually if you think of rolling a die you think of the six outcomes as being equally probable, but the theorem actually doesn't care about that. ",
-  "translatedText": "בדרך כלל אם אתה חושב על הטלת קובייה אתה חושב על שש התוצאות כסבירות באותה מידה, אבל למשפט למעשה לא אכפת מזה. ",
+  "translatedText": "בדרך כלל אם אתם חושבים על הטלת קובייה אתם חושבים על שש התוצאות כסבירות באותה מידה, אבל למשפט למעשה לא אכפת מזה. ",
   "model": "nmt",
   "time_range": [
    380.91,
@@ -433,7 +433,7 @@
  },
  {
   "input": "I'm going to take 10 distinct samples from that distribution and then I'll record the sum of that sample on the plot on the bottom. ",
-  "translatedText": "אני הולך לקחת 10 דגימות נפרדות מההפצה הזו ואז ארשום את הסכום של הדגימה על העלילה בתחתית. ",
+  "translatedText": "אני הולך לקחת 10 דגימות נפרדות מההתפלגות הזו ואז ארשום את הסכום של הדגימה הזו בתחתית התרשים. ",
   "model": "nmt",
   "time_range": [
    400.25,
@@ -442,7 +442,7 @@
  },
  {
   "input": "Then I'm going to do this many many different times, always with a sum of size 10, but keep track of where those sums ended up to give us a sense of the distribution. ",
-  "translatedText": "אז אני הולך לעשות את זה הרבה פעמים שונות, תמיד עם סכום של גודל 10, אבל עקוב אחר היכן הסכומים האלה הגיעו כדי לתת לנו תחושה של התפלגות. ",
+  "translatedText": "אז אני הולך לעשות את זה הרבה פעמים שונות, תמיד עם סכום בגודל 10, אבל עם מעקב היכן הסכומים האלה הגיעו כדי לתת לנו תחושה של התפלגות. ",
   "model": "nmt",
   "time_range": [
    408.63,
@@ -460,7 +460,7 @@
  },
  {
   "input": "And I'll let it go all the way up to a couple thousand, and as it does you'll notice that the shape that starts to emerge looks like a bell curve. ",
-  "translatedText": "ואני אתן לזה ללכת עד כמה אלפים, ובזמן שזה יקרה אתה תשים לב שהצורה שמתחילה להופיע נראית כמו עקומה של פעמון. ",
+  "translatedText": "ואני אתן לזה ללכת עד כמה אלפים, ובזמן שזה יקרה אתם תשימו לב שהצורה שמתחילה להופיע נראית כמו עקומה של פעמון. ",
   "model": "nmt",
   "time_range": [
    425.03,
@@ -469,7 +469,7 @@
  },
  {
   "input": "Maybe if you squint your eyes you can see it skews a tiny bit to the left, but it's neat that something so symmetric emerged from a starting point that was so asymmetric. ",
-  "translatedText": "אולי אם תמצמצם את עיניך תוכל לראות את הטיה קטנטנה שמאלה, אבל זה יפה שמשהו כל כך סימטרי צץ מנקודת התחלה שהייתה כל כך אסימטרית. ",
+  "translatedText": "אולי אם תמצמצמו את עיניכם תוכלו לראות הטיה קטנטנה שמאלה, אבל זה יפה שמשהו כל כך סימטרי צץ מנקודת התחלה שהייתה כל כך אסימטרית. ",
   "model": "nmt",
   "time_range": [
    432.87,
@@ -478,7 +478,7 @@
  },
  {
   "input": "To better illustrate what the central limit theorem is all about, let me run four of these simulations in parallel, where on the upper left I'm doing it where we're only adding two dice at a time, on the upper right we're doing it where we're adding five dice at a time, the lower left is the one that we just saw adding 10 dice at a time, and then we'll do another one with a bigger sum, 15 at a time. ",
-  "translatedText": "כדי להמחיש טוב יותר על מה עוסק משפט הגבול המרכזי, הרשו לי להריץ ארבע מהסימולציות הללו במקביל, כאשר בפינה השמאלית העליונה אני עושה זאת כאשר אנו מוסיפים רק שתי קוביות בכל פעם, בצד ימין למעלה אנו אם אנחנו עושים את זה במקום שבו אנחנו מוסיפים חמש קוביות בכל פעם, השמאלית התחתונה היא זו שראינו עכשיו מוסיפה 10 קוביות בכל פעם, ואז נעשה עוד אחת עם סכום גדול יותר, 15 בכל פעם. ",
+  "translatedText": "כדי להמחיש טוב יותר על מה עוסק משפט הגבול המרכזי, הרשו לי להריץ ארבע מהסימולציות הללו במקביל, כאשר בפינה השמאלית העליונה אני עושה זאת כאשר אנו מוסיפים רק שתי קוביות בכל פעם, בצד ימין למעלה אנו אנחנו עושים את זה כאשר אנחנו מוסיפים חמש קוביות בכל פעם, השמאלית התחתונה היא זו שראינו עכשיו ושבה מוסיפים 10 קוביות בכל פעם, ואז נעשה עוד אחת עם סכום גדול יותר, 15 בכל פעם. ",
   "model": "nmt",
   "time_range": [
    441.47,
@@ -487,7 +487,7 @@
  },
  {
   "input": "Notice how on the upper left when we're just adding two dice, the resulting distribution doesn't really look like a bell curve, it looks a lot more reminiscent of the one we started with skewed towards the left. ",
-  "translatedText": "שימו לב איך בצד שמאל למעלה כשאנחנו רק מוסיפים שתי קוביות, ההתפלגות המתקבלת לא ממש נראית כמו עקומת פעמון, היא מזכירה הרבה יותר את זו שהתחלנו איתה מוטה לכיוון שמאל. ",
+  "translatedText": "שימו לב איך בצד שמאל למעלה כשאנחנו מוסיפים רק שתי קוביות, ההתפלגות המתקבלת לא ממש נראית כמו עקומת פעמון, היא מזכירה הרבה יותר את זו שהתחלנו איתה עם הטיה לכיוון שמאל. ",
   "model": "nmt",
   "time_range": [
    462.25,
@@ -496,7 +496,7 @@
  },
  {
   "input": "But as we allow for more and more dice in each sum, the resulting shape that comes up in these distributions looks more and more symmetric. ",
-  "translatedText": "אבל ככל שאנו מאפשרים יותר ויותר קוביות בכל סכום, הצורה המתקבלת שעולה בהתפלגויות אלו נראית יותר ויותר סימטרית. ",
+  "translatedText": "אבל ככל שאנו מאפשרים יותר ויותר קוביות בכל סכום, הצורה המתקבלת שעולה מהתפלגויות אלו נראית יותר ויותר סימטרית. ",
   "model": "nmt",
   "time_range": [
    472.81,
@@ -505,7 +505,7 @@
  },
  {
   "input": "It has the lump in the middle and fade towards the tail's shape of a bell curve. ",
-  "translatedText": "יש לו את הגוש באמצע והוא דוהה לקראת צורת הזנב של עקומת פעמון. ",
+  "translatedText": "יש לו את התפיחה באמצע והוא יורד לקראת צורת הזנב של עקומת פעמון. ",
   "model": "nmt",
   "time_range": [
    479.95,
@@ -514,7 +514,7 @@
  },
  {
   "input": "And let me emphasize again, you can start with any different distribution. ",
-  "translatedText": "ותן לי להדגיש שוב, אתה יכול להתחיל עם כל הפצה אחרת. ",
+  "translatedText": "ותנו לי להדגיש שוב, אתם יכולים להתחיל עם כל התפלגות אחרת. ",
   "model": "nmt",
   "time_range": [
    487.05,
@@ -532,7 +532,7 @@
  },
  {
   "input": "Despite completely changing the distribution for an individual roll of the die, it's still the case that a bell curve shape will emerge as we consider the different sums. ",
-  "translatedText": "למרות שינוי מוחלט של ההתפלגות עבור זריקת קובייה בודדת, זה עדיין המקרה שצורת עקומת פעמון תופיע כשאנחנו בוחנים את הסכומים השונים. ",
+  "translatedText": "למרות שינוי מוחלט של ההתפלגות עבור זריקת קובייה בודדת, צורת עקומת פעמון עדיין תופיע כשאנחנו בוחנים את הסכומים השונים. ",
   "model": "nmt",
   "time_range": [
    498.19,
@@ -541,7 +541,7 @@
  },
  {
   "input": "Illustrating things with a simulation like this is very fun, and it's kind of neat to see order emerge from chaos, but it also feels a little imprecise. ",
-  "translatedText": "להמחיש דברים בסימולציה כזו זה מאוד כיף, וזה די מסודר לראות סדר עולה מתוך הכאוס, אבל זה גם מרגיש קצת לא מדויק. ",
+  "translatedText": "להמחיש דברים בסימולציה כזו זה מאוד כיף, וזה די יפה לראות סדר עולה מתוך הכאוס, אבל זה גם מרגיש קצת לא מדויק. ",
   "model": "nmt",
   "time_range": [
    507.27,
@@ -550,7 +550,7 @@
  },
  {
   "input": "Like in this case, when I cut off the simulation at 3000 samples, even though it kind of looks like a bell curve, the different buckets seem pretty spiky. ",
-  "translatedText": "כמו במקרה הזה, כשניתקתי את הסימולציה ב-3000 דגימות, למרות שזה נראה כמו עקומת פעמון, הדליים השונים נראים די קוצניים. ",
+  "translatedText": "כמו במקרה הזה, כשניתקתי את הסימולציה ב-3000 דגימות, למרות שזה נראה כמו עקומת פעמון, המיכלים השונים נראים די חדים. ",
   "model": "nmt",
   "time_range": [
    515.39,
@@ -559,7 +559,7 @@
  },
  {
   "input": "And you might wonder, is it supposed to look that way, or is that just an artifact of the randomness in the simulation? ",
-  "translatedText": "ואתם עשויים לתהות, האם זה אמור להיראות כך, או שזה רק חפץ של האקראיות בסימולציה? ",
+  "translatedText": "ואתם עשויים לתהות, האם זה אמור להיראות כך, או שזה רק תוצאה של האקראיות בסימולציה? ",
   "model": "nmt",
   "time_range": [
    522.99,
@@ -577,7 +577,7 @@
  },
  {
   "input": "Instead moving forward, let's get a little more theoretical and show the precise shape that these distributions will take on in the long run. ",
-  "translatedText": "במקום להתקדם, בואו נהיה קצת יותר תיאורטיים ונראה את הצורה המדויקת שההפצות הללו יקבלו בטווח הארוך. ",
+  "translatedText": "במקום להתקדם, בואו נהיה קצת יותר תיאורטיים ונראה את הצורה המדויקת שההתפלגויות הללו יקבלו בטווח הארוך. ",
   "model": "nmt",
   "time_range": [
    539.19,
@@ -586,7 +586,7 @@
  },
  {
   "input": "The easiest case to make this calculation is if we have a uniform distribution, where each possible face of the die has an equal probability, 1 6th. ",
-  "translatedText": "המקרה הקל ביותר לעשות את החישוב הזה הוא אם יש לנו התפלגות אחידה, כאשר לכל פנים אפשרי של הקוביה יש הסתברות שווה, 1 6. ",
+  "translatedText": "המקרה הקל ביותר לחישוב הזה הוא כשיש לנו התפלגות אחידה, כאשר לכל צד אפשרי של הקוביה יש הסתברות שווה, 1 ל-6. ",
   "model": "nmt",
   "time_range": [
    546.13,
@@ -595,7 +595,7 @@
  },
  {
   "input": "For example, if you then want to know how likely different sums are for a pair of dice, it's essentially a counting game, where you count up how many distinct pairs take on the same sum, which in the diagram I've drawn, you can conveniently think about by going through all of the different diagonals. ",
-  "translatedText": "לדוגמה, אם אז אתה רוצה לדעת מה הסיכוי לסכומים שונים עבור זוג קוביות, זה בעצם משחק ספירה, שבו אתה סופר כמה זוגות נפרדים לוקחים על אותו סכום, שבדיאגרמה שציירתי, אתה יכול בקלות לחשוב על ידי מעבר על כל האלכסונים השונים. ",
+  "translatedText": "לדוגמה, אם אתם רוצים לדעת מה הסיכוי לסכומים שונים עבור זוג קוביות, זה בעצם משחק ספירה, שבו אתם סופרים לכמה זוגות נפרדים יש אותו סכום, כשבדיאגרמה שציירתי, אתם יכולים בקלות לחשוב עליהם על ידי מעבר על כל האלכסונים השונים. ",
   "model": "nmt",
   "time_range": [
    553.99,
@@ -604,7 +604,7 @@
  },
  {
   "input": "Since each such pair has an equal chance of showing up, 1 in 36, all you have to do is count the sizes of these buckets. ",
-  "translatedText": "מכיוון שלכל זוג כזה יש סיכוי שווה להופיע, 1 ל-36, כל שעליכם לעשות הוא לספור את הגדלים של הדליים הללו. ",
+  "translatedText": "מכיוון שלכל זוג כזה יש סיכוי שווה להופיע, 1 ל-36, כל שעליכם לעשות הוא לספור את הגדלים של המיכלים הללו. ",
   "model": "nmt",
   "time_range": [
    571.41,
@@ -640,7 +640,7 @@
  },
  {
   "input": "You do essentially the same thing, you go through all the distinct pairs of dice which add up to the same value. ",
-  "translatedText": "אתה עושה את אותו הדבר בעצם, אתה עובר על כל זוגות הקוביות הנבדלים שמצטברים לאותו ערך. ",
+  "translatedText": "אתם עושים את אותו הדבר בעצם, אתם עוברים על כל זוגות הקוביות הנבדלים שמצטברים לאותו ערך. ",
   "model": "nmt",
   "time_range": [
    598.45,
@@ -649,7 +649,7 @@
  },
  {
   "input": "It's just that instead of counting those pairs, for each pair you multiply the two probabilities of each particular face coming up, and then you add all those together. ",
-  "translatedText": "רק שבמקום לספור את הזוגות האלה, עבור כל זוג אתה מכפיל את שתי ההסתברויות של כל פרצוף מסוים שמגיע, ואז אתה מוסיף את כל אלה יחד. ",
+  "translatedText": "רק שבמקום לספור את הזוגות האלה, עבור כל זוג אתם מכפילים את שתי ההסתברויות של כל צד מסוים שמגיע, ואז אתם מוסיפים את כל אלה יחד. ",
   "model": "nmt",
   "time_range": [
    603.97,
@@ -658,7 +658,7 @@
  },
  {
   "input": "The computation that does this for all possible sums has a fancy name, it's called a convolution, but it's essentially just the weighted version of the counting game that anyone who's played with a pair of dice already finds familiar. ",
-  "translatedText": "לחישוב שעושה זאת עבור כל הסכומים האפשריים יש שם מפואר, זה נקרא קונבולציה, אבל זה בעצם רק הגרסה המשוקללת של משחק הספירה שכל מי ששיחק עם זוג קוביות כבר מוצא. ",
+  "translatedText": "לחישוב שעושה זאת עבור כל הסכומים האפשריים יש שם מפואר, זה נקרא קונבולציה, אבל זוהי בעצם רק הגרסה המשוקללת של משחק הספירה שכל מי ששיחק עם זוג קוביות כבר מוצא כמוכר. ",
   "model": "nmt",
   "time_range": [
    613.29,
@@ -676,7 +676,7 @@
  },
  {
   "input": "So just to be crystal clear on what's being represented here, if you imagine sampling two different values from that top distribution, the one describing a single die, and adding them together, then the second distribution I'm drawing represents how likely you are to see various different sums. ",
-  "translatedText": "אז רק כדי להיות ברור לגמרי לגבי מה שמיוצג כאן, אם אתה מדמיין לדגום שני ערכים שונים מההתפלגות העליונה ההיא, זה שמתאר קובייה בודדת, ומחבר אותם יחד, אז ההתפלגות השנייה שאני מצייר מייצגת את הסבירות שאתה לראות סכומים שונים. ",
+  "translatedText": "אז רק כדי להיות ברור לגמרי לגבי מה שמיוצג כאן, אם אתם מדמיינים דגימה של שני ערכים שונים מההתפלגות העליונה ההיא, זו שמתארת קובייה בודדת, ומחברים אותם יחד, אז ההתפלגות השנייה שאני מצייר מייצגת את הסבירות שלכם לראות סכומים שונים. ",
   "model": "nmt",
   "time_range": [
    636.65,
@@ -685,7 +685,7 @@
  },
  {
   "input": "Likewise, if you imagine sampling three distinct values from that top distribution, and adding them together, the next plot represents the probabilities for various different sums in that case. ",
-  "translatedText": "באופן דומה, אם אתה מדמיין לדגום שלושה ערכים נפרדים מאותה התפלגות עליונה, ולחבר אותם יחד, העלילה הבאה מייצגת את ההסתברויות עבור סכומים שונים במקרה זה. ",
+  "translatedText": "באופן דומה, אם אתם מדמיינים דגימה של שלושה ערכים נפרדים מאותה התפלגות עליונה, ולחבר אותם יחד, התרשים הבא מייצג את ההסתברויות עבור סכומים שונים במקרה זה. ",
   "model": "nmt",
   "time_range": [
    652.89,
@@ -694,7 +694,7 @@
  },
  {
   "input": "So if I compute what the distributions for these sums look like for larger and larger sums, well you know what I'm going to say, it looks more and more like a bell curve. ",
-  "translatedText": "אז אם אני מחשב איך נראות ההתפלגויות של הסכומים האלה עבור סכומים גדולים יותר ויותר, ובכן, אתה יודע מה אני הולך להגיד, זה נראה יותר ויותר כמו עקומת פעמון. ",
+  "translatedText": "אז אם אני מחשב איך נראות ההתפלגויות של הסכומים האלה עבור סכומים גדולים יותר ויותר, ובכן, אתם יודעים מה אני הולך להגיד, זה נראה יותר ויותר כמו עקומת פעמון. ",
   "model": "nmt",
   "time_range": [
    663.51,
@@ -703,7 +703,7 @@
  },
  {
   "input": "But before we get to that, I want you to make a couple more simple observations. ",
-  "translatedText": "אבל לפני שנגיע לזה, אני רוצה שתערוך עוד כמה הערות פשוטות. ",
+  "translatedText": "אבל לפני שנגיע לזה, אני רוצה שתשימו לב לעוד כמה דברים פשוטים. ",
   "model": "nmt",
   "time_range": [
    673.35,
@@ -712,7 +712,7 @@
  },
  {
   "input": "For example, these distributions seem to be wandering to the right, and also they seem to be getting more spread out, and a little bit more flat. ",
-  "translatedText": "לדוגמה, נראה שההפצות הללו נודדות ימינה, וגם נראה שהן מתפרסות יותר וקצת יותר שטוחות. ",
+  "translatedText": "לדוגמה, נראה שההתפלגויות הללו נודדות ימינה, וגם נראה שהן מתפרסות יותר וקצת יותר שטוחות. ",
   "model": "nmt",
   "time_range": [
    677.45,
@@ -721,7 +721,7 @@
  },
  {
   "input": "You cannot describe the central limit theorem quantitatively without taking into account both of those effects, which in turn requires describing the mean and the standard deviation. ",
-  "translatedText": "אינך יכול לתאר את משפט הגבול המרכזי בצורה כמותית מבלי לקחת בחשבון את שתי ההשפעות הללו, אשר בתורו מחייב לתאר את הממוצע ואת סטיית התקן. ",
+  "translatedText": "אינכם יכולים לתאר את משפט הגבול המרכזי בצורה כמותית מבלי לקחת בחשבון את שתי ההשפעות הללו, אשר מחייבות לתאר את הממוצע ואת סטיית התקן. ",
   "model": "nmt",
   "time_range": [
    685.25,
@@ -730,7 +730,7 @@
  },
  {
   "input": "Maybe you're already familiar with those, but I want to make minimal assumptions here, and it never hurts to review, so let's quickly go over both of those. ",
-  "translatedText": "אולי אתה כבר מכיר את אלה, אבל אני רוצה להניח הנחות מינימליות כאן, וזה אף פעם לא מזיק לסקור, אז בואו נעבור במהירות על שניהם. ",
+  "translatedText": "אולי אתם כבר מכירים את המושגים האלו, אבל אני רוצה להניח הנחות מינימליות כאן, וזה אף פעם לא מזיק לסקור מחדש, אז בואו נעבור במהירות על שניהם. ",
   "model": "nmt",
   "time_range": [
    693.95,
@@ -748,7 +748,7 @@
  },
  {
   "input": "It's calculated as the expected value of our random variable, which is a way of saying you go through all of the different possible outcomes, and you multiply the probability of that outcome times the value of the variable. ",
-  "translatedText": "זה מחושב כערך הצפוי של המשתנה האקראי שלנו, שזו דרך לומר שאתה עובר על כל התוצאות האפשריות השונות, ואתה מכפיל את ההסתברות של התוצאה הזו כפול ערכו של המשתנה. ",
+  "translatedText": "זה מחושב כערך הצפוי של המשתנה האקראי שלנו, שזו דרך לומר שאתם עוברים על כל התוצאות האפשריות השונות, ואתם מכפילים את ההסתברות של התוצאה הזו כפול ערכו של המשתנה. ",
   "model": "nmt",
   "time_range": [
    711.19,
@@ -757,7 +757,7 @@
  },
  {
   "input": "If higher values are more probable, that weighted sum is going to be bigger. ",
-  "translatedText": "אם ערכים גבוהים יותר סבירים יותר, הסכום המשוקלל הזה יהיה גדול יותר. ",
+  "translatedText": "אם ערכים גבוהים יותר הם יותר סבירים, הסכום המשוקלל הזה יהיה גדול יותר. ",
   "model": "nmt",
   "time_range": [
    723.19,
@@ -766,7 +766,7 @@
  },
  {
   "input": "If lower values are more probable, that weighted sum is going to be smaller. ",
-  "translatedText": "אם ערכים נמוכים יותר סבירים יותר, הסכום המשוקלל הזה יהיה קטן יותר. ",
+  "translatedText": "אם ערכים נמוכים יותר הם יותר סבירים, הסכום המשוקלל הזה יהיה קטן יותר. ",
   "model": "nmt",
   "time_range": [
    726.75,
@@ -775,7 +775,7 @@
  },
  {
   "input": "A little more interesting is if you want to measure how spread out this distribution is, because there's multiple different ways you might do it. ",
-  "translatedText": "קצת יותר מעניין אם אתה רוצה למדוד עד כמה התפלגות זו מפוזרת, כי ישנן מספר דרכים שונות שבהן תוכל לעשות זאת. ",
+  "translatedText": "קצת יותר מעניין אם אתם רוצים למדוד עד כמה התפלגות זו מפוזרת, כי ישנן מספר דרכים שונות שבהן תוכלו לעשות זאת. ",
   "model": "nmt",
   "time_range": [
    730.79,
@@ -793,7 +793,7 @@
  },
  {
   "input": "The idea there is to look at the difference between each possible value and the mean, square that difference, and ask for its expected value. ",
-  "translatedText": "הרעיון שם הוא להסתכל על ההבדל בין כל ערך אפשרי לבין הממוצע, לרבע את ההבדל ולבקש את הערך הצפוי שלו. ",
+  "translatedText": "הרעיון הוא להסתכל על ההבדל בין כל ערך אפשרי לבין הממוצע, לרבע את ההבדל ולבקש את הערך הצפוי שלו. ",
   "model": "nmt",
   "time_range": [
    740.83,
@@ -802,7 +802,7 @@
  },
  {
   "input": "The idea is that whether your value is below or above the mean, when you square that difference, you get a positive number, and the larger the difference, the bigger that number. ",
-  "translatedText": "הרעיון הוא שבין אם הערך שלך מתחת לממוצע או מעליו, כאשר אתה בריבוע את ההפרש, אתה מקבל מספר חיובי, וככל שההפרש גדול יותר, כך המספר גדול יותר. ",
+  "translatedText": "הרעיון הוא שבין אם הערך מתחת לממוצע או מעליו, כאשר מעלים בריבוע את ההפרש, אתם מקבלים מספר חיובי, וככל שההפרש גדול יותר, כך המספר גדול יותר. ",
   "model": "nmt",
   "time_range": [
    748.73,
@@ -811,7 +811,7 @@
  },
  {
   "input": "Squaring it like this turns out to make the math much much nicer than if we did something like an absolute value, but the downside is that it's hard to think about this as a distance in our diagram because the units are off. ",
-  "translatedText": "ריבוע זה הופך את המתמטיקה להרבה יותר יפה מאשר אם היינו עושים משהו כמו ערך מוחלט, אבל החיסרון הוא שקשה לחשוב על זה כעל מרחק בתרשים שלנו כי היחידות כבויות. ",
+  "translatedText": "ריבוע זה הופך את המתמטיקה להרבה הרבה יותר יפה מאשר אם היינו משתמשים במשהו כמו ערך מוחלט, אבל החיסרון הוא שקשה לחשוב על זה כעל מרחק בתרשים שלנו כי היחידות לא מתואמות. ",
   "model": "nmt",
   "time_range": [
    757.3699999999999,
@@ -820,7 +820,7 @@
  },
  {
   "input": "Kind of like the units here are square units, whereas a distance in our diagram would be a kind of linear unit. ",
-  "translatedText": "בערך כמו היחידות כאן הן יחידות מרובעות, בעוד שמרחק בתרשים שלנו יהיה סוג של יחידה לינארית. ",
+  "translatedText": "בערך כמו שהיחידות כאן הן יחידות מרובעות, בעוד שמרחק בתרשים שלנו יהיה סוג של יחידה לינארית. ",
   "model": "nmt",
   "time_range": [
    768.33,
@@ -838,7 +838,7 @@
  },
  {
   "input": "That can be interpreted much more reasonably as a distance on our diagram, and it's commonly denoted with the Greek letter sigma, so you know m for mean as for standard deviation, but both in Greek. ",
-  "translatedText": "זה יכול להתפרש בצורה הרבה יותר סבירה כמרחק בתרשים שלנו, והוא מסומן בדרך כלל באות היוונית סיגמה, אז אתה יודע m עבור ממוצע כמו עבור סטיית תקן, אבל שניהם ביוונית. ",
+  "translatedText": "זה יכול להתפרש בצורה הרבה יותר סבירה כמרחק בתרשים שלנו, והוא מסומן בדרך כלל באות היוונית סיגמה, אז אתה מכיר m עבור ממוצע וגם עבור סטיית תקן, אבל שניהם ביוונית. ",
   "model": "nmt",
   "time_range": [
    778.69,
@@ -856,7 +856,7 @@
  },
  {
   "input": "If we call the mean of the initial distribution mu, which for the one illustrated happens to be 2.24, hopefully it won't be too surprising if I tell you that the mean of the next one is 2 times mu. ",
-  "translatedText": "אם נקרא לממוצע של ההתפלגות הראשונית mu, אשר עבור זו המוצגת במקרה הוא 2.24, אני מקווה שזה לא יהיה מפתיע מדי אם אני אגיד לך שהממוצע של הבא הוא פי 2 mu. ",
+  "translatedText": "אם נקרא לממוצע של ההתפלגות הראשונית mu, אשר עבור זו המוצגת הוא במקרה 2.24, אני מקווה שזה לא יהיה מפתיע מדי אם אני אגיד לכם שהממוצע של הבא הוא פי 2 mu. ",
   "model": "nmt",
   "time_range": [
    796.63,
@@ -865,7 +865,7 @@
  },
  {
   "input": "That is, you roll a pair of dice, you want to know the expected value of the sum, it's two times the expected value for a single die. ",
-  "translatedText": "כלומר, אתה מטיל זוג קוביות, אתה רוצה לדעת את הערך הצפוי של הסכום, זה פי שניים מהערך הצפוי לקובייה בודדת. ",
+  "translatedText": "כלומר, אתם מטילים זוג קוביות, אתם רוצים לדעת את הערך הצפוי של הסכום, זה פי שניים מהערך הצפוי לקובייה בודדת. ",
   "model": "nmt",
   "time_range": [
    807.13,
@@ -883,7 +883,7 @@
  },
  {
   "input": "The mean just marches steadily on to the right, which is why our distributions seem to be drifting off in that direction. ",
-  "translatedText": "הממוצע פשוט צועד ימינה בהתמדה, ולכן נראה שההתפלגות שלנו נסחפת לכיוון הזה. ",
+  "translatedText": "הממוצע פשוט זז ימינה בהתמדה, ולכן נראה שההתפלגות שלנו נסחפת לכיוון הזה. ",
   "model": "nmt",
   "time_range": [
    819.63,
@@ -901,7 +901,7 @@
  },
  {
   "input": "The key fact here is that if you have two different random variables, then the variance for the sum of those variables is the same as just adding together the original two variances. ",
-  "translatedText": "עובדת המפתח כאן היא שאם יש לך שני משתנים אקראיים שונים, השונות עבור סכום המשתנים האלה זהה לחיבור של שתי השונות המקוריות. ",
+  "translatedText": "עובדת המפתח כאן היא שאם יש לכם שני משתנים אקראיים שונים, השונות עבור סכום המשתנים האלה זהה לחיבור של שתי השונות המקוריות. ",
   "model": "nmt",
   "time_range": [
    830.49,
@@ -910,7 +910,7 @@
  },
  {
   "input": "This is one of those facts that you can just compute when you unpack all the definitions. ",
-  "translatedText": "זו אחת העובדות שאתה יכול פשוט לחשב כשאתה מפרק את כל ההגדרות. ",
+  "translatedText": "זו אחת העובדות שאתם יכולים פשוט לחשב כשאתם מנתחים את כל ההגדרות. ",
   "model": "nmt",
   "time_range": [
    839.93,
@@ -928,7 +928,7 @@
  },
  {
   "input": "My tentative plan is to just actually make a series about probability and talk about things like intuitions underlying variance and its cousins there. ",
-  "translatedText": "התוכנית הטנטטיבית שלי היא פשוט לעשות סדרה על הסתברות ולדבר על דברים כמו אינטואיציות שבבסיס השונות ובני הדודים שלה שם. ",
+  "translatedText": "התוכנית הטנטטיבית שלי היא פשוט לעשות סדרה על הסתברות ולדבר על דברים כמו אינטואיציות שבבסיס השונות ובני הדודים שלה. ",
   "model": "nmt",
   "time_range": [
    846.63,
@@ -946,7 +946,7 @@
  },
  {
   "input": "So, critically, if you were to take n different realizations of the same random variable and ask what the sum looks like, the variance of that sum is n times the variance of your original variable, meaning the standard deviation, the square root of all this, is the square root of n times the original standard deviation. ",
-  "translatedText": "אז, באופן קריטי, אם היית לוקח n מימושים שונים של אותו משתנה אקראי ושואל איך נראה הסכום, השונות של הסכום הזה היא פי n מהשונות של המשתנה המקורי שלך, כלומר סטיית התקן, השורש הריבועי של כולם. זהו השורש הריבועי של n כפול סטיית התקן המקורית. ",
+  "translatedText": "אז, באופן קריטי, אם הייתם לוקחים n מימושים שונים של אותו משתנה אקראי ושואלים איך נראה הסכום, השונות של הסכום הזה היא פי n מהשונות של המשתנה המקורי שלכם, כלומר סטיית התקן, השורש הריבועי של כולם. זהו השורש הריבועי של n כפול סטיית התקן המקורית. ",
   "model": "nmt",
   "time_range": [
    859.73,
@@ -955,7 +955,7 @@
  },
  {
   "input": "For example, back in our sequence of distributions, if we label the standard deviation of our initial one with sigma, then the next standard deviation is going to be the square root of 2 times sigma, and after that it looks like the square root of 3 times sigma, and so on and so forth. ",
-  "translatedText": "לדוגמה, ברצף ההתפלגויות שלנו, אם נסמן את סטיית התקן של ההתחלה שלנו עם סיגמא, סטיית התקן הבאה תהיה השורש הריבועי של פי 2 סיגמא, ואחרי זה זה נראה כמו השורש הריבועי של 3 פעמים סיגמא, וכן הלאה וכן הלאה. ",
+  "translatedText": "לדוגמה, ברצף ההתפלגויות שלנו, אם נסמן את סטיית התקן של ההתחלה שלנו בסיגמא, סטיית התקן הבאה תהיה השורש הריבועי של פי 2 סיגמא, ובהמשך זה נראה כמו השורש הריבועי של 3 פעמים סיגמא, וכן הלאה וכן הלאה. ",
   "model": "nmt",
   "time_range": [
    879.29,
@@ -982,7 +982,7 @@
  },
  {
   "input": "As we prepare to make a more quantitative description of the central limit theorem, the core intuition I want you to keep in your head is that we'll basically realign all of these distributions so that their means line up together, and then rescale them so that all of the standard deviations are just going to be equal to 1. ",
-  "translatedText": "כשאנחנו מתכוננים לעשות תיאור כמותי יותר של משפט הגבול המרכזי, האינטואיציה המרכזית שאני רוצה שתשמרו בראשכם היא שאנחנו בעצם ניישר מחדש את כל ההתפלגויות האלה כך שהאמצעים שלהן יסתדרו יחד, ואז נספח אותם מחדש כך שכל סטיות התקן פשוט יהיו שוות ל-1. ",
+  "translatedText": "כשאנחנו מתכוננים לתיאור כמותי יותר של משפט הגבול המרכזי, האינטואיציה המרכזית שאני רוצה שתשמרו בראשכם היא שאנחנו בעצם נערוך מחדש את כל ההתפלגויות האלה כך שהאמצעים שלהן יסתדרו יחד, ואז נשנה את קנה המידה כך שכל סטיות התקן פשוט יהיו שוות ל-1. ",
   "model": "nmt",
   "time_range": [
    904.71,
@@ -991,7 +991,7 @@
  },
  {
   "input": "And when we do that, the shape that results gets closer and closer to a certain universal shape, described with an elegant little function that we'll unpack in just a moment. ",
-  "translatedText": "וכשאנחנו עושים את זה, הצורה שמתקבלת מתקרבת יותר ויותר לצורה אוניברסלית מסוימת, המתוארת בפונקציה קטנה ואלגנטית שנפרק תוך רגע. ",
+  "translatedText": "וכשאנחנו עושים את זה, הצורה שמתקבלת מתקרבת יותר ויותר לצורה אוניברסלית מסוימת, המתוארת בפונקציה קטנה ואלגנטית שנסביר מיד. ",
   "model": "nmt",
   "time_range": [
    921.29,
@@ -1000,7 +1000,7 @@
  },
  {
   "input": "And let me say one more time, the real magic here is how we could have started with any distribution, describing a single roll of the die, and if we play the same game, considering what the distributions for the many different sums look like, and we realign them so that the means line up, and we rescale them so that the standard deviations are all 1, we still approach that same universal shape, which is kind of mind-boggling. ",
-  "translatedText": "ותן לי לומר עוד פעם, הקסם האמיתי כאן הוא איך היינו יכולים להתחיל עם כל חלוקה, לתאר זריקת קובייה בודדת, ואם נשחק באותו משחק, בהתחשב איך נראות ההפצות עבור הסכומים הרבים השונים, ואנחנו מיישרים אותם מחדש כך שהאמצעים יסתדרו, ואנחנו מחדש את קנה המידה שלהם כך שסטיות התקן יהיו כולן 1, אנחנו עדיין מתקרבים לאותה צורה אוניברסלית, שהיא סוג של מטריד. ",
+  "translatedText": "ותנו לי לומר עוד פעם, הקסם האמיתי כאן הוא איך היינו יכולים להתחיל עם כל חלוקה, לתאר זריקת קובייה בודדת, ואם נשחק באותו משחק, בהתחשב איך נראות ההתפלגויות עבור הסכומים הרבים השונים, ואנחנו מארגנים אותם מחדש כך שהאמצעים יסתדרו, ואנחנו משנים את קנה המידה שלהם כך שסטיות התקן יהיו כולן 1, אנחנו עדיין מתקרבים לאותה צורה אוניברסלית, שהיא סוג של תוצאה מפתיעה. ",
   "model": "nmt",
   "time_range": [
    930.47,
@@ -1009,7 +1009,7 @@
  },
  {
   "input": "And now, my friends, is probably as good a time as any to finally get into the formula for a normal distribution. ",
-  "translatedText": "ועכשיו, חברים שלי, זה כנראה זמן טוב ככל האפשר להיכנס סוף סוף לנוסחה של התפלגות נורמלית. ",
+  "translatedText": "ועכשיו ידידי, זה כנראה זמן טוב להיכנס סוף סוף לנוסחה של התפלגות נורמלית. ",
   "model": "nmt",
   "time_range": [
    954.81,
@@ -1027,7 +1027,7 @@
  },
  {
   "input": "The function e to the x, or anything to the x, describes exponential growth, and if you make that exponent negative, which flips around the graph horizontally, you might think of it as describing exponential decay. ",
-  "translatedText": "הפונקציה e ל-x, או כל דבר ל-x, מתארת צמיחה מעריכית, ואם תהפוך את המעריך הזה לשלילי, שמתהפך על הגרף אופקית, אולי תחשוב שזה מתאר דעיכה מעריכית. ",
+  "translatedText": "הפונקציה e בחזקת-x, או כל דבר בחזקת-x, מתארת צמיחה מעריכית, ואם תהפכו את המעריך הזה לשלילי, שינוי שהופך את הגרף אופקית, אולי תחשבו על זה כתאור של דעיכה מעריכית. ",
   "model": "nmt",
   "time_range": [
    966.53,
@@ -1036,7 +1036,7 @@
  },
  {
   "input": "To make this decay in both directions, you could do something to make sure the exponent is always negative and growing, like taking the negative absolute value. ",
-  "translatedText": "כדי לגרום לדעיכה הזו בשני הכיוונים, אתה יכול לעשות משהו כדי לוודא שהמעריך תמיד שלילי וגדל, כמו לקחת את הערך המוחלט השלילי. ",
+  "translatedText": "כדי לגרום לדעיכה הזו בשני הכיוונים, אתם יכולים לעשות משהו כדי לוודא שהמעריך תמיד שלילי וגדל, כמו לקחת את הערך המוחלט השלילי. ",
   "model": "nmt",
   "time_range": [
    978.51,
@@ -1045,7 +1045,7 @@
  },
  {
   "input": "That would give us this kind of awkward sharp point in the middle, but if instead you make that exponent the negative square of x, you get a smoother version of the same thing, which decays in both directions. ",
-  "translatedText": "זה ייתן לנו סוג כזה של נקודה חדה מביכה באמצע, אבל אם במקום זאת תהפוך את המעריך הזה לריבוע השלילי של x, תקבל גרסה חלקה יותר של אותו דבר, שמתפוגג בשני הכיוונים. ",
+  "translatedText": "זה ייתן לנו סוג כזה של נקודה חדה מוזרה באמצע, אבל אם במקום זאת תהפכו את המעריך הזה לריבוע השלילי של x, תקבלו גרסה חלקה יותר של אותו דבר, שדועך בשני הכיוונים. ",
   "model": "nmt",
   "time_range": [
    985.93,
@@ -1063,7 +1063,7 @@
  },
  {
   "input": "Now if you throw a constant in front of that x, and you scale that constant up and down, it lets you stretch and squish the graph horizontally, allowing you to describe narrow and wider bell curves. ",
-  "translatedText": "עכשיו, אם אתה זורק קבוע לפני ה-X הזה, ומשנה את הקבוע הזה למעלה ולמטה, זה מאפשר לך למתוח ולמעוך את הגרף אופקית, ומאפשר לך לתאר עקומות פעמון צרות ורחבות יותר. ",
+  "translatedText": "עכשיו, אם אתם שמים קבוע לפני ה-X הזה, ומשנים את קנה המידה של הקבוע הזה למעלה ולמטה, זה מאפשר לכם למתוח ולמעוך את הגרף אופקית, דבר שמאפשר לכם לתאר עקומות פעמון צרות ורחבות יותר. ",
   "model": "nmt",
   "time_range": [
    998.65,
@@ -1072,7 +1072,7 @@
  },
  {
   "input": "And a quick thing I'd like to point out here is that based on the rules of exponentiation, as we tweak around that constant c, you could also think about it as simply changing the base of the exponentiation. ",
-  "translatedText": "ודבר מהיר שהייתי רוצה לציין כאן הוא שבהתבסס על כללי האקספונציה, כשאנחנו משנים סביב אותו c קבוע, אתה יכול גם לחשוב על זה כפשוט לשנות את בסיס האקספונציה. ",
+  "translatedText": "ודבר מהיר שהייתי רוצה לציין כאן הוא שבהתבסס על כללי החזקה, כשאנחנו משנים אותו קבוע c, אתם יכולים גם לחשוב על זה פשוט כשינוי בסיס החקה. ",
   "model": "nmt",
   "time_range": [
    1009.01,
@@ -1090,7 +1090,7 @@
  },
  {
   "input": "We could replace it with any other positive constant, and you'll get the same family of curves as we tweak that constant. ",
-  "translatedText": "נוכל להחליף אותו בכל קבוע חיובי אחר, ותקבל את אותה משפחה של עקומות כאשר אנו מצווים את הקבוע הזה. ",
+  "translatedText": "נוכל להחליף אותו בכל קבוע חיובי אחר, ונקבל את אותה משפחה של עקומות כאשר אנו משנים את הקבוע הזה. ",
   "model": "nmt",
   "time_range": [
    1024.05,
@@ -1126,7 +1126,7 @@
  },
  {
   "input": "Or rather, if we reconfigure things a little bit so that the exponent looks like negative one half times x divided by a certain constant, which we'll suggestively call sigma squared, then once we turn this into a probability distribution, that constant sigma will be the standard deviation of that distribution. ",
-  "translatedText": "או ליתר דיוק, אם נגדיר את הדברים מחדש קצת כך שהמעריך ייראה כמו שלילי חצי כפול x חלקי קבוע מסוים, שנקרא לו סיגמא בריבוע, אז ברגע שנהפוך את זה להתפלגות הסתברות, הסיגמה הקבועה תהיה להיות סטיית התקן של התפלגות זו. ",
+  "translatedText": "או ליתר דיוק, אם נגדיר את הדברים קצת מחדש כך שהמעריך ייראה כמו שלילי חצי כפול x חלקי קבוע מסוים, שנקרא לו סיגמא בריבוע, אז ברגע שנהפוך את זה להתפלגות הסתברותית, הקבוע סיגמה יהיה סטיית התקן של התפלגות זו. ",
   "model": "nmt",
   "time_range": [
    1040.11,
@@ -1171,7 +1171,7 @@
  },
  {
   "input": "Instead, you ask for the probability that a value falls between two different values. ",
-  "translatedText": "במקום זאת, אתה שואל את ההסתברות שערך נופל בין שני ערכים שונים. ",
+  "translatedText": "במקום זאת, שואלים על ההסתברות שערך נופל בין שני ערכים שונים. ",
   "model": "nmt",
   "time_range": [
    1073.79,
@@ -1189,7 +1189,7 @@
  },
  {
   "input": "There's a whole other video about this, they're called probability density functions. ",
-  "translatedText": "יש סרטון אחר לגמרי על זה, הם נקראים פונקציות צפיפות הסתברות. ",
+  "translatedText": "יש סרטון אחר לגמרי על זה, הם נקראים פונקציות צפיפות הסתברותיות. ",
   "model": "nmt",
   "time_range": [
    1086.03,
@@ -1207,7 +1207,7 @@
  },
  {
   "input": "That should be 1, which is why we want the area under this to be 1. ",
-  "translatedText": "זה צריך להיות 1, וזו הסיבה שאנחנו רוצים שהשטח מתחת לזה יהיה 1. ",
+  "translatedText": "זה צריך להיות 1, וזו הסיבה שאנחנו רוצים שהשטח מתחת לעקומה יהיה 1. ",
   "model": "nmt",
   "time_range": [
    1097.41,
@@ -1216,7 +1216,7 @@
  },
  {
   "input": "As it stands with the basic bell curve shape of e to the negative x squared, the area is not 1, it's actually the square root of pi. ",
-  "translatedText": "כפי שהוא עומד עם צורת עקומת הפעמון הבסיסית של e ל-x השלילי בריבוע, השטח אינו 1, זה למעשה השורש הריבועי של pi. ",
+  "translatedText": "כפי שהוא עומד עם צורת עקומת הפעמון הבסיסית של e בחזקת-x השלילי בריבוע, השטח אינו 1, זה למעשה השורש הריבועי של pi. ",
   "model": "nmt",
   "time_range": [
    1101.05,
@@ -1234,7 +1234,7 @@
  },
  {
   "input": "What is pi doing here? ",
-  "translatedText": "מה פי עושה כאן? ",
+  "translatedText": "מה פאי עושה כאן? ",
   "model": "nmt",
   "time_range": [
    1109.27,
@@ -1261,7 +1261,7 @@
  },
  {
   "input": "But if you can spare your excitement for our purposes right now, all it means is that we should divide this function by the square root of pi, and it gives us the area we want. ",
-  "translatedText": "אבל אם אתה יכול לחסוך את ההתרגשות שלך למטרות שלנו עכשיו, כל מה שזה אומר הוא שעלינו לחלק את הפונקציה הזו בשורש הריבועי של pi, וזה נותן לנו את השטח שאנחנו רוצים. ",
+  "translatedText": "אבל אם אתם יכולים לוותר בינתיים על הציפייה שלכם למטרות שלנו, כל מה שזה אומר הוא שעלינו לחלק את הפונקציה הזו בשורש הריבועי של pi, וזה נותן לנו את השטח שאנחנו רוצים. ",
   "model": "nmt",
   "time_range": [
    1115.33,
@@ -1270,7 +1270,7 @@
  },
  {
   "input": "Throwing back in the constants we had earlier, the 1 half and the sigma, the effect there is to stretch out the graph by a factor of sigma times the square root of 2. ",
-  "translatedText": "אם זורקים לאחור את הקבועים שהיו לנו קודם, החצי 1 והסיגמה, ההשפעה שם היא למתוח את הגרף בגורם של סיגמה כפול השורש הריבועי של 2. ",
+  "translatedText": "אם מחזירים את הקבועים שהיו לנו קודם, החצי והסיגמה, ההשפעה שם היא למתוח את הגרף בגורם של סיגמה כפול השורש הריבועי של 2. ",
   "model": "nmt",
   "time_range": [
    1123.61,
@@ -1306,7 +1306,7 @@
  },
  {
   "input": "As we tweak that value sigma, resulting in narrower and wider curves, that constant in the front always guarantees that the area equals 1. ",
-  "translatedText": "כאשר אנו מצווים את הערך של הסיגמה, וכתוצאה מכך עקומות צרות ורחבות יותר, הקבוע הקדמי תמיד מבטיח שהשטח שווה ל-1. ",
+  "translatedText": "כאשר אנו משנים את הערך של הסיגמה, וכתוצאה מכך מקבלים עקומות צרות ורחבות יותר, הקבוע הקדמי תמיד מבטיח שהשטח שווה ל-1. ",
   "model": "nmt",
   "time_range": [
    1146.45,
@@ -1315,7 +1315,7 @@
  },
  {
   "input": "The special case where sigma equals 1 has a specific name, we call it the standard normal distribution, which plays an especially important role for you and me in this lesson. ",
-  "translatedText": "למקרה המיוחד שבו סיגמא שווה ל-1 יש שם ספציפי, אנו קוראים לו התפלגות נורמלית סטנדרטית, אשר משחקת תפקיד חשוב במיוחד עבורך ולי בשיעור זה. ",
+  "translatedText": "למקרה המיוחד שבו סיגמא שווה ל-1 יש שם ספציפי, אנו קוראים לו התפלגות נורמלית סטנדרטית, אשר משחקת תפקיד חשוב במיוחד עבורם ובשבילי בשיעור זה. ",
   "model": "nmt",
   "time_range": [
    1155.91,
@@ -1324,7 +1324,7 @@
  },
  {
   "input": "And all possible normal distributions are not only parameterized with this value sigma, but we also subtract off another constant mu from the variable x, and this essentially just lets you slide the graph left and right so that you can prescribe the mean of this distribution. ",
-  "translatedText": "וכל ההתפלגויות הנורמליות האפשריות לא רק עוברות פרמטרים עם הערך הזה סיגמה, אלא אנחנו גם מפחיתים עוד קבוע mu מהמשתנה x, וזה בעצם רק מאפשר לך להחליק את הגרף ימינה ושמאלה כדי שתוכל לקבוע את הממוצע של ההתפלגות הזו. ",
+  "translatedText": "וכל ההתפלגויות הנורמליות האפשריות לא רק עוברות פרמטריזציה עם הערך הזה סיגמה, אלא אנחנו גם מפחיתים עוד קבוע mu מהמשתנה x, וזה בעצם רק מאפשר לכם להחליק את הגרף ימינה ושמאלה כדי שתוכלו לקבוע את הממוצע של ההתפלגות הזו. ",
   "model": "nmt",
   "time_range": [
    1165.13,
@@ -1351,7 +1351,7 @@
  },
  {
   "input": "As we've already gone over, when you increase the size of that sum, the resulting distribution will shift according to a growing mean, and it slowly spreads out according to a growing standard deviation. ",
-  "translatedText": "כפי שכבר עברנו עליו, כאשר אתה מגדיל את גודל הסכום הזה, ההתפלגות המתקבלת תשתנה לפי ממוצע גדל, והיא תתפשט לאט לפי סטיית תקן הולכת וגדלה. ",
+  "translatedText": "כפי שכבר הסברנו, כאשר אתם מגדילים את גודל הסכום הזה, ההתפלגות המתקבלת תשתנה לפי ממוצע גדל, והיא תתפשט לאט לפי סטיית תקן הולכת וגדלה. ",
   "model": "nmt",
   "time_range": [
    1200.13,
@@ -1360,7 +1360,7 @@
  },
  {
   "input": "And putting some actual formulas to it, if we know the mean of our underlying random variable, we call it mu, and we also know its standard deviation, and we call it sigma, then the mean for the sum on the bottom will be mu times the size of the sum, and the standard deviation will be sigma times the square root of that size. ",
-  "translatedText": "ואם נניח לזה כמה נוסחאות ממשיות, אם אנחנו יודעים את הממוצע של המשתנה האקראי הבסיסי שלנו, נקרא לו mu, ואנחנו גם יודעים את סטיית התקן שלו, ואנחנו קוראים לזה סיגמה, אז הממוצע של הסכום בתחתית יהיה mu כפול גודל הסכום, וסטיית התקן תהיה סיגמה כפול השורש הריבועי של גודל זה. ",
+  "translatedText": "ואם נבחן כמה נוסחאות ראליות, אם אנחנו יודעים את הממוצע של המשתנה האקראי הבסיסי שלנו, נקרא לו mu, ואנחנו גם יודעים את סטיית התקן שלו, ואנחנו קוראים לזה סיגמה, אז הממוצע של הסכום בתחתית יהיה mu כפול גודל הסכום, וסטיית התקן תהיה סיגמה כפול השורש הריבועי של גודל זה. ",
   "model": "nmt",
   "time_range": [
    1210.33,
@@ -1369,7 +1369,7 @@
  },
  {
   "input": "So now, if we want to claim that this looks more and more like a bell curve, and a bell curve is only described by two different parameters, the mean and the standard deviation, you know what to do. ",
-  "translatedText": "אז עכשיו, אם אנחנו רוצים לטעון שזה נראה יותר ויותר כמו עקומת פעמון, ועקומת פעמון מתוארת רק על ידי שני פרמטרים שונים, הממוצע וסטיית התקן, אתה יודע מה לעשות. ",
+  "translatedText": "אז עכשיו, אם אנחנו רוצים לטעון שזה נראה יותר ויותר כמו עקומת פעמון, ועקומת פעמון מתוארת רק על ידי שני פרמטרים שונים, הממוצע וסטיית התקן, אתם יודעים מה לעשות. ",
   "model": "nmt",
   "time_range": [
    1228.19,
@@ -1378,7 +1378,7 @@
  },
  {
   "input": "You could plug those two values into the formula, and it gives you a highly explicit, albeit kind of complicated, formula for a curve that should closely fit our distribution. ",
-  "translatedText": "אתה יכול לחבר את שני הערכים האלה לנוסחה, והיא נותנת לך נוסחה מאוד מפורשת, גם אם סוג של מסובכת, לעקומה שאמורה להתאים היטב להפצה שלנו. ",
+  "translatedText": "אתם יכולים לחבר את שני הערכים האלה לנוסחה, והיא נותנת לכם נוסחה מאוד מפורשת, גם אם סוג של מסובכת, לעקומה שאמורה להתאים היטב להתפלגות שלנו. ",
   "model": "nmt",
   "time_range": [
    1237.93,
@@ -1387,7 +1387,7 @@
  },
  {
   "input": "But there's another way we can describe it that's a little more elegant and lends itself to a very fun visual that we can build up to. ",
-  "translatedText": "אבל יש דרך אחרת שבה אנחנו יכולים לתאר את זה שהיא קצת יותר אלגנטית ומתאימה לחזות מאוד מהנה שאנחנו יכולים לבנות אליו. ",
+  "translatedText": "אבל יש דרך אחרת שבה אנחנו יכולים לתאר את זה שהיא קצת יותר אלגנטית ומביאה לתצוגה מאוד מהנה שאנחנו יכולים לפתח. ",
   "model": "nmt",
   "time_range": [
    1248.39,
@@ -1396,7 +1396,7 @@
  },
  {
   "input": "Instead of focusing on the sum of all of these random variables, let's modify this expression a little bit, where what we'll do is we'll look at the mean that we expect that sum to take, and we subtract it off so that our new expression has a mean of 0, and then we're going to look at the standard deviation we expect of our sum, and divide out by that, which basically just rescales the units so that the standard deviation of our expression will equal 1. ",
-  "translatedText": "במקום להתמקד בסכום של כל המשתנים האקראיים האלה, הבה נשנה מעט את הביטוי הזה, שם מה שנעשה הוא נסתכל על הממוצע שאנו מצפים שהסכום הזה ייקח, ונחסר אותו כך לביטוי החדש שלנו יש ממוצע של 0, ואז נסתכל על סטיית התקן שאנו מצפים מהסכום שלנו, ונחלק בזה, שבעצם רק משנה את קנה המידה של היחידות כך שסטיית התקן של הביטוי שלנו תהיה שווה ל-1 . ",
+  "translatedText": "במקום להתמקד בסכום של כל המשתנים האקראיים האלה, הבה נשנה מעט את הביטוי הזה, ומה שנעשה הוא להסתכל על הממוצע שאנו מצפים שהסכום הזה יקבל, ונחסר אותו כך לביטוי החדש שלנו יש ממוצע של 0, ואז נסתכל על סטיית התקן שאנו מצפים מהסכום שלנו, ונחלק בזה, חלוקה שבעצם רק משנה את קנה המידה של היחידות כך שסטיית התקן של הביטוי שלנו תהיה שווה ל-1 . ",
   "model": "nmt",
   "time_range": [
    1255.27,
@@ -1414,7 +1414,7 @@
  },
  {
   "input": "It's essentially saying how many standard deviations away from the mean is this sum? ",
-  "translatedText": "זה בעצם אומר כמה סטיות תקן רחוקות מהממוצע הוא הסכום הזה? ",
+  "translatedText": "זה בעצם אומר בכמה סטיות תקן הסכום הזה רחוק מהממוצע? ",
   "model": "nmt",
   "time_range": [
    1284.45,
@@ -1423,7 +1423,7 @@
  },
  {
   "input": "For example, this bar here corresponds to a certain value that you might find when you roll 10 dice and you add them all up, and its position a little above negative 1 is telling you that that value is a little bit less than one standard deviation lower than the mean. ",
-  "translatedText": "לדוגמה, סרגל זה כאן מתאים לערך מסוים שאתה עשוי למצוא כאשר אתה מטיל 10 קוביות ומחבר את כולן, והמיקום שלו קצת מעל 1 השלילי אומר לך שהערך הזה הוא קצת פחות מסטיית תקן אחת נמוך מהממוצע. ",
+  "translatedText": "לדוגמה, סרגל זה כאן מתאים לערך מסוים שאתם עשויים למצוא כאשר אתם מטילים 10 קוביות ומחברים את כולן, והמיקום שלו קצת מעל 1 השלילי אומר לכם שהערך הזה הוא קצת פחות מסטיית תקן אחת נמוך מהממוצע. ",
   "model": "nmt",
   "time_range": [
    1290.75,
@@ -1432,7 +1432,7 @@
  },
  {
   "input": "Also, by the way, in anticipation for the animation I'm trying to build to here, the way I'm representing things on that lower plot is that the area of each one of these bars is telling us the probability of the corresponding value rather than the height. ",
-  "translatedText": "כמו כן, אגב, בציפייה לאנימציה שאני מנסה לבנות לה כאן, הדרך שבה אני מייצג דברים על החלק התחתון הזה הוא שהשטח של כל אחד מהברים האלה אומר לנו את ההסתברות של הערך המתאים ולא הגובה. ",
+  "translatedText": "כמו כן, אגב, בציפייה לאנימציה שאני מנסה לבנות לה כאן, הדרך שבה אני מייצג דברים על התרשים התחתון הזה הוא שהשטח של כל אחת מהעמודות האלה אומר לנו את ההסתברות של הערך המתאים ולא הגובה. ",
   "model": "nmt",
   "time_range": [
    1305.13,
@@ -1450,7 +1450,7 @@
  },
  {
   "input": "The reason for this is to set the stage so that it aligns with the way we interpret continuous distributions, where the probability of falling between a range of values is equal to an area under a curve between those values. ",
-  "translatedText": "הסיבה לכך היא להגדיר את השלב כך שיתיישר עם הדרך בה אנו מפרשים התפלגויות רציפות, כאשר ההסתברות ליפול בין טווח ערכים שווה לשטח מתחת לעקומה בין הערכים הללו. ",
+  "translatedText": "הסיבה לכך היא להגדיר את השלב כך שיתיישר עם הדרך בה אנו מפרשים התפלגויות רציפות, כאשר ההסתברות ליפול בטווח ערכים שווה לשטח מתחת לעקומה בין הערכים האלו. ",
   "model": "nmt",
   "time_range": [
    1322.27,
@@ -1459,7 +1459,7 @@
  },
  {
   "input": "In particular, the area of all the bars together is going to be 1. ",
-  "translatedText": "במיוחד, השטח של כל הסורגים יחד יהיה 1. ",
+  "translatedText": "במיוחד, השטח של כל העמודות יחד יהיה 1. ",
   "model": "nmt",
   "time_range": [
    1333.91,
@@ -1477,7 +1477,7 @@
  },
  {
   "input": "Let me start by rolling things back so that the distribution on the bottom represents a relatively small sum, like adding together only three such random variables. ",
-  "translatedText": "תן לי להתחיל בגלגל את הדברים לאחור כך שההתפלגות בתחתית מייצגת סכום קטן יחסית, כמו חיבור רק של שלושה משתנים אקראיים כאלה. ",
+  "translatedText": "תנו לי להתחיל בחזרה לאחור כך שההתפלגות בתחתית מייצגת סכום קטן יחסית, כמו חיבור של רק שלושה משתנים אקראיים כאלה. ",
   "model": "nmt",
   "time_range": [
    1341.33,
@@ -1513,7 +1513,7 @@
  },
  {
   "input": "If we let the size of our sum get a little bit bigger, say going up to 10, and as I change the distribution for x, it largely stays looking like a bell curve, but I can find some distributions that get it to change shape. ",
-  "translatedText": "אם נניח לגודל הסכום שלנו לגדול קצת יותר, נניח עולה ל-10, וכשאני משנה את ההתפלגות עבור x, הוא נשאר ברובו להיראות כמו עקומת פעמון, אבל אני יכול למצוא כמה התפלגויות שגורמות לו לשנות צורה . ",
+  "translatedText": "אם נניח לגודל הסכום שלנו לגדול קצת יותר, נניח עולה ל-10, וכשאני משנה את ההתפלגות עבור x, הוא נשאר ברובו כמו עקומת פעמון, אבל אני יכול למצוא כמה התפלגויות שגורמות לו לשנות צורה . ",
   "model": "nmt",
   "time_range": [
    1360.35,
@@ -1522,7 +1522,7 @@
  },
  {
   "input": "For example, the really lopsided one where almost all the probability is in the numbers 1 or 6 results in this kind of spiky bell curve, and if you'll recall, earlier on I actually showed this in the form of a simulation. ",
-  "translatedText": "לדוגמה, התופעה השגויה שבה כמעט כל ההסתברות היא במספרים 1 או 6 מביאה לסוג כזה של עקומת פעמון קוצנית, ואם תזכרו, קודם לכן למעשה הראיתי זאת בצורה של סימולציה. ",
+  "translatedText": "לדוגמה, המצב המוטה שבו כמעט כל ההסתברות היא במספרים 1 או 6 מביאה לסוג כזה של עקומת פעמון מחודדת, ואם תזכרו, קודם לכן למעשה הראיתי זאת בצורה של סימולציה. ",
   "model": "nmt",
   "time_range": [
    1372.23,
@@ -1531,7 +1531,7 @@
  },
  {
   "input": "So if you were wondering whether that spikiness was an artifact of the randomness or reflected the true distribution, turns out it reflects the true distribution. ",
-  "translatedText": "אז אם תהיתם אם הדוקרנות הזו היא חפץ של האקראיות או שיקפה את ההתפלגות האמיתית, מסתבר שהיא משקפת את ההתפלגות האמיתית. ",
+  "translatedText": "אז אם תהיתם אם הדוקרנות הזו היא תוצאה של האקראיות או שיקפה את ההתפלגות האמיתית, מסתבר שהיא משקפת את ההתפלגות האמיתית. ",
   "model": "nmt",
   "time_range": [
    1384.23,
@@ -1549,7 +1549,7 @@
  },
  {
   "input": "But if instead I let that sum grow and I consider adding 50 different values, which is actually not that big, then no matter how I change the distribution for our underlying random variable, it has essentially no effect on the shape of the plot on the bottom. ",
-  "translatedText": "אבל אם במקום זאת אתן לסכום הזה לגדול ואני שוקל להוסיף 50 ערכים שונים, שהם למעשה לא כל כך גדולים, אז לא משנה איך אני משנה את ההתפלגות עבור המשתנה האקראי הבסיסי שלנו, אין לזה השפעה בעצם על צורת העלילה ב- תַחתִית. ",
+  "translatedText": "אבל אם במקום זאת אתן לסכום הזה לגדול ואני שוקל להוסיף 50 ערכים שונים, שהם למעשה לא כל כך גדולים, אז לא משנה איך אני משנה את ההתפלגות עבור המשתנה האקראי הבסיסי שלנו, אין לזה השפעה בעצם על צורת התרשים ב- תַחתִית. ",
   "model": "nmt",
   "time_range": [
    1396.47,
@@ -1558,7 +1558,7 @@
  },
  {
   "input": "No matter where we start, all of the information and nuance for the distribution of x gets washed away, and we tend towards this single universal shape described by a very elegant function for the standard normal distribution, 1 over square root of 2 pi times e to the negative x squared over 2. ",
-  "translatedText": "לא משנה מאיפה נתחיל, כל המידע והניואנסים להתפלגות x נשטפים, ואנו נוטים לצורה אוניברסלית יחידה זו המתוארת על ידי פונקציה אלגנטית מאוד עבור ההתפלגות הנורמלית הסטנדרטית, 1 מעל שורש ריבועי של 2 pi כפול e ל-X השלילי בריבוע על פני 2. ",
+  "translatedText": "לא משנה מאיפה נתחיל, כל המידע והניואנסים להתפלגות x נעלמים, ואנו נוטים לצורה אוניברסלית יחידה זו המתוארת על ידי פונקציה אלגנטית מאוד עבור ההתפלגות הנורמלית הסטנדרטית, 1 מעל שורש ריבועי של 2 pi כפול e בחזקת-X השלילי בריבוע על פני 2. ",
   "model": "nmt",
   "time_range": [
    1411.17,
@@ -1576,7 +1576,7 @@
  },
  {
   "input": "Almost nothing you can do to this initial distribution changes the shape we tend towards. ",
-  "translatedText": "כמעט שום דבר שאתה יכול לעשות להפצה הראשונית הזו משנה את הצורה שאליו אנו נוטים. ",
+  "translatedText": "כמעט שום דבר שאתם יכולים לעשות להתפלגות הראשונית הזו משנה את הצורה שאנו נוטים לכיוונה. ",
   "model": "nmt",
   "time_range": [
    1431.13,
@@ -1594,7 +1594,7 @@
  },
  {
   "input": "Like, what's the mathematical statement that could be proved or disproved that we're claiming here? ",
-  "translatedText": "כאילו, מהי האמירה המתמטית שניתן להוכיח או להפריך שאנו טוענים כאן? ",
+  "translatedText": "ז"א, מהי האמירה המתמטית שניתן להוכיח או להפריך שאנו טוענים כאן? ",
   "model": "nmt",
   "time_range": [
    1444.81,
@@ -1603,7 +1603,7 @@
  },
  {
   "input": "If you want a nice formal statement, here's how it might go. ",
-  "translatedText": "אם אתה רוצה הצהרה רשמית נחמדה, הנה איך זה יכול ללכת. ",
+  "translatedText": "אם אתם רוצים הצהרה רשמית חביבה, הנה איך זה יכול ללכת. ",
   "model": "nmt",
   "time_range": [
    1449.03,
@@ -1612,7 +1612,7 @@
  },
  {
   "input": "Consider this value, where we're summing up n different instantiations of our random variable, but tweaked and tuned so that its mean and standard deviation are 1. ",
-  "translatedText": "קחו בחשבון את הערך הזה, שבו אנו מסכמים n מופעים שונים של המשתנה האקראי שלנו, אך מכוונים ומכוונים כך שהממוצע וסטיית התקן שלו הם 1. ",
+  "translatedText": "קחו בחשבון את הערך הזה, שבו אנו מסכמים n מופעים שונים של המשתנה האקראי שלנו, אך מכוונים ומכווננים כך שהממוצע וסטיית התקן שלו הם 1. ",
   "model": "nmt",
   "time_range": [
    1451.05,
@@ -1621,7 +1621,7 @@
  },
  {
   "input": "Again, meaning you can read it as asking how many standard deviations away from the mean is the sum. ",
-  "translatedText": "שוב, כלומר אתה יכול לקרוא את זה כשואל כמה סטיות תקן רחוקות מהממוצע הוא הסכום. ",
+  "translatedText": "שוב, כלומר אתם יכולים לקרוא את זה כשאלה בכמה סטיות תקן רחוקות הסכום רחוק מהממוצע. ",
   "model": "nmt",
   "time_range": [
    1460.23,
@@ -1630,7 +1630,7 @@
  },
  {
   "input": "Then the actual rigorous no-jokes-this-time statement of the central limit theorem is that if you consider the probability that this value falls between two given real numbers, a and b, and you consider the limit of that probability as the size of your sum goes to infinity, then that limit is equal to a certain integral, which basically describes the area under a standard normal distribution between those two values. ",
-  "translatedText": "אז ההצהרה המחמירה האמיתית ללא בדיחות-הפעם של משפט הגבול המרכזי היא שאם אתה מחשיב את ההסתברות שהערך הזה נופל בין שני מספרים ממשיים נתונים, a ו-b, ואתה מחשיב את הגבול של ההסתברות הזו כגודל של הסכום שלך מגיע לאינסוף, ואז הגבול הזה שווה לאינטגרל מסוים, שמתאר בעצם את השטח תחת התפלגות נורמלית סטנדרטית בין שני הערכים הללו. ",
+  "translatedText": "אז ההצהרה המחמירה האמיתית ללא בדיחות-הפעם של משפט הגבול המרכזי היא שאם אתם מחשיבים את ההסתברות שהערך הזה נופל בין שני מספרים ממשיים נתונים, a ו-b, ואתה מחשיב את הגבול של ההסתברות הזו כגודל של הסכום שלכם באינסוף, ואז הגבול הזה שווה לאינטגרל מסוים, שמתאר בעצם את השטח תחת התפלגות נורמלית סטנדרטית בין שני הערכים הללו. ",
   "model": "nmt",
   "time_range": [
    1465.77,
@@ -1639,7 +1639,7 @@
  },
  {
   "input": "Again, there are three underlying assumptions that I have yet to tell you, but other than those, in all of its gory detail, this right here is the central limit theorem. ",
-  "translatedText": "שוב, ישנן שלוש הנחות יסוד שעדיין לא סיפרתי לך, אבל חוץ מאלה, על כל הפרטים המדהימים שלה, זה ממש כאן משפט הגבול המרכזי. ",
+  "translatedText": "שוב, ישנן שלוש הנחות יסוד שעדיין לא סיפרתי לכם, אבל חוץ מאלה, על כל הפרטים המרשימים שלה, ממש כאן זהו משפט הגבול המרכזי. ",
   "model": "nmt",
   "time_range": [
    1491.25,
@@ -1648,7 +1648,7 @@
  },
  {
   "input": "All of that is a bit theoretical, so it might be helpful to bring things back down to Earth and turn back to the concrete example that I mentioned at the start, where you imagine rolling a die 100 times, and let's assume it's a fair die for this example, and you add together the results. ",
-  "translatedText": "כל זה קצת תיאורטי, אז זה עשוי להיות מועיל להחזיר את הדברים לכדור הארץ ולחזור לדוגמא הקונקרטית שהזכרתי בהתחלה, שבה אתה מדמיין להטיל קובייה 100 פעמים, ובואו נניח שזו קובייה הוגנת עבור דוגמה זו, ואתה מוסיף את התוצאות. ",
+  "translatedText": "כל זה קצת תיאורטי, אז זה עשוי להיות מועיל להחזיר את הדברים לכדור הארץ ולחזור לדוגמה הקונקרטית שהזכרתי בהתחלה, שבה אתם מדמיינים הטלת קובייה 100 פעמים, ובואו נניח שזו קובייה הוגנת עבור דוגמה זו, ואתם מחברים את התוצאות. ",
   "model": "nmt",
   "time_range": [
    1504.55,
@@ -1657,7 +1657,7 @@
  },
  {
   "input": "The challenge for you is to find a range of values such that you're 95% sure that the sum will fall within this range. ",
-  "translatedText": "האתגר עבורך הוא למצוא טווח של ערכים כך שאתה בטוח ב-95% שהסכום ייכנס לטווח הזה. ",
+  "translatedText": "האתגר עבורכם הוא למצוא טווח של ערכים כך שאתם בטוחים ב-95% שהסכום יהיה בטווח הזה. ",
   "model": "nmt",
   "time_range": [
    1518.87,
@@ -1666,7 +1666,7 @@
  },
  {
   "input": "For questions like this, there's a handy rule of thumb about normal distributions, which is that about 68% of your values are going to fall within one standard deviation of the mean, 95% of your values, the thing we care about, fall within two standard deviations of the mean, and a whopping 99.7% of your values will fall within three standard deviations of the mean. ",
-  "translatedText": "לשאלות כאלה, יש כלל אצבע שימושי לגבי התפלגויות נורמליות, שהוא שכ-68% מהערכים שלך עומדים ליפול בתוך סטיית תקן אחת מהממוצע, 95% מהערכים שלך, הדבר שאכפת לנו ממנו, נופלים בתוך שתי סטיות תקן של הממוצע, ו-99 עצום. 7% מהערכים שלך יפלו בתוך שלוש סטיות תקן מהממוצע. ",
+  "translatedText": "לשאלות כאלה, יש כלל אצבע שימושי לגבי התפלגויות נורמליות, שהוא שכ-68% מהערכים עומדים ליפול בתוך סטיית תקן אחת מהממוצע, 95% מהערכים, הדבר שאכפת לנו ממנו, נופלים בתוך שתי סטיות תקן של הממוצע, ו-99. 7% מהערכים שלך יפלו בתוך שלוש סטיות תקן מהממוצע. ",
   "model": "nmt",
   "time_range": [
    1527.13,
@@ -1675,7 +1675,7 @@
  },
  {
   "input": "It's a rule of thumb that's commonly memorized by people who do a lot of probability and stats. ",
-  "translatedText": "זה כלל אצבע שנשנן בדרך כלל על ידי אנשים שעושים הרבה הסתברות וסטטיסטיקות. ",
+  "translatedText": "זה כלל אצבע שמשונן בדרך כלל על ידי אנשים שעוסקים הרבה בהסתברות וסטטיסטיקות. ",
   "model": "nmt",
   "time_range": [
    1551.05,
@@ -1684,7 +1684,7 @@
  },
  {
   "input": "Naturally, this gives us what we need for our example, and let me go ahead and draw out what this would look like, where I'll show the distribution for a fair die up at the top, and the distribution for a sum of 100 such dice on the bottom, which by now as you know looks like a certain normal distribution. ",
-  "translatedText": "כמובן, זה נותן לנו את מה שאנחנו צריכים עבור הדוגמה שלנו, ותן לי להמשיך ולשרטט איך זה ייראה, איפה אני אראה את ההתפלגות עבור קובייה הוגנת בחלק העליון, ואת ההתפלגות עבור סכום של 100 קוביות כאלה בתחתית, שעד עכשיו, כפי שאתה יודע, נראית כמו התפלגות נורמלית מסוימת. ",
+  "translatedText": "כמובן, זה נותן לנו את מה שאנחנו צריכים עבור הדוגמה שלנו, ותנו לי להמשיך ולשרטט איך זה ייראה, כאשר אני אראה את ההתפלגות עבור קובייה הוגנת בחלק העליון, ואת ההתפלגות עבור סכום של 100 קוביות כאלה בתחתית, שעד עכשיו, כפי שאתם יודעים, נראית כמו התפלגות נורמלית מסוימת. ",
   "model": "nmt",
   "time_range": [
    1555.67,
@@ -1693,7 +1693,7 @@
  },
  {
   "input": "Step one with a problem like this is to find the mean of your initial distribution, which in this case will look like 1 6th times 1 plus 1 6th times 2 on and on and on, and works out to be 3.5. ",
-  "translatedText": "שלב ראשון עם בעיה כזו הוא למצוא את הממוצע של ההתפלגות הראשונית שלך, שבמקרה זה ייראה כמו 1 6 כפול 1 ועוד 1 6 כפול 2 והלאה והלאה, ומסתבר להיות 3. ",
+  "translatedText": "שלב ראשון עם בעיה כזו הוא למצוא את הממוצע של ההתפלגות הראשונית שלכם, שבמקרה זה תראה כמו שישית כפול 1 ועוד שישית כפול 2 והלאה והלאה, והתוצאה המתקבלת היא 3. ",
   "model": "nmt",
   "time_range": [
    1571.51,
@@ -1702,7 +1702,7 @@
  },
  {
   "input": "We also need the standard deviation, which requires calculating the variance, which as you know involves adding all the squares of the differences between the values and the means, and it works out to be 2.92, square root of that comes out to be 1.71. ",
-  "translatedText": "5. צריך גם את סטיית התקן שדורשת חישוב השונות, שכידוע כרוכה בהוספת כל הריבועים של ההפרשים בין הערכים והאמצעים, ומסתבר שזה 2.92, השורש הריבועי של זה יוצא כ-1.71. ",
+  "translatedText": "5. צריך גם את סטיית התקן שדורשת את חישוב השונות, שכידוע כרוכה בהוספת כל הריבועים של ההפרשים בין הערכים והאמצעים, ומסתבר שזה 2.92, השורש הריבועי של זה יוצא כ-1.71. ",
   "model": "nmt",
   "time_range": [
    1581.53,
@@ -1711,7 +1711,7 @@
  },
  {
   "input": "Those are the only two numbers we need, and I will invite you again to reflect on how magical it is that those are the only two numbers that you need to completely understand the bottom distribution. ",
-  "translatedText": "אלה שני המספרים היחידים שאנחנו צריכים, ואני אזמין אותך שוב לחשוב על כמה זה קסום שאלו שני המספרים היחידים שאתה צריך כדי להבין לחלוטין את ההתפלגות התחתונה. ",
+  "translatedText": "אלה שני המספרים היחידים שאנחנו צריכים, ואני אזמין אותכם לחשוב שוב על כמה זה קסום שאלו שני המספרים היחידים שאתם צריכים כדי להבין לחלוטין את ההתפלגות התחתונה. ",
   "model": "nmt",
   "time_range": [
    1595.25,
@@ -1720,7 +1720,7 @@
  },
  {
   "input": "Its mean will be 100 times mu, which is 350, and its standard deviation will be the square root of 100 times sigma, so 10 times sigma 17.1. ",
-  "translatedText": "הממוצע שלו יהיה פי 100 מו, שהם 350, וסטיית התקן שלו תהיה השורש הריבועי של פי 100 סיגמא, אז פי 10 סיגמא 17.1. ",
+  "translatedText": "הממוצע שלו יהיה פי 100 mu , שהו 350, וסטיית התקן שלו תהיה השורש הריבועי של פי 100 סיגמא, אז פי 10 סיגמא 17.1. ",
   "model": "nmt",
   "time_range": [
    1604.71,
@@ -1729,7 +1729,7 @@
  },
  {
   "input": "Remembering our handy rule of thumb, we're looking for values two standard deviations away from the mean, and when you subtract 2 sigma from the mean you end up with about 316, and when you add 2 sigma you end up with 384. ",
-  "translatedText": "נזכור את כלל האצבע השימושי שלנו, אנו מחפשים ערכים במרחק שתי סטיות תקן מהממוצע, וכשאתה מפחית 2 סיגמא מהממוצע אתה מגיע ל-316 בערך, וכשאתה מוסיף 2 סיגמא אתה מגיע ל-384. ",
+  "translatedText": "נזכור את כלל האצבע השימושי שלנו, אנו מחפשים ערכים במרחק שתי סטיות תקן מהממוצע, וכשאתם מפחיתים 2 סיגמא מהממוצע אתם מגיעים ל-316 בערך, וכשאתם מוסיפים 2 סיגמא אתם מגיעים ל-384. ",
   "model": "nmt",
   "time_range": [
    1613.67,
@@ -1747,7 +1747,7 @@
  },
  {
   "input": "Okay, I promised to wrap things up shortly, but while we're on this example there's one more question that's worth your time to ponder. ",
-  "translatedText": "אוקיי, הבטחתי לסכם את הדברים בקרוב, אבל בזמן שאנחנו בדוגמה הזו יש עוד שאלה אחת ששווה את הזמן שלך להרהר בה. ",
+  "translatedText": "אוקיי, הבטחתי לסכם את הדברים בקרוב, אבל בזמן שאנחנו בדוגמה הזו יש עוד שאלה אחת ששווה את הזמן שלכם להרהר בה. ",
   "model": "nmt",
   "time_range": [
    1631.47,
@@ -1765,7 +1765,7 @@
  },
  {
   "input": "Take a moment to interpret what this all would be saying then. ",
-  "translatedText": "קח רגע לפרש מה כל זה היה אומר אז. ",
+  "translatedText": "קחו רגע לפרש מה כל מה שזה אומר. ",
   "model": "nmt",
   "time_range": [
    1648.57,
@@ -1774,7 +1774,7 @@
  },
  {
   "input": "The expression essentially tells you the empirical average for 100 different die rolls, and that interval we found is now telling you what range you are expecting to see for that empirical average. ",
-  "translatedText": "הביטוי בעצם אומר לך את הממוצע האמפירי עבור 100 סיבובי קוביות שונים, והמרווח הזה שמצאנו אומר לך עכשיו איזה טווח אתה מצפה לראות עבור הממוצע האמפירי הזה. ",
+  "translatedText": "הביטוי בעצם נותן את הממוצע האמפירי עבור 100 סיבובי קוביות שונים, והמרווח הזה שמצאנו אומר לכם איזה טווח אתם מצפים לראות עבור הממוצע האמפירי הזה. ",
   "model": "nmt",
   "time_range": [
    1652.07,
@@ -1783,7 +1783,7 @@
  },
  {
   "input": "In other words, you might expect it to be around 3.5, that's the expected value for a die roll, but what's much less obvious and what the central limit theorem lets you compute is how close to that expected value you'll reasonably find yourself. ",
-  "translatedText": "במילים אחרות, אתה עשוי לצפות שזה יהיה בסביבות 3.5, זה הערך הצפוי להטלת קובייה, אבל מה שהרבה פחות ברור ומה שמשפט הגבול המרכזי מאפשר לך לחשב זה כמה קרוב לערך הצפוי הזה תמצא את עצמך באופן סביר. ",
+  "translatedText": "במילים אחרות, אתם עשויים לצפות שזה יהיה בסביבות 3.5, שזהו הערך הצפוי להטלת קובייה, אבל מה שהרבה פחות ברור ומה שמשפט הגבול המרכזי מאפשר לכם לחשב זה כמה קרוב לערך הצפוי הזה תמצאו את עצמכם באופן סביר. ",
   "model": "nmt",
   "time_range": [
    1664.35,
@@ -1792,7 +1792,7 @@
  },
  {
   "input": "In particular, it's worth your time to take a moment mulling over what the standard deviation for this empirical average is, and what happens to it as you look at a bigger and bigger sample of die rolls. ",
-  "translatedText": "בפרט, שווה את הזמן שלך להרהר רגע מה סטיית התקן של הממוצע האמפירי הזה, ומה קורה לו כשאתה מסתכל על מדגם גדול יותר ויותר של גלילי קוביות. ",
+  "translatedText": "בפרט, שווה את הזמן שלך להרהר רגע מה סטיית התקן של הממוצע האמפירי הזה, ומה קורה לו כשאתה מסתכל על מדגם גדול יותר ויותר של הטלות של קוביות. ",
   "model": "nmt",
   "time_range": [
    1677.59,
@@ -1810,7 +1810,7 @@
  },
  {
   "input": "The first one is that all of these variables that we're adding up are independent from each other. ",
-  "translatedText": "הראשון הוא שכל המשתנים האלה שאנחנו מוסיפים הם בלתי תלויים זה בזה. ",
+  "translatedText": "הראשונה היא שכל המשתנים האלה שאנחנו מוסיפים הם בלתי תלויים זה בזה. ",
   "model": "nmt",
   "time_range": [
    1698.01,
@@ -1828,7 +1828,7 @@
  },
  {
   "input": "The second is that all of these variables are drawn from the same distribution. ",
-  "translatedText": "השני הוא שכל המשתנים הללו נמשכים מאותה התפלגות. ",
+  "translatedText": "השניה היא שכל המשתנים הללו נשלפים מאותה התפלגות. ",
   "model": "nmt",
   "time_range": [
    1707.25,
@@ -1837,7 +1837,7 @@
  },
  {
   "input": "Both of these have been implicitly assumed with our dice example. ",
-  "translatedText": "שני אלה הונחו באופן מרומז עם דוגמה לקוביות שלנו. ",
+  "translatedText": "שתי אלו הונחו באופן מרומז עם דוגמה לקוביות שלנו. ",
   "model": "nmt",
   "time_range": [
    1711.31,
@@ -1855,7 +1855,7 @@
  },
  {
   "input": "Sometimes in the literature you'll see these two assumptions lumped together under the initials IID for independent and identically distributed. ",
-  "translatedText": "לפעמים בספרות אתה תראה את שתי ההנחות הללו מחוברות יחדיו תחת ראשי התיבות IID לעצמאיות ומופצות באופן זהה. ",
+  "translatedText": "לפעמים בספרות תראו את שתי ההנחות הללו מחוברות יחדי תחת ראשי התיבות IID (independent and identically distributed). ",
   "model": "nmt",
   "time_range": [
    1722.85,
@@ -1864,7 +1864,7 @@
  },
  {
   "input": "One situation where these assumptions are decidedly not true would be the Galton board. ",
-  "translatedText": "מצב אחד שבו הנחות אלו אינן נכונות בהחלט יהיה מועצת המנהלים של גלטון. ",
+  "translatedText": "מצב אחד שבו הנחות אלו אינן נכונות בהחלט יהיה לוח גלטון. ",
   "model": "nmt",
   "time_range": [
    1730.53,
@@ -1873,7 +1873,7 @@
  },
  {
   "input": "I mean, think about it. ",
-  "translatedText": "כלומר, תחשוב על זה. ",
+  "translatedText": "כלומר, תחשובו על זה. ",
   "model": "nmt",
   "time_range": [
    1735.71,
@@ -1882,7 +1882,7 @@
  },
  {
   "input": "Is it the case that the way a ball bounces off of one of the pegs is independent from how it's going to bounce off the next peg? ",
-  "translatedText": "האם זה המקרה שהאופן שבו כדור קופץ מאחת מהיתדות אינה תלויה איך הוא עומד לקפוץ מהיתד הבא? ",
+  "translatedText": "האם זה המקרה שהאופן שבו כדור קופץ מאחת מהיתדות אינה תלויה באיך הוא עומד לקפוץ מהיתד הבא? ",
   "model": "nmt",
   "time_range": [
    1736.97,
@@ -1900,7 +1900,7 @@
  },
  {
   "input": "Depending on the last bounce, it's coming in with a completely different trajectory. ",
-  "translatedText": "בהתאם להקפצה האחרונה, זה מגיע עם מסלול שונה לחלוטין. ",
+  "translatedText": "בהתאם לקפיצה האחרונה, מגיע מסלול שונה לחלוטין. ",
   "model": "nmt",
   "time_range": [
    1744.77,
@@ -1909,7 +1909,7 @@
  },
  {
   "input": "And is it the case that the distribution of possible outcomes off of each peg are the same for each peg that it hits? ",
-  "translatedText": "והאם זה המצב שהתפלגות התוצאות האפשריות מכל יתד זהה לכל יתד שהוא פוגע? ",
+  "translatedText": "והאם זהו המצב שהתפלגות התוצאות האפשריות מכל יתד זהה לכל יתד שבו הוא פוגע? ",
   "model": "nmt",
   "time_range": [
    1748.21,
@@ -1927,7 +1927,7 @@
  },
  {
   "input": "Maybe it hits one peg glancing to the left, meaning the outcomes are hugely skewed in that direction, and then hits the next one glancing to the right. ",
-  "translatedText": "אולי זה פוגע בפית אחת שמסתכלת שמאלה, כלומר התוצאות מוטות מאוד בכיוון הזה, ואז פוגע במבט הבא שמביט ימינה. ",
+  "translatedText": "אולי זה פוגע ביתד אחד ונזרק שמאלה, כלומר התוצאות מוטות מאוד בכיוון הזה, ואז פוגע ביתד הבא ומועף ימינה. ",
   "model": "nmt",
   "time_range": [
    1756.71,
@@ -1945,7 +1945,7 @@
  },
  {
   "input": "It's also that those assumptions were necessary for this to actually be an example of the central limit theorem. ",
-  "translatedText": "זה גם שההנחות הללו היו הכרחיות כדי שזה יהיה למעשה דוגמה למשפט הגבול המרכזי. ",
+  "translatedText": "זה גם כדי שההנחות הללו היו הכרחיות כדי שזה יהיה למעשה דוגמה למשפט הגבול המרכזי. ",
   "model": "nmt",
   "time_range": [
    1771.97,
@@ -1954,7 +1954,7 @@
  },
  {
   "input": "Nevertheless, it seems to be true that for the real Galton board, despite violating both of these, a normal distribution does kind of come about? ",
-  "translatedText": "עם זאת, נראה שזה נכון שעבור הלוח האמיתי של גלטון, למרות הפרה של שני אלה, אכן נוצרת התפלגות נורמלית? ",
+  "translatedText": "עם זאת, נראה שזה נכון שעבור הלוח האמיתי של גלטון, למרות הפרה של שתי אלו, אכן נוצרת התפלגות נורמלית? ",
   "model": "nmt",
   "time_range": [
    1778.13,
@@ -1963,7 +1963,7 @@
  },
  {
   "input": "Part of the reason might be that there are generalizations of the theorem beyond the scope of this video that relax these assumptions, especially the second one. ",
-  "translatedText": "חלק מהסיבה עשויה להיות שיש הכללות של המשפט מעבר להיקף הסרטון הזה שמרפות את ההנחות הללו, במיוחד השנייה. ",
+  "translatedText": "חלק מהסיבה עשויה להיות שיש הכללות של המשפט מעבר להיקף הסרטון הזה שמחלישות את ההנחות הללו, במיוחד את השנייה. ",
   "model": "nmt",
   "time_range": [
    1786.05,
@@ -1972,7 +1972,7 @@
  },
  {
   "input": "But I do want to caution you against the fact that many times people seem to assume that a variable is normally distributed, even when there's no actual justification to do so. ",
-  "translatedText": "אבל אני כן רוצה להזהיר אותך מהעובדה שפעמים רבות נראה שאנשים מניחים שמשתנה מופץ באופן נורמאלי, גם כשאין הצדקה ממשית לעשות זאת. ",
+  "translatedText": "אבל אני כן רוצה להזהיר אותכם מהעובדה שפעמים רבות נראה שאנשים מניחים שמשתנה מתפלג באופן נורמאלי, גם כשאין הצדקה ממשית לעשות זאת. ",
   "model": "nmt",
   "time_range": [
    1794.49,
@@ -1990,7 +1990,7 @@
  },
  {
   "input": "It's that the variance we've been computing for these variables is finite. ",
-  "translatedText": "זה שהשונות שחישבנו עבור המשתנים האלה היא סופית. ",
+  "translatedText": "היא שהשונות שחישבנו עבור המשתנים האלה היא סופית. ",
   "model": "nmt",
   "time_range": [
    1806.21,
@@ -1999,7 +1999,7 @@
  },
  {
   "input": "This was never an issue for the dice example, because there were only six possible outcomes. ",
-  "translatedText": "זה אף פעם לא היה בעיה עבור דוגמה לקוביות, כי היו רק שש תוצאות אפשריות. ",
+  "translatedText": "זה אף פעם לא היה בעיה עבור דוגמת הקוביות, כי היו רק שש תוצאות אפשריות. ",
   "model": "nmt",
   "time_range": [
    1810.81,
@@ -2008,7 +2008,7 @@
  },
  {
   "input": "But in certain situations where you have an infinite set of outcomes, when you go to compute the variance, the sum ends up diverging off to infinity. ",
-  "translatedText": "אבל במצבים מסוימים שבהם יש לך קבוצה אינסופית של תוצאות, כאשר אתה הולך לחשב את השונות, הסכום מסתיים בסופו של דבר לאינסוף. ",
+  "translatedText": "אבל במצבים מסוימים שבהם יש לכם קבוצה אינסופית של תוצאות, כאשר אתם הולכים לחשב את השונות, הסכום מסתיים בסופו של דבר באינסוף. ",
   "model": "nmt",
   "time_range": [
    1815.03,
@@ -2017,7 +2017,7 @@
  },
  {
   "input": "These can be perfectly valid probability distributions, and they do come up in practice. ",
-  "translatedText": "אלו יכולות להיות התפלגויות הסתברות תקפות לחלוטין, והן עולות בפועל. ",
+  "translatedText": "אלו יכולות להיות התפלגויות הסתברות תקפות לחלוטין, והן מופיעות בפועל. ",
   "model": "nmt",
   "time_range": [
    1823.45,
@@ -2026,7 +2026,7 @@
  },
  {
   "input": "But in those situations, as you consider adding many different instantiations of that variable and letting that sum approach infinity, even if the first two assumptions hold, it is very much a possibility that the thing you tend towards is not actually a normal distribution. ",
-  "translatedText": "אבל במצבים האלה, כאשר אתה שוקל להוסיף מופעים רבים ושונים של אותו משתנה ולתת לסכום הזה להתקרב לאינסוף, גם אם שתי ההנחות הראשונות מתקיימות, קיימת אפשרות מאוד שהדבר שאליו אתה נוטה אינו למעשה התפלגות נורמלית. ",
+  "translatedText": "אבל במצבים האלה, כאשר אתם שוקלים להוסיף מופעים רבים ושונים של אותו משתנה ולתת לסכום הזה להתקרב לאינסוף, גם אם שתי ההנחות הראשונות מתקיימות, קיימת אפשרות מאוד מעשית שהדבר שאתה נוטה לכיוונו אינו למעשה התפלגות נורמלית. ",
   "model": "nmt",
   "time_range": [
    1827.55,
@@ -2044,7 +2044,7 @@
  },
  {
   "input": "And next up, I'd like to explain why it is that this particular function is the thing that we tend towards, and why it has a pi in it, what it has to do with circles. ",
-  "translatedText": "ובהמשך, אני רוצה להסביר מדוע הפונקציה הספציפית הזו היא הדבר שאליו אנו נוטים, ולמה יש בה פאי, מה זה קשור לעיגולים. ",
+  "translatedText": "ובהמשך, אני רוצה להסביר מדוע הפונקציה הספציפית הזו היא הדבר שאליו אנו נוטים לכיוונו, למה יש בה פאי, ומה זה קשור לעיגולים. ",
   "model": "nmt",
   "time_range": [
    1848.29,


### PR DESCRIPTION
Updated Hebrew subtitles for the CTL lecture.  Since **I don't know how to view the lecture using this subtitles version**, I don't know how well it is showing.  This is important, since there are some major issues when editing mixed RTL (Hebrew) and LTL (English, numbers) text.

There is an **issue that needs discussion** - male and female language.  I believe this is a general issue for other languages, like Arabic.  The problem is that in most cases the auto translation of "**you**" is to the **male** form.  In Hebrew, there a 4 ways to translate "you": single male/female (I will call it "youM"/"youF") and plural male/female ("youPM"/"youPF").

One way to fix that is to translate "you can ..." to "youF/M canF/M ...", but this seems to be too cumbersome.

Another option, which is the **option I used in this translation** is to change to plural male - "youPM canPM ...".  This is usually acceptable also for women.  (Alternative approach is to sometime use male plural and sometimes female plural, but personally I don't like it.)

A third option is to **remove the direct reference to the viewers/students**. E.g "you can do something" becomes "something can be done".  This option completely solves the male/female issue, but I don't know if this is an acceptable approach, because of the removal of the reference to the viewers.

**Suggestions/guidelines about that can help** for further updates to translations.  As I wrote, I believe this is a common issue for several languages.