### PR TITLE
Updated 2024/shorts/mandelbrot/german

### DIFF
--- a/2024/shorts/mandelbrot/german/description.json
+++ b/2024/shorts/mandelbrot/german/description.json
@@ -1,6 +1,6 @@
 [
  {
-  "translatedText": "Unten auf dem Bildschirm finden Sie einen Link zum vollständigen Video mit der Antwort auf diese Frage. Oder als Referenz: https://youtu.be/LqbZpur38nw",
+  "translatedText": "Ein Link zu dem ganzen Video ist unten auf Ihrem Bildschirm. Oder alternativ: https://youtu.be/LqbZpur38nw",
   "input": "A link to the full video answering this is at the bottom of the screen. Or, for reference: https://youtu.be/LqbZpur38nw"
  }
 ]

--- a/2024/shorts/mandelbrot/german/sentence_translations.json
+++ b/2024/shorts/mandelbrot/german/sentence_translations.json
@@ -16,7 +16,7 @@
   ]
  },
  {
-  "translatedText": "So berechnet man bei der ersten Iteration 0 Quadrat und addiert c, also ist z1 gleich c. Für die nächste Iteration quadriert man diese Zahl und addiert c, dass heißt z2 ist c Quadrat plus c, und so weiter und so fort.",
+  "translatedText": "So berechnet man bei der ersten Iteration 0 Quadrat und addiert c, also ist z1 gleich c. Für die nächste Iteration quadriert man diese Zahl und addiert c, das heißt z2 ist c Quadrat plus c, und so weiter und so fort.",
   "input": "So, for example, on the very first iteration, you take 0 squared plus c, meaning z1 is just c, and then for the next iteration, you take that number squared plus c, meaning z2 is c squared plus c, and so on and so forth.",
   "time_range": [
    16.78,

--- a/2024/shorts/mandelbrot/german/sentence_translations.json
+++ b/2024/shorts/mandelbrot/german/sentence_translations.json
@@ -1,6 +1,6 @@
 [
  {
-  "translatedText": "Die Mandelbrot-Menge ist eines der bekanntesten Bilder in der Mathematik.",
+  "translatedText": "Die Mandelbrot-Menge ist eine der bekanntesten Abbildungen der Mathematik.",
   "input": "The Mandelbrot set is one of the most iconic images in all of math.",
   "time_range": [
    0.0,
@@ -8,7 +8,7 @@
   ]
  },
  {
-  "translatedText": "Sie beginnen mit einer komplexen Zahl, c, und definieren dann rekursiv eine Folge komplexer Zahlen, wobei die Folge mit 0 beginnt und jeder neue Wert als Quadrat des vorherigen Werts plus c definiert wird.",
+  "translatedText": "Beginnen Sie mit einer komplexen Zahl, c, und betrachten eine rekursive Reihe von komplexen Zahlen, angefangen mit 0, wobei jeder neue Wert als Quadrat des vorherigen Wertes plus c definiert ist.",
   "input": "You start with some complex number, c, and then you recursively define a sequence of complex numbers where the sequence starts with 0, and each new value is defined to be the square of the previous value, plus c.",
   "time_range": [
    3.78,
@@ -16,7 +16,7 @@
   ]
  },
  {
-  "translatedText": "So nehmen Sie zum Beispiel bei der allerersten Iteration 0 zum Quadrat plus c, was bedeutet, dass z1 einfach c ist, und dann nehmen Sie für die nächste Iteration diese Zahl zum Quadrat plus c, was bedeutet, dass z2 das Quadrat von c plus c ist, und so weiter und so weiter.",
+  "translatedText": "So berechnet man bei der ersten Iteration 0 Quadrat und addiert c, also ist z1 gleich c. Für die nächste Iteration nimmt man dann diese Zahl ins Quadrat plus c, dass heißt c Quadrat plus c, und so weiter und so fort.",
   "input": "So, for example, on the very first iteration, you take 0 squared plus c, meaning z1 is just c, and then for the next iteration, you take that number squared plus c, meaning z2 is c squared plus c, and so on and so forth.",
   "time_range": [
    16.78,
@@ -24,7 +24,7 @@
   ]
  },
  {
-  "translatedText": "Jeder neue Wert ist das Quadrat des vorherigen plus c.",
+  "translatedText": "Jeder neue Wert ist das Quadrat des vorherigen Wertes plus c.",
   "input": "Each new value is the square of the previous plus c.",
   "time_range": [
    32.18,
@@ -32,7 +32,7 @@
   ]
  },
  {
-  "translatedText": "Abhängig von der Wahl dieses Werts c bleibt die Folge manchmal begrenzt und manchmal geht sie in die Unendlichkeit über.",
+  "translatedText": "Je nach Wahl dieses ersten Wertes c bleibt die Reihe manchmal beschränkt oder steigt ins Unendliche an.",
   "input": "Depending on the choice for that value c, sometimes the sequence stays bounded, and sometimes it blows up to infinity.",
   "time_range": [
    35.56,
@@ -40,7 +40,7 @@
   ]
  },
  {
-  "translatedText": "Wenn Sie alle Werte von c, die dazu führen, dass dieser Prozess begrenzt bleibt, schwarz einfärben und auf die anderen Werte einen Farbverlauf anwenden, wobei die Farbe davon abhängt, wie schnell der Prozess bis ins Unendliche ansteigt, erhalten Sie diese ikonische Niere -mit-Blasen-Form.",
+  "translatedText": "Würde man jedem Wert von c, bei dem diese Reihe beschränkt bleibt, schwarz einfärben und allen anderen Werten von c einen Farbverlauf zuordnen, wobei die Farbe davon abhängt, wie schnell die Reihe für diesen Wert von c ins Unendliche ansteigt, erhält man diese ikonische Form, die Mandelbrot-Menge.",
   "input": "If you color all of the values of c that cause this process to stay bounded black, and you apply some gradient of colors to the other values, where the color depends on how quickly the process blows up to infinity, you get this iconic, cardioid-with-bubbles shape.",
   "time_range": [
    42.06,

--- a/2024/shorts/mandelbrot/german/sentence_translations.json
+++ b/2024/shorts/mandelbrot/german/sentence_translations.json
@@ -8,7 +8,7 @@
   ]
  },
  {
-  "translatedText": "Beginnen Sie mit einer komplexen Zahl, c, und betrachten eine rekursive Reihe von komplexen Zahlen, angefangen mit 0, wobei jeder neue Wert als Quadrat des vorherigen Wertes plus c definiert ist.",
+  "translatedText": "Beginnen Sie mit einer komplexen Zahl, c, und betrachten eine rekursiv definierte Folge von komplexen Zahlen, angefangen mit 0, wobei jeder neue Wert als Quadrat des vorherigen Wertes plus c definiert ist.",
   "input": "You start with some complex number, c, and then you recursively define a sequence of complex numbers where the sequence starts with 0, and each new value is defined to be the square of the previous value, plus c.",
   "time_range": [
    3.78,
@@ -16,7 +16,7 @@
   ]
  },
  {
-  "translatedText": "So berechnet man bei der ersten Iteration 0 Quadrat und addiert c, also ist z1 gleich c. Für die nächste Iteration nimmt man dann diese Zahl ins Quadrat plus c, dass heißt c Quadrat plus c, und so weiter und so fort.",
+  "translatedText": "So berechnet man bei der ersten Iteration 0 Quadrat und addiert c, also ist z1 gleich c. Für die nächste Iteration quadriert man diese Zahl und addiert c, dass heißt z2 ist c Quadrat plus c, und so weiter und so fort.",
   "input": "So, for example, on the very first iteration, you take 0 squared plus c, meaning z1 is just c, and then for the next iteration, you take that number squared plus c, meaning z2 is c squared plus c, and so on and so forth.",
   "time_range": [
    16.78,
@@ -32,7 +32,7 @@
   ]
  },
  {
-  "translatedText": "Je nach Wahl dieses ersten Wertes c bleibt die Reihe manchmal beschränkt oder steigt ins Unendliche an.",
+  "translatedText": "Je nach Wahl dieses ersten Wertes c bleibt diese Folge manchmal beschränkt oder steigt ins Unendliche an.",
   "input": "Depending on the choice for that value c, sometimes the sequence stays bounded, and sometimes it blows up to infinity.",
   "time_range": [
    35.56,
@@ -40,7 +40,7 @@
   ]
  },
  {
-  "translatedText": "Würde man jedem Wert von c, bei dem diese Reihe beschränkt bleibt, schwarz einfärben und allen anderen Werten von c einen Farbverlauf zuordnen, wobei die Farbe davon abhängt, wie schnell die Reihe für diesen Wert von c ins Unendliche ansteigt, erhält man diese ikonische Form, die Mandelbrot-Menge.",
+  "translatedText": "Würde man jedem Wert von c, bei dem diese Folge beschränkt bleibt, schwarz einfärben und allen anderen Werten von c einen Farbverlauf zuordnen, wobei die Farbe davon abhängt, wie schnell die Folge für diesen Wert von c ins Unendliche ansteigt, erhält man diese ikonische Form, die Mandelbrot-Menge.",
   "input": "If you color all of the values of c that cause this process to stay bounded black, and you apply some gradient of colors to the other values, where the color depends on how quickly the process blows up to infinity, you get this iconic, cardioid-with-bubbles shape.",
   "time_range": [
    42.06,

--- a/2024/shorts/mandelbrot/german/title.json
+++ b/2024/shorts/mandelbrot/german/title.json
@@ -1,4 +1,4 @@
 {
- "translatedText": "Wie die Mandelbrot-Menge definiert ist",
+ "translatedText": "Definition der Mandelbrot-Menge",
  "input": "How the Mandelbrot set is defined"
 }


### PR DESCRIPTION
# German translations for mandelbrot short

### To-Do:

- /mandelbrot
   - [x] Update title
   - [x] Update description
   - [x] Update video translations