### PR TITLE
Update German Captions on Newton's Fractal 

### DIFF
--- a/2021/newtons-fractal/german/description.json
+++ b/2021/newtons-fractal/german/description.json
@@ -1,6 +1,6 @@
 [
  {
-  "translatedText": "Wer hätte gedacht, dass die Wurzelsuche so kompliziert sein kann?",
+  "translatedText": "Wer hätte gedacht, dass die Suche nach Nullstellen so kompliziert sein kann?",
   "input": "Who knew root-finding could be so complicated?"
  },
  {

--- a/2021/newtons-fractal/german/sentence_translations.json
+++ b/2021/newtons-fractal/german/sentence_translations.json
@@ -2,7 +2,7 @@
  {
   "input": "You've seen the title, so you know this is leading to a certain fractal.",
   "model": "nmt",
-  "translatedText": "Sie haben den Titel gesehen und wissen daher, dass dies zu einem bestimmten Fraktal führt.",
+  "translatedText": "Ihr habt den Titel gesehen und weißt daher, dass es zu einem Fraktal führen wird.",
   "time_range": [
    2.459999999999999,
    5.58
@@ -20,7 +20,7 @@
  {
   "input": "And yeah, it'll be one of those mind-bogglingly intricate shapes that has infinite detail no matter how far you zoom in.",
   "model": "nmt",
-  "translatedText": "Und ja, es wird eine dieser unglaublich komplizierten Formen sein, die unendlich viele Details aufweist, egal wie weit Sie hineinzoomen.",
+  "translatedText": "Und ja, es wird eine dieser unglaublich komplizierten Formen sein, die unendlich viele Details besitzt, egal wie weit man hineinzoomt.",
   "time_range": [
    8.72,
    14.62
@@ -47,7 +47,7 @@
  {
   "input": "And more than that, the final images that we get to will become a lot more meaningful if we make an effort to understand why, given what they represent, they kind of have to look as complicated as they do, and what this complexity reflects about an algorithm that is used all over the place in engineering.",
   "model": "nmt",
-  "translatedText": "Und darüber hinaus werden die endgültigen Bilder, die wir erhalten, viel aussagekräftiger, wenn wir uns bemühen zu verstehen, warum sie angesichts dessen, was sie darstellen, irgendwie so kompliziert aussehen müssen, wie sie sind, und was diese Komplexität widerspiegelt ein Algorithmus, der in der Technik überall eingesetzt wird.",
+  "translatedText": "Und darüber hinaus werden die endgültigen Bilder, die wir erhalten, viel aussagekräftiger, wenn wir uns bemühen zu verstehen, warum sie angesichts dessen, was sie darstellen, irgendwie so kompliziert aussehen müssen, wie sie sind, und was diese Komplexität über einen Algorithmus aussagt, der in der Technik überall eingesetzt wird.",
   "time_range": [
    26.18,
    41.62
@@ -56,7 +56,7 @@
  {
   "input": "The starting point here will be to assume that you have some kind of polynomial, and that you want to know when it equals zero.",
   "model": "nmt",
-  "translatedText": "Der Ausgangspunkt hier ist die Annahme, dass Sie eine Art Polynom haben und wissen möchten, wann es gleich Null ist.",
+  "translatedText": "Der Ausgangspunkt hier ist die Annahme, dass ihr eine Art Polynom habt und wissen möchtet, wann dessen Wert gleich Null ist.",
   "time_range": [
    48.0,
    53.9
@@ -65,7 +65,7 @@
  {
   "input": "For the one graph here, you can visually see there's three different places where it crosses the x-axis, and you can kind of eyeball what those values might be.",
   "model": "nmt",
-  "translatedText": "Bei dem einen Diagramm hier können Sie visuell erkennen, dass es drei verschiedene Stellen gibt, an denen es die x-Achse schneidet, und Sie können sich vorstellen, wie diese Werte aussehen könnten.",
+  "translatedText": "Bei diesem Graph hier könnt ihr visuell erkennen, dass es drei verschiedene Stellen gibt, an denen er die x-Achse schneidet, und ihr könnt diese Werte ungefähr herauslesen.",
   "time_range": [
    54.32,
    61.76
@@ -74,7 +74,7 @@
  {
   "input": "We'd call those the roots of the polynomial.",
   "model": "nmt",
-  "translatedText": "Wir würden das als Wurzeln des Polynoms bezeichnen.",
+  "translatedText": "Wir bezeichnen diese als Nullstellen des Polynoms.",
   "time_range": [
    61.9,
    63.7
@@ -92,7 +92,7 @@
  {
   "input": "Now this is the kind of question where if you're already bought into math, maybe it's interesting enough in its own right to move forward.",
   "model": "nmt",
-  "translatedText": "Das ist die Art von Frage, bei der Sie, wenn Sie bereits mit Mathematik vertraut sind, vielleicht an sich schon interessant genug sind, um weiterzumachen.",
+  "translatedText": "Das ist die Art von Frage, bei der man, wenn man bereits mit Mathematik vertraut ist, vielleicht an sich schon genug Interesse besteht, um weiterzumachen.",
   "time_range": [
    67.44,
    72.58
@@ -101,7 +101,7 @@
  {
   "input": "But if you just pull someone on the street aside and ask them this, I mean, they're already falling asleep, because who cares?",
   "model": "nmt",
-  "translatedText": "Aber wenn man einfach jemanden auf der Straße beiseite nimmt und ihn das fragt, dann schläft er schon ein, denn wen interessiert das schon?",
+  "translatedText": "Aber wenn man einfach jemanden auf der Straße beiseite nimmt und ihn das fragt, naja, er oder sie würde gerade schon einschlafen, denn wen interessiert das schon?",
   "time_range": [
    72.94,
    78.12
@@ -128,7 +128,7 @@
  {
   "input": "So it's not uncommon that when you're figuring out how a given pixel should be colored, that somehow involves solving an equation that uses these polynomials.",
   "model": "nmt",
-  "translatedText": "Daher ist es nicht ungewöhnlich, dass man, wenn man herausfindet, wie ein bestimmtes Pixel gefärbt werden soll, irgendwie eine Gleichung lösen muss, die diese Polynome verwendet.",
+  "translatedText": "Daher ist es nicht ungewöhnlich, dass man, wenn man herausfinden will, wie ein bestimmtes Pixel gefärbt werden soll, irgendwie eine Gleichung lösen muss, die diese Polynome verwendet.",
   "time_range": [
    90.42,
    98.38
@@ -137,7 +137,7 @@
  {
   "input": "Here let me give you one fun example.",
   "model": "nmt",
-  "translatedText": "Hier möchte ich Ihnen ein lustiges Beispiel geben.",
+  "translatedText": "Hier möchte ich euch ein interessantes Beispiel geben.",
   "time_range": [
    99.48,
    100.88
@@ -164,7 +164,7 @@
  {
   "input": "And any of you who've messed around with vector graphics, maybe in some design software, would be well familiar with these kinds of curves.",
   "model": "nmt",
-  "translatedText": "Und jeder von Ihnen, der sich mit Vektorgrafiken beschäftigt hat, vielleicht in einer Design-Software, ist mit dieser Art von Kurven bestens vertraut.",
+  "translatedText": "Und jeder von euch, der sich mit Vektorgrafik beschäftigt hat, vielleicht in einer Design-Software, ist mit solchen Kurven sehr vertraut.",
   "time_range": [
    113.4,
    119.7
@@ -173,7 +173,7 @@
  {
   "input": "But to actually display one of them on the screen, you need a way to tell each one of the pixels of your screen whether it should be colored in or not.",
   "model": "nmt",
-  "translatedText": "Um jedoch eines davon tatsächlich auf dem Bildschirm anzuzeigen, müssen Sie jedem einzelnen Pixel Ihres Bildschirms mitteilen, ob er eingefärbt werden soll oder nicht.",
+  "translatedText": "Um jedoch eine solche Kurve tatsächlich auf dem Bildschirm anzuzeigen, muss man jedem einzelnen Pixel eines Bildschirms mitteilen, ob er eingefärbt werden soll oder nicht.",
   "time_range": [
    120.42,
    127.68
@@ -200,7 +200,7 @@
  {
   "input": "I mean, take the case of stroke width.",
   "model": "nmt",
-  "translatedText": "Ich meine, nehmen Sie den Fall der Strichbreite.",
+  "translatedText": "Ich meine, man nehme sich den Fall der Strichbreite.",
   "time_range": [
    145.64,
    146.94
@@ -209,7 +209,7 @@
  {
   "input": "This comes down to understanding how far away a given pixel is from this pure mathematical curve, which itself is some platonic ideal, it has zero width.",
   "model": "nmt",
-  "translatedText": "Dabei kommt es darauf an, zu verstehen, wie weit ein bestimmtes Pixel von dieser rein mathematischen Kurve entfernt ist, die selbst ein platonisches Ideal ist und eine Breite von Null hat.",
+  "translatedText": "Hierbei kommt es darauf an, zu verstehen, wie weit ein bestimmtes Pixel von dieser rein mathematischen Kurve entfernt ist, die selbst ein platonisches Ideal ist, sie hat eine Breite von Null.",
   "time_range": [
    147.32,
    156.14
@@ -218,7 +218,7 @@
  {
   "input": "You would think of it as a parametric curve that has some parameter t.",
   "model": "nmt",
-  "translatedText": "Man könnte es sich als eine parametrische Kurve vorstellen, die einen Parameter t hat.",
+  "translatedText": "Ihr könntet es euch als eine parametrische Kurve vorstellen, die einen Parameter t hat.",
   "time_range": [
    156.7,
    159.92
@@ -227,7 +227,7 @@
  {
   "input": "Now one thing that you could do to figure out this distance is to compute the distance between your pixel and a bunch of sample points on that curve, and then figure out the smallest.",
   "model": "nmt",
-  "translatedText": "Um diesen Abstand zu ermitteln, können Sie nun den Abstand zwischen Ihrem Pixel und einer Reihe von Beispielpunkten auf dieser Kurve berechnen und dann den kleinsten ermitteln.",
+  "translatedText": "Um diesen Abstand zu ermitteln, könnte man nun den Abstand zwischen deinem Pixel und einer Reihe von Beispielpunkten auf dieser Kurve berechnen und dann den kleinsten ermitteln.",
   "time_range": [
    161.08,
    169.02
@@ -254,7 +254,7 @@
  {
   "input": "And as it happens, the square of that distance will itself be a polynomial, which makes it pretty nice to deal with.",
   "model": "nmt",
-  "translatedText": "Und zufällig wird das Quadrat dieser Entfernung selbst ein Polynom sein, was den Umgang damit recht angenehm macht.",
+  "translatedText": "Und zufällig wird das Quadrat dieser Entfernung selbst ein Polynom sein, was den Umgang damit recht einfach macht.",
   "time_range": [
    181.24,
    187.0
@@ -263,7 +263,7 @@
  {
   "input": "And if this were meant to be a full lesson on rendering vector graphics, we could expand all that out and embrace the mess, but right now the only salient point that I want to highlight is that in principle, this function, whose minimum you want to know, is some polynomial.",
   "model": "nmt",
-  "translatedText": "Und wenn dies eine vollständige Lektion zum Rendern von Vektorgrafiken sein sollte, könnten wir das alles erweitern und uns auf das Durcheinander einlassen, aber im Moment ist der einzige hervorstechende Punkt, den ich hervorheben möchte, dass im Prinzip diese Funktion, deren Minimum Sie wollen zu wissen, ist ein Polynom.",
+  "translatedText": "Und wäre das ein vollständiges Video zum Rendern von Vektorgrafiken, könnten wir das alles erweitern und uns auf das Durcheinander einlassen, aber im Moment ist der einzige Punkt, den ich hervorheben möchte, dass im Prinzip diese Funktion, dessen Tiefpunkt ihr wissen wollt, ein Polynom ist.",
   "time_range": [
    187.82,
    200.78
@@ -272,7 +272,7 @@
  {
   "input": "Finding this minimum, and hence determining how close the pixel is to the curve and whether it should get filled in, is now just a classic calculus problem.",
   "model": "nmt",
-  "translatedText": "Dieses Minimum zu finden und damit zu bestimmen, wie nah das Pixel an der Kurve liegt und ob es ausgefüllt werden sollte, ist heute nur noch ein klassisches Rechenproblem.",
+  "translatedText": "Diesen Tiefpunkt zu finden und damit zu bestimmen, wie nah das Pixel an der Kurve liegt und ob es ausgefüllt werden sollte, ist jetzt nur noch ein klassisches Problem der Differentialrechnung.",
   "time_range": [
    201.58,
    208.7
@@ -281,7 +281,7 @@
  {
   "input": "What you do is figure out the slope of this function graph, which is to say its derivative, again some polynomial, and you ask, when does that equal zero?",
   "model": "nmt",
-  "translatedText": "Was Sie tun, ist, die Steigung dieses Funktionsgraphen herauszufinden, das heißt seine Ableitung, wiederum ein Polynom, und Sie fragen sich, wann dieser gleich Null ist?",
+  "translatedText": "Was man tut, ist, die Steigung dieses Funktionsgraphen herauszufinden, also seine Ableitung, welches wieder ein Polynom ist, und man fragt sich, wann ist dieses Polynom Null?",
   "time_range": [
    209.34,
    217.7
@@ -290,7 +290,7 @@
  {
   "input": "So to actually carry out this seemingly simple task of just displaying a curve, wouldn't it be nice if you had a systematic and general way to figure out when a given polynomial equals zero?",
   "model": "nmt",
-  "translatedText": "Wäre es nicht schön, wenn Sie eine systematische und allgemeine Möglichkeit hätten, herauszufinden, wann ein bestimmtes Polynom gleich Null ist, um diese scheinbar einfache Aufgabe, nur eine Kurve anzuzeigen, tatsächlich auszuführen?",
+  "translatedText": "Wäre es also nicht schön, wenn man eine systematische und allgemeine Möglichkeit hätte, herauszufinden, wann ein bestimmtes Polynom gleich Null ist, um diese scheinbar einfache Aufgabe, nur eine Kurve anzuzeigen, tatsächlich auszuführen?",
   "time_range": [
    218.98000000000002,
    229.9
@@ -299,7 +299,7 @@
  {
   "input": "Of course we could draw 100 other examples from 100 other disciplines, I just want you to keep in mind that as we seek the roots of polynomials, even though we always display it in a way that's cleanly abstracted away from the messiness of any real-world problem, the task is hardly just an academic one.",
   "model": "nmt",
-  "translatedText": "Natürlich könnten wir 100 weitere Beispiele aus 100 anderen Disziplinen heranziehen. Ich möchte nur, dass Sie bedenken, dass wir bei der Suche nach den Wurzeln von Polynomen, auch wenn wir sie immer auf eine Weise darstellen, die sauber abstrahiert ist, weg von der Unordnung jeder realen Obwohl es sich um ein Weltproblem handelt, handelt es sich kaum um eine rein akademische Aufgabe.",
+  "translatedText": "Natürlich könnten wir 100 weitere Beispiele aus 100 anderen Disziplinen heranziehen. Ich möchte nur, dass ihr bedenkt, dass wir bei der Suche nach den Nullstellen von Polynomen, auch wenn wir sie immer auf eine Weise darstellen, die von den Problemen der echten Welt wegabstrahiert ist, es nicht nur eine rein akademische Aufgabe ist.",
   "time_range": [
    230.96,
    246.1
@@ -308,7 +308,7 @@
  {
   "input": "But again, ask yourself, how do you actually compute one of those roots?",
   "model": "nmt",
-  "translatedText": "Aber fragen Sie sich noch einmal: Wie berechnet man eigentlich eine dieser Wurzeln?",
+  "translatedText": "Aber fragt euch noch einmal: Wie berechnet man eigentlich eine dieser Nullstellen?",
   "time_range": [
    246.1,
    250.4
@@ -317,7 +317,7 @@
  {
   "input": "If whatever problem you're working on leads you to a quadratic function, then happy days, you can use the quadratic formula we all know and love.",
   "model": "nmt",
-  "translatedText": "Wenn das Problem, an dem Sie gerade arbeiten, Sie zu einer quadratischen Funktion führt, dann können Sie glückliche Tage die quadratische Formel verwenden, die wir alle kennen und lieben.",
+  "translatedText": "Wenn das Problem, an dem ihr gerade arbeitet, zu einer quadratischen Funktion führt, dann könnt ihr euch glücklich schätzen, ihr könnt die einfache a-b-c-Formel verwenden.",
   "time_range": [
    252.12,
    260.54
@@ -326,7 +326,7 @@
  {
   "input": "As a fun side note, again relevant to root finding in computer graphics, I once had a Pixar engineer give me the estimate that considering how many lights were used in some of the scenes for the movie Coco, and given the nature of some of these per-pixel calculations when polynomially defined things like spheres are involved, the quadratic formula was easily used multiple trillions of times in the production of that film.",
   "model": "nmt",
-  "translatedText": "Als lustige Randbemerkung, die wiederum für die Wurzelfindung in der Computergrafik relevant ist, ließ ich mir einmal von einem Pixar-Ingenieur die Schätzung geben, wie viele Lichter in einigen Szenen für den Film „Coco“ verwendet wurden und welche Art einige davon hatten Bei Berechnungen pro Pixel, bei denen es um polynomisch definierte Dinge wie Kugeln geht, wurde die quadratische Formel bei der Produktion dieses Films problemlos mehrere Billionen Mal verwendet.",
+  "translatedText": "Als lustige Randbemerkung, die wiederum für die Nullstellenfindung in der Computergrafik relevant ist, ich ließ mir einmal von einem Pixar-Ingenieur eine Schätzung dafür geben, wie viele Lichter in einigen Szenen für den Film „Coco“ verwendet wurden und mit der Natur einiger Kalkulationen die pro pixel geschehen, wenn Objekte, die durch Polynome definiert werden involviert sind, würde die a-b-c-Formel.",
   "time_range": [
    260.54,
    281.98
@@ -335,7 +335,7 @@
  {
   "input": "Now, when your problem leads you to a higher order polynomial, things start to get trickier.",
   "model": "nmt",
-  "translatedText": "Wenn Ihr Problem Sie nun zu einem Polynom höherer Ordnung führt, wird es schwieriger.",
+  "translatedText": "Wenn Ihr Problem Sie nun zu einem Polynom höheren Grades führt, wird es schwieriger.",
   "time_range": [
    283.42,
    287.6
@@ -344,7 +344,7 @@
  {
   "input": "For cubic polynomials, there is also a formula, which Mathologer has done a wonderful video on, and there's even a quartic formula, something that solves degree 4 polynomials, although honestly that one is such a god-awful nightmare of a formula that essentially no one actually uses it in practice.",
   "model": "nmt",
-  "translatedText": "Für kubische Polynome gibt es auch eine Formel, zu der Mathologer ein wunderbares Video gemacht hat, und es gibt sogar eine quartische Formel, etwas, das Polynome vom Grad 4 löst, obwohl diese ehrlich gesagt so ein schrecklicher Albtraum von einer Formel ist, die im Wesentlichen nein man nutzt es tatsächlich in der Praxis.",
+  "translatedText": "Für kubische Polynome gibt es auch eine Formel, zu der Mathologer ein wunderbares Video gemacht hat, und es gibt sogar eine quartische Formel, etwas, das Polynome vierten Grades löst, obwohl diese ehrlich gesagt so ein schrecklicher Albtraum von einer Formel ist, dass sie im Wesentlichen keiner in der Praxis nutzt.",
   "time_range": [
    288.12,
    302.98
@@ -353,7 +353,7 @@
  {
   "input": "But after that, and I find this one of the most fascinating results in all of math, you cannot have an analogous formula to solve polynomials that have a degree 5 or more.",
   "model": "nmt",
-  "translatedText": "Aber danach, und ich finde, dass dies eines der faszinierendsten Ergebnisse in der Mathematik ist, kann man keine analoge Formel mehr haben, um Polynome vom Grad 5 oder höher zu lösen.",
+  "translatedText": "Aber danach, und ich finde, dass dies eines der faszinierendsten Ergebnisse in der Mathematik ist, kann man keine analoge Formel mehr haben, um Polynome fünften Grades oder höher zu lösen.",
   "time_range": [
    304.06,
    313.22
@@ -362,7 +362,7 @@
  {
   "input": "More specifically, for a pretty extensive set of standard functions, you can prove that there is no possible way that you can combine those functions together that allows you to plug in the coefficients of a quintic polynomial and always get out a root.",
   "model": "nmt",
-  "translatedText": "Genauer gesagt können Sie für einen ziemlich umfangreichen Satz von Standardfunktionen beweisen, dass es keine Möglichkeit gibt, diese Funktionen miteinander zu kombinieren, die es Ihnen ermöglicht, die Koeffizienten eines quintischen Polynoms einzusetzen und immer eine Wurzel zu erhalten.",
+  "translatedText": "Genauer gesagt kann man für eine ziemlich umfangreiche Menge von Standardfunktionen beweisen, dass es keine Möglichkeit gibt, diese Funktionen miteinander zu kombinieren, sodass es ermöglicht wird, die Koeffizienten eines quintischen Polynoms einzusetzen und immer eine Nullstelle zu erhalten.",
   "time_range": [
    314.02,
    326.5
@@ -371,7 +371,7 @@
  {
   "input": "This is known as the unsolvability of the quintic, which is a whole other can of worms, we can hopefully get into it some other time, but in practice it kind of doesn't matter, because we have algorithms to approximate solutions to these kinds of equations with whatever level of precision you want.",
   "model": "nmt",
-  "translatedText": "Dies ist als Unlösbarkeit des Quintikums bekannt, das eine ganz andere Sache ist. Wir können hoffentlich ein anderes Mal darauf eingehen, aber in der Praxis spielt es keine Rolle, weil wir Algorithmen haben, um Lösungen dieser Art anzunähern von Gleichungen mit der von Ihnen gewünschten Präzision.",
+  "translatedText": "Das nennt man Unlösbarkeit von Polynomen fünften Grades, welches eine ganz andere Sache ist. Wir können hoffentlich ein anderes Mal darauf eingehen, aber in der Praxis spielt es keine Rolle, da wir Algorithmen haben, um uns Lösungen dieser Art von Gleichungen mit gewünschter Präzision anzunähern.",
   "time_range": [
    327.36,
    342.62
@@ -380,7 +380,7 @@
  {
   "input": "A common one, and the main topic for you and me today, is Newton's method.",
   "model": "nmt",
-  "translatedText": "Ein häufiges Thema und das Hauptthema für Sie und mich heute ist Newtons Methode.",
+  "translatedText": "Ein dabei häufig genutzter Algorithmus, und das Hauptthema für euch und mich heute ist das Newtonverfahren.",
   "time_range": [
    343.24,
    347.1
@@ -389,7 +389,7 @@
  {
   "input": "And yes, this is what will lead us to the fractals, but I want you to pay attention to just how innocent and benign the whole procedure seems at first.",
   "model": "nmt",
-  "translatedText": "Und ja, das ist es, was uns zu den Fraktalen führen wird, aber ich möchte, dass Sie darauf achten, wie unschuldig und harmlos das ganze Verfahren zunächst erscheint.",
+  "translatedText": "Und ja, das ist es, was uns zu den Fraktalen führen wird, aber ich möchte, dass ihr darauf achtet, wie unschuldig und harmlos das ganze Verfahren zunächst erscheint.",
   "time_range": [
    347.62,
    354.52
@@ -407,7 +407,7 @@
  {
   "input": "Almost certainly, the output of your polynomial at x0 is not 0, so you haven't found a solution, it's some other value visible as the height of this graph at that point.",
   "model": "nmt",
-  "translatedText": "Mit ziemlicher Sicherheit ist die Ausgabe Ihres Polynoms bei x0 nicht 0, Sie haben also keine Lösung gefunden, sondern ein anderer Wert, der als Höhe dieses Diagramms an diesem Punkt sichtbar ist.",
+  "translatedText": "Mit ziemlicher Sicherheit ist die Ausgabe eures Polynoms bei x0 nicht 0, ihr habt also keine Lösung gefunden, sondern einen anderen Wert, der als Höhe dieses Diagramms an diesem Punkt sichtbar ist.",
   "time_range": [
    359.66,
    367.78
@@ -425,7 +425,7 @@
  {
   "input": "In other words, if you were to draw a tangent line to the graph at this point, when does that tangent line cross the x-axis?",
   "model": "nmt",
-  "translatedText": "Mit anderen Worten: Wenn Sie an diesem Punkt eine Tangente zum Diagramm zeichnen würden, wann schneidet diese Tangente die x-Achse?",
+  "translatedText": "Mit anderen Worten: Wenn man an diesem Punkt eine Tangente zum Diagramm zeichnen würde, wann schneidet diese Tangente die x-Achse?",
   "time_range": [
    376.02,
    381.82
@@ -434,7 +434,7 @@
  {
   "input": "Now assuming this tangent line is a decent approximation of the function in the loose vicinity of some true root, the place where this approximation equals 0 should take you closer to that true root.",
   "model": "nmt",
-  "translatedText": "Nehmen wir nun an, dass diese Tangente eine gute Näherung der Funktion in der losen Umgebung einer wahren Wurzel darstellt. Die Stelle, an der diese Näherung gleich 0 ist, sollte Sie näher an diese wahre Wurzel bringen.",
+  "translatedText": "Nehmen wir nun an, dass diese Tangente eine gute Näherung der Funktion in der losen Umgebung einer wahren Nullstelle darstellt. Die Stelle, an der diese Näherung gleich 0 ist, sollte euch näher an diese wahre Nullstelle bringen.",
   "time_range": [
    383.1,
    392.86
@@ -443,7 +443,7 @@
  {
   "input": "As long as you're able to take a derivative of this function, and with polynomials you'll always be able to do that, you can concretely compute the slope of this line.",
   "model": "nmt",
-  "translatedText": "Solange Sie in der Lage sind, eine Ableitung dieser Funktion zu bilden, und das ist mit Polynomen immer möglich, können Sie die Steigung dieser Geraden konkret berechnen.",
+  "translatedText": "Solange ihr in der Lage seid, eine Ableitung dieser Funktion zu bilden, und das ist mit Polynomen immer möglich, könnt ihr die Steigung dieser Geraden konkret berechnen.",
   "time_range": [
    393.9,
    401.12
@@ -452,7 +452,7 @@
  {
   "input": "So here's where the active viewers among you might want to pause and ask, how do you figure out the difference between the current guess and the improved guess?",
   "model": "nmt",
-  "translatedText": "Hier möchten die aktiven Zuschauer unter Ihnen vielleicht innehalten und fragen: Wie finden Sie den Unterschied zwischen der aktuellen Schätzung und der verbesserten Schätzung heraus?",
+  "translatedText": "Hier möchten die aktiven Zuschauer unter euch vielleicht innehalten und fragen: Wie findet man den Unterschied zwischen der aktuellen Schätzung und der verbesserten Schätzung heraus?",
   "time_range": [
    402.1,
    408.3
@@ -470,7 +470,7 @@
  {
   "input": "One way to think of it is to consider the fact that the slope of this tangent line, its rise over run, looks like the height of this graph divided by the length of that step.",
   "model": "nmt",
-  "translatedText": "Eine Möglichkeit, sich das vorzustellen, besteht darin, die Tatsache zu berücksichtigen, dass die Steigung dieser Tangente, ihr Anstieg über der Strecke, wie die Höhe dieses Diagramms geteilt durch die Länge dieser Stufe aussieht.",
+  "translatedText": "Eine Möglichkeit, sich das vorzustellen, besteht darin, die Tatsache zu berücksichtigen, dass die Steigung dieser Tangente, ihr Anstieg über der Strecke, wie die Höhe dieses Graphen geteilt durch die Länge dieser Stufe aussieht.",
   "time_range": [
    410.90000000000003,
    419.76
@@ -488,7 +488,7 @@
  {
   "input": "If we kind of rearrange this equation here, this gives you a super concrete way that you can compute that step size.",
   "model": "nmt",
-  "translatedText": "Wenn wir diese Gleichung hier irgendwie umstellen, erhalten Sie eine sehr konkrete Möglichkeit, diese Schrittgröße zu berechnen.",
+  "translatedText": "Wenn wir diese Gleichung hier irgendwie umstellen, erhaltet ihr eine sehr konkrete Möglichkeit, diese Schrittgröße zu berechnen.",
   "time_range": [
    425.84,
    431.4
@@ -506,7 +506,7 @@
  {
   "input": "And after that, you can just repeat the process.",
   "model": "nmt",
-  "translatedText": "Und danach können Sie den Vorgang einfach wiederholen.",
+  "translatedText": "Und danach könnt ihr den Vorgang einfach wiederholen.",
   "time_range": [
    438.4,
    440.98
@@ -515,7 +515,7 @@
  {
   "input": "You compute the value of this function and the slope at this new guess, which gives you a new linear approximation, and then you make the next guess, x2, wherever that tangent line crosses the x-axis.",
   "model": "nmt",
-  "translatedText": "Sie berechnen den Wert dieser Funktion und die Steigung bei dieser neuen Schätzung, wodurch Sie eine neue lineare Näherung erhalten, und dann treffen Sie die nächste Schätzung, x2, überall dort, wo diese Tangente die x-Achse schneidet.",
+  "translatedText": "Ihr berechnet den Wert dieser Funktion und die Steigung bei dieser neuen Schätzung, wodurch ihr eine neue lineare Näherung erhaltet, und dann gebt ihr eure nächste Schätzung, x2 dort, wo diese Tangente die x-Achse schneidet.",
   "time_range": [
    441.52,
    452.08
@@ -524,7 +524,7 @@
  {
   "input": "And then apply the same calculation to x2, and this gives you x3.",
   "model": "nmt",
-  "translatedText": "Wenden Sie dann dieselbe Berechnung auf x2 an, und Sie erhalten x3.",
+  "translatedText": "Wendet dann dieselbe Berechnung auf x2 an, und ihr erhaltet x3.",
   "time_range": [
    452.78,
    455.98
@@ -533,7 +533,7 @@
  {
   "input": "And before too long, you find yourself extremely close to a true root, pretty much as close as you could ever want to be.",
   "model": "nmt",
-  "translatedText": "Und schon bald sind Sie einer wahren Wurzel so nahe, wie Sie es sich nur wünschen können.",
+  "translatedText": "Und schon bald seid ihr einer wahren Nullstelle so nahe, wie ihr es euch nur wünschen könnt.",
   "time_range": [
    456.44,
    462.18
@@ -542,7 +542,7 @@
  {
   "input": "It's always worth gut checking that a formula actually makes sense, and in this case, hopefully it does.",
   "model": "nmt",
-  "translatedText": "Es lohnt sich immer, aus dem Bauch heraus zu prüfen, ob eine Formel tatsächlich Sinn macht, und in diesem Fall ist dies hoffentlich der Fall.",
+  "translatedText": "Es lohnt sich immer, aus dem Bauch heraus zu prüfen, ob eine Formel tatsächlich Sinn macht, und in diesem Fall ist das hoffentlich der Fall.",
   "time_range": [
    464.76000000000005,
    469.5
@@ -551,7 +551,7 @@
  {
   "input": "If p of x is large, meaning the graph is really high, you need to take a bigger step to get down to a root.",
   "model": "nmt",
-  "translatedText": "Wenn p von x groß ist, also der Graph sehr hoch ist, müssen Sie einen größeren Schritt machen, um zu einer Wurzel zu gelangen.",
+  "translatedText": "Wenn p von x groß ist, also der Graph sehr hoch ist, muss man einen größeren Schritt machen, um zu einer Nullstelle zu gelangen.",
   "time_range": [
    469.84,
    475.36
@@ -560,7 +560,7 @@
  {
   "input": "But if p' of x is also large, meaning the graph is quite steep, you should maybe ease off on just how big you make that step.",
   "model": "nmt",
-  "translatedText": "Aber wenn p' von x auch groß ist, was bedeutet, dass der Graph ziemlich steil ist, sollten Sie vielleicht die Größe dieses Schritts etwas langsamer angehen.",
+  "translatedText": "Aber wenn p' von x auch groß ist, was bedeutet, dass der Graph ziemlich steil ist, sollte man vielleicht die Größe dieses Schritts etwas langsamer angehen.",
   "time_range": [
    475.98,
    483.28
@@ -569,7 +569,7 @@
  {
   "input": "Now as the name suggests, this was a method that Newton used to solve polynomial expressions.",
   "model": "nmt",
-  "translatedText": "Wie der Name schon sagt, war dies eine Methode, die Newton zur Lösung von Polynomausdrücken verwendete.",
+  "translatedText": "Wie der Name schon sagt, war dies ein Verfahren, die Newton zur Lösung von Polynomausdrücken verwendete.",
   "time_range": [
    484.52,
    488.76
@@ -578,7 +578,7 @@
  {
   "input": "But he sort of made it look a lot more complicated than it needed to be, and a fellow named Joseph Rafson published a much simpler version, more like what you and I are looking at now, so you also often hear this algorithm called the Newton-Rafson method.",
   "model": "nmt",
-  "translatedText": "Aber er hat es irgendwie viel komplizierter aussehen lassen, als es sein musste, und ein Kollege namens Joseph Rafson hat eine viel einfachere Version veröffentlicht, die eher dem ähnelt, was Sie und ich jetzt sehen, daher hört man diesen Algorithmus auch oft als Newton -Rafson-Methode.",
+  "translatedText": "Aber er hat es viel komplizierter aussehen lassen, als es sein musste, und ein gewisser Mensch namens Joseph Rafson hat eine viel einfachere Version veröffentlicht, die eher dem ähnelt, was wir jetzt sehen, daher wird dieser Algorithmus auch oft als Newton-Rafson-Verfahren bezeichnet.",
   "time_range": [
    488.76,
    501.56
@@ -587,7 +587,7 @@
  {
   "input": "These days it's a common topic in calculus classes.",
   "model": "nmt",
-  "translatedText": "Heutzutage ist es ein häufiges Thema im Mathematikunterricht.",
+  "translatedText": "Heutzutage ist es ein häufiges Thema beim behandeln von Differentialrechnung.",
   "time_range": [
    502.64,
    504.92
@@ -596,7 +596,7 @@
  {
   "input": "One nice little exercise to try to get a feel for it, by the way, is to try using this method to approximate square roots by hand.",
   "model": "nmt",
-  "translatedText": "Eine nette kleine Übung, um ein Gefühl dafür zu bekommen, besteht übrigens darin, mit dieser Methode Quadratwurzeln von Hand zu approximieren.",
+  "translatedText": "Eine nette kleine Übung, um ein Gefühl dafür zu bekommen, besteht übrigens darin, mit dieser Methode Nullstellen einer quadratischen Funktion aus dem Kopf zu approximieren.",
   "time_range": [
    505.36,
    511.52
@@ -605,7 +605,7 @@
  {
   "input": "But what most calculus students don't see, which is unfortunate, is just how deep things can get when you let yourself play around with this seemingly simple procedure and start kind of picking at some of its scabs.",
   "model": "nmt",
-  "translatedText": "Aber was die meisten Analysis-Studenten nicht sehen, was bedauerlich ist, ist, wie tiefgreifend die Dinge werden können, wenn man sich mit diesem scheinbar einfachen Verfahren herumspielen lässt und anfängt, einige seiner Krusten herauszupicken.",
+  "translatedText": "Aber was die meisten Studenten bedauerlicherweise nicht sehen, ist, wie tiefgreifend die Dinge werden können, wenn man mit diesem scheinbar einfachen Verfahren herumspielt und anfängt, gewisserweise einige seiner Krusten herauszupicken.",
   "time_range": [
    513.18,
    524.3
@@ -614,7 +614,7 @@
  {
   "input": "You see, while Newton's method works great if you start near a root, where it converges really quickly, if your initial guess is far from a root, it can have a couple foibles.",
   "model": "nmt",
-  "translatedText": "Sie sehen, während Newtons Methode großartig funktioniert, wenn Sie in der Nähe einer Wurzel beginnen, wo sie sehr schnell konvergiert, kann es jedoch ein paar Schwächen geben, wenn Ihre anfängliche Schätzung weit von einer Wurzel entfernt ist.",
+  "translatedText": "Schaut mal, während Newtons Methode großartig funktioniert, wenn ihr in der Nähe einer Nullstelle startet, wo sie sehr schnell konvergiert, kann es jedoch ein paar Schwächen geben, wenn eure anfängliche Schätzung weit von einer Nullstelle entfernt ist.",
   "time_range": [
    525.38,
    533.96
@@ -623,7 +623,7 @@
  {
   "input": "For example, let's take the function we were just looking at, but shift it upward, and play the same game with the same initial guess.",
   "model": "nmt",
-  "translatedText": "Nehmen wir zum Beispiel die Funktion, die wir gerade betrachtet haben, verschieben sie aber nach oben und spielen das gleiche Spiel mit der gleichen anfänglichen Schätzung.",
+  "translatedText": "Nehmen wir zum Beispiel die Funktion, die wir gerade gesehen haben, verschieben sie aber nach oben und spielen das gleiche Spiel mit der gleichen anfänglichen Schätzung.",
   "time_range": [
    534.92,
    541.0
@@ -632,7 +632,7 @@
  {
   "input": "Notice how the sequence of new guesses that we're getting kind of bounces around the local minimum of this function sitting above the x-axis.",
   "model": "nmt",
-  "translatedText": "Beachten Sie, wie die Folge neuer Schätzungen, die wir erhalten, um das lokale Minimum dieser Funktion herumspringt, das über der x-Achse liegt.",
+  "translatedText": "Seht ihr, wie die Folge neuer Schätzungen, die wir erhalten, um das lokale Minimum dieser Funktion, die über der x-Achse liegt, herumspringt?",
   "time_range": [
    547.4,
    554.56
@@ -641,7 +641,7 @@
  {
   "input": "This should kind of make sense, I mean a linear approximation of the function around these values all the way to the right is pretty much entirely unrelated to the nature of the function around the one true root that it has off to the left, so they're sort of giving you no useful information about that true root.",
   "model": "nmt",
-  "translatedText": "Das sollte irgendwie Sinn machen, ich meine, eine lineare Annäherung der Funktion um diese Werte ganz nach rechts hat so gut wie nichts mit der Natur der Funktion um die eine wahre Wurzel herum zu tun, die sie ganz nach links hat, also sie Sie geben Ihnen irgendwie keine nützlichen Informationen über diese wahre Wurzel.",
+  "translatedText": "Das sollte irgendwie Sinn machen, ich meine, eine lineare Annäherung der Funktion um diese Werte ganz nach rechts hat so gut wie nichts mit der Natur der Funktion um die eine wahre Nullstelle herum zu tun, die sie ganz nach links hat, also geben sie euch irgendwie keine nützlichen Informationen über diese wahre Nullstelle.",
   "time_range": [
    555.46,
    571.24
@@ -650,7 +650,7 @@
  {
   "input": "It's only when this process just happens to throw the new guess off far enough to the left, by chance, that the sequence of new guesses does anything productive and actually approaches that true root.",
   "model": "nmt",
-  "translatedText": "Erst wenn dieser Prozess die neue Vermutung zufällig weit genug nach links verschiebt, bewirkt die Folge neuer Vermutungen etwas Produktives und nähert sich tatsächlich dieser wahren Wurzel.",
+  "translatedText": "Erst wenn dieser Prozess die neue Vermutung zufällig weit genug nach links verschiebt, bewirkt die Folge neuer Vermutungen etwas Produktives und nähert sich tatsächlich dieser wahren Nullstelle.",
   "time_range": [
    571.88,
    580.9
@@ -659,7 +659,7 @@
  {
   "input": "Where things get especially interesting is if we ask about finding roots in the complex plane.",
   "model": "nmt",
-  "translatedText": "Besonders interessant wird es, wenn wir nach Wurzeln in der komplexen Ebene fragen.",
+  "translatedText": "Besonders interessant wird es, wenn wir nach Nullstellen in der komplexen Ebene fragen.",
   "time_range": [
    582.68,
    587.52
@@ -668,7 +668,7 @@
  {
   "input": "Even if a polynomial like the one shown here has only a single real number root, you'll always be able to factor this polynomial into five terms like this if you allow these roots to potentially be complex numbers.",
   "model": "nmt",
-  "translatedText": "Selbst wenn ein Polynom wie das hier gezeigte nur eine einzige Wurzel einer reellen Zahl hat, können Sie dieses Polynom immer in fünf Terme wie diesen zerlegen, wenn Sie zulassen, dass diese Wurzeln möglicherweise komplexe Zahlen sind.",
+  "translatedText": "Selbst wenn ein Polynom wie das hier gezeigte nur eine einzige reelle Nullstelle hat, können Sie dieses Polynom immer in fünf Terme wie hier zerlegen, wenn Sie zulassen, dass diese Nullstellen möglicherweise komplexe Zahlen sind.",
   "time_range": [
    588.38,
    599.62
@@ -677,7 +677,7 @@
  {
   "input": "This is the famous fundamental theorem of algebra.",
   "model": "nmt",
-  "translatedText": "Dies ist der berühmte Grundsatz der Algebra.",
+  "translatedText": "Dies ist der berühmte Fundamentalsatz der Algebra.",
   "time_range": [
    600.1,
    602.1
@@ -686,7 +686,7 @@
  {
   "input": "Now, in the happy-go-lucky land of functions with real number inputs and real number outputs, where you can picture the association between inputs and outputs as a graph, Newton's method has this really nice visual meaning with tangent lines and intersecting the x-axis.",
   "model": "nmt",
-  "translatedText": "Nun, im unbeschwerten Land der Funktionen mit reellen Zahleneingaben und reellen Zahlenausgaben, wo man sich den Zusammenhang zwischen Eingaben und Ausgaben als Diagramm vorstellen kann, hat Newtons Methode diese wirklich schöne visuelle Bedeutung mit Tangentenlinien und dem Schnittpunkt des x -Achse.",
+  "translatedText": "Nun, im unbeschwerten Land der Funktionen mit reellen Zahleneingaben und reellen Zahlenausgaben, wo man sich den Zusammenhang zwischen Eingaben und Ausgaben als Graph vorstellen kann, hat das Newtonverfahren diese wirklich schöne visuelle Bedeutung mit Tangentenlinien und dem Schnittpunkt an der x-Achse.",
   "time_range": [
    602.82,
    615.52
@@ -695,7 +695,7 @@
  {
   "input": "But if you want to allow these inputs to be any complex number, which means our corresponding outputs might also be any complex number, you can't think about tangent lines and graphs anymore.",
   "model": "nmt",
-  "translatedText": "Wenn Sie jedoch zulassen möchten, dass diese Eingaben beliebige komplexe Zahlen sind, was bedeutet, dass unsere entsprechenden Ausgaben auch beliebige komplexe Zahlen sein können, können Sie nicht mehr an Tangentenlinien und Diagramme denken.",
+  "translatedText": "Wenn man jedoch zulassen möchte, dass diese Eingaben beliebige komplexe Zahlen sind, was bedeutet, dass unsere entsprechenden Ausgaben auch beliebige komplexe Zahlen sein können, kann man nicht mehr an Tangentenlinien und Graphen denken.",
   "time_range": [
    616.1,
    625.52
@@ -704,7 +704,7 @@
  {
   "input": "But the formula doesn't really care how you visualize it.",
   "model": "nmt",
-  "translatedText": "Aber der Formel ist es egal, wie Sie es visualisieren.",
+  "translatedText": "Aber der Formel ist es egal, wie man sie visualisiert.",
   "time_range": [
    626.1999999999999,
    629.1
@@ -713,7 +713,7 @@
  {
   "input": "You can still play the same game, starting with a random guess, and evaluating the polynomial at this point, as well as its derivative, then using this update rule to generate a new guess.",
   "model": "nmt",
-  "translatedText": "Sie können immer noch das gleiche Spiel spielen, indem Sie mit einer zufälligen Schätzung beginnen und an diesem Punkt das Polynom sowie seine Ableitung auswerten und dann diese Aktualisierungsregel verwenden, um eine neue Schätzung zu generieren.",
+  "translatedText": "Man kann immer noch das gleiche Spiel spielen, indem man mit einer zufälligen Schätzung beginnt und an diesem Punkt das Polynom sowie seine Ableitung ausrechnet und dann diese Aktualisierungsregel verwendet, um eine neue Schätzung zu generieren.",
   "time_range": [
    629.1,
    640.64
@@ -722,7 +722,7 @@
  {
   "input": "And hopefully that new guess is closer to the true root.",
   "model": "nmt",
-  "translatedText": "Und hoffentlich liegt diese neue Vermutung näher an der wahren Wurzel.",
+  "translatedText": "Und hoffentlich liegt diese neue Vermutung näher an der wahren Nullstelle.",
   "time_range": [
    641.16,
    643.62
@@ -740,7 +740,7 @@
  {
   "input": "We're figuring out where a linear approximation of the function around your guess would equal zero, and then you use that zero of the linear approximation as your next guess.",
   "model": "nmt",
-  "translatedText": "Wir finden heraus, wo eine lineare Näherung der Funktion um Ihre Schätzung herum gleich Null wäre, und dann verwenden Sie diese Nullstelle der linearen Näherung als Ihre nächste Schätzung.",
+  "translatedText": "Wir finden heraus, wo eine lineare Näherung der Funktion um die Schätzung herum gleich Null wäre, und dann verwendet man diese Nullstelle der linearen Näherung als Ihre nächste Schätzung.",
   "time_range": [
    651.18,
    661.18
@@ -758,7 +758,7 @@
  {
   "input": "And indeed, with at least the one I'm showing here after a few iterations, you can see that we land on a value whose corresponding output is essentially zero.",
   "model": "nmt",
-  "translatedText": "Und tatsächlich können Sie zumindest bei dem, den ich hier zeige, nach ein paar Iterationen erkennen, dass wir bei einem Wert landen, dessen entsprechende Ausgabe im Wesentlichen Null ist.",
+  "translatedText": "Und tatsächlich kann man zumindest bei dem, den ich hier zeige, nach ein paar Iterationen erkennen, dass wir bei einem Wert landen, dessen entsprechende Ausgabe im Wesentlichen Null ist.",
   "time_range": [
    666.98,
    674.5
@@ -776,7 +776,7 @@
  {
   "input": "Let's apply this idea to many different possible initial guesses.",
   "model": "nmt",
-  "translatedText": "Wenden wir diese Idee auf viele verschiedene mögliche anfängliche Vermutungen an.",
+  "translatedText": "Wenden wir diese Idee mal auf viele verschiedene anfängliche Vermutungen an.",
   "time_range": [
    677.2,
    680.86
@@ -785,7 +785,7 @@
  {
   "input": "For reference, I'll put up the five true roots of this particular polynomial in the complex plane.",
   "model": "nmt",
-  "translatedText": "Als Referenz stelle ich die fünf wahren Wurzeln dieses speziellen Polynoms in der komplexen Ebene auf.",
+  "translatedText": "Als Hilfe stelle ich die fünf wahren Nullstellen dieses speziellen Polynoms in der komplexen Ebene auf.",
   "time_range": [
    681.78,
    686.54
@@ -794,7 +794,7 @@
  {
   "input": "With each iteration, each one of our little dots takes some step based on Newton's method.",
   "model": "nmt",
-  "translatedText": "Mit jeder Iteration macht jeder unserer kleinen Punkte einen Schritt, basierend auf Newtons Methode.",
+  "translatedText": "Mit jeder Iteration macht jeder unserer kleinen Punkte einen Schritt, basierend auf das Newtonverfahren.",
   "time_range": [
    687.5,
    692.0
@@ -803,7 +803,7 @@
  {
   "input": "Most of the dots will quickly converge to one of the five true roots, but there are some noticeable stragglers which seem to spend a while bouncing around.",
   "model": "nmt",
-  "translatedText": "Die meisten Punkte werden schnell zu einer der fünf wahren Wurzeln zusammenlaufen, aber es gibt einige bemerkenswerte Nachzügler, die eine Weile damit zu verbringen scheinen, herumzuspringen.",
+  "translatedText": "Die meisten Punkte werden schnell zu einer der fünf wahren Nullstellen zusammenlaufen, aber es gibt einige bemerkenswerte Nachzügler, die eine Weile damit zu verbringen scheinen, herumzuspringen.",
   "time_range": [
    692.74,
    700.4
@@ -812,7 +812,7 @@
  {
   "input": "In particular, notice how the ones that are trapped on the positive real number line?",
   "model": "nmt",
-  "translatedText": "Beachten Sie insbesondere, wie diejenigen, die auf der Geraden der positiven reellen Zahlen gefangen sind?",
+  "translatedText": "Achtet mal insbesondere auf diejenigen, die auf der Achse der positiven reellen Zahlen gefangen sind.",
   "time_range": [
    701.0,
    705.66
@@ -821,7 +821,7 @@
  {
   "input": "They look a little bit lost, and this is exactly what we already saw before for this same polynomial when we were looking at the real number case with its graph.",
   "model": "nmt",
-  "translatedText": "Sie sehen etwas verloren aus, und genau das haben wir bereits zuvor für dasselbe Polynom gesehen, als wir den Fall der reellen Zahlen mit seinem Graphen betrachteten.",
+  "translatedText": "Sie sehen etwas verloren aus, und genau das haben wir bereits zuvor für dasselbe Polynom gesehen, als wir den Fall der reellen Zahlen mit seinem Graphen betrachtet haben.",
   "time_range": [
    705.68,
    713.14
@@ -830,7 +830,7 @@
  {
   "input": "Now what I'm going to do is color each one of these dots based on which of those five roots it ended up closest to, and then we'll kind of roll back the clock so that every dot goes back to where it started.",
   "model": "nmt",
-  "translatedText": "Was ich nun tun werde, ist, jeden einzelnen dieser Punkte anhand dessen zu färben, bei welcher dieser fünf Wurzeln er am nächsten gelandet ist, und dann drehen wir die Uhr sozusagen zurück, sodass jeder Punkt dorthin zurückkehrt, wo er begonnen hat.",
+  "translatedText": "Was ich nun tun werde, ist, jeden einzelnen dieser Punkte anhand dessen zu färben, bei welcher dieser fünf Nullstellen er am nächsten gelandet ist, und dann drehen wir die Uhr sozusagen zurück, sodass jeder Punkt dorthin zurückkehrt, wo er begonnen hat.",
   "time_range": [
    716.44,
    727.18
@@ -839,7 +839,7 @@
  {
   "input": "Now as I've done it here, this isn't quite enough resolution to get the full story, so let me show you what it would look like if we started with an even finer grid of initial guesses and played the same game, applying Newton's method a whole bunch of times, letting each root march forward, coloring each dot based on what root it lands on, then rolling back the clock to see where it originally came from.",
   "model": "nmt",
-  "translatedText": "Nun, da ich es hier gemacht habe, reicht die Auflösung nicht ganz aus, um die ganze Geschichte zu verstehen. Lassen Sie mich Ihnen also zeigen, wie es aussehen würde, wenn wir mit einem noch feineren Raster anfänglicher Vermutungen beginnen und dasselbe Spiel spielen würden Wenden Sie Newtons Methode eine ganze Reihe von Malen an, lassen Sie jede Wurzel vorwärts wandern, färben Sie jeden Punkt entsprechend der Wurzel, auf der er landet, und drehen Sie dann die Uhr zurück, um zu sehen, woher er ursprünglich kam.",
+  "translatedText": "So wie ich es hier gemacht habe reicht jedoch die Auflösung nicht ganz aus, um die ganze Geschichte zu verstehen. Lasst mich euch also zeigen, wie es aussehen würde, wenn wir mit einem noch feineren Raster anfänglicher Vermutungen beginnen und dasselbe Spiel spielen würden, also das Newtonverfahren mehrere Male anwenden, sodass wir jede Nullstelle vorwärts wandern lassen, färben jeden Punkt entsprechend der Nullstelle, auf der er landet, und drehen dann die Uhr zurück, um zu sehen, woher sie ursprünglich kamen.",
   "time_range": [
    729.24,
    748.76
@@ -848,7 +848,7 @@
  {
   "input": "But even this isn't really a high enough resolution to appreciate the pattern.",
   "model": "nmt",
-  "translatedText": "Aber selbst diese Auflösung reicht nicht aus, um das Muster erkennen zu können.",
+  "translatedText": "Aber selbst diese Auflösung reicht nicht aus, um dem Muster alle Ehre zu machen.",
   "time_range": [
    749.4,
    752.78
@@ -857,7 +857,7 @@
  {
   "input": "If we did this process for every single pixel on the plane, here's what you would get.",
   "model": "nmt",
-  "translatedText": "Wenn wir diesen Vorgang für jedes einzelne Pixel auf der Ebene durchführen würden, erhalten Sie Folgendes.",
+  "translatedText": "Wenn wir diesen Vorgang für jedes einzelne Pixel auf der Ebene durchführen würden, erhalten wir Folgendes.",
   "time_range": [
    753.18,
    758.38
@@ -866,7 +866,7 @@
  {
   "input": "And at this level of detail the color scheme is a little jarring to my eye at least, so let me calm it down a little.",
   "model": "nmt",
-  "translatedText": "Und bei diesem Detaillierungsgrad irritiert das Farbschema zumindest ein wenig für mein Auge, also lassen Sie es mich ein wenig beruhigen.",
+  "translatedText": "Und bei diesem Detaillierungsgrad ist das Farbschema zumindest für mein Auge ein wenig irritierend, also lasst mich einen Gang zurückschalten.",
   "time_range": [
    760.16,
    765.5
@@ -875,7 +875,7 @@
  {
   "input": "Really whatever resolution I try to use to show this to you here could never possibly be enough, because the finer details of the shape we get go on with endless complexity.",
   "model": "nmt",
-  "translatedText": "Ganz gleich, welche Auflösung ich zu verwenden versuche, um Ihnen dies hier zu zeigen, sie könnte niemals ausreichen, da die feineren Details der Form, die wir erhalten, unendlich komplex sind.",
+  "translatedText": "Ganz gleich, welche Auflösung ich zu verwenden versuche, um euch das hier zu zeigen, sie könnte niemals ausreichen, da die feineren Details der Form, die wir erhalten, unendlich komplex sind.",
   "time_range": [
    766.32,
    775.9
@@ -884,7 +884,7 @@
  {
   "input": "But take a moment to think about what this is actually saying.",
   "model": "nmt",
-  "translatedText": "Aber nehmen Sie sich einen Moment Zeit, darüber nachzudenken, was das eigentlich bedeutet.",
+  "translatedText": "Aber nehmt euch einen Moment Zeit, darüber nachzudenken, was das eigentlich bedeutet.",
   "time_range": [
    781.76,
    783.7
@@ -893,7 +893,7 @@
  {
   "input": "It means that there are regions in the complex plane where if you slightly adjust that seed value, you know, you just kind of bump it to the side by 1,1 millionth or 1,1 trillionth, it can completely change which of the five true roots it ends up landing on.",
   "model": "nmt",
-  "translatedText": "Das bedeutet, dass es Bereiche in der komplexen Ebene gibt, in denen sich, wenn man den Ausgangswert leicht anpasst, einfach um 1,1 Millionstel oder 1,1 Billionstel zur Seite verschiebt, dies völlig ändern kann, welcher der fünf Werte vorliegt wahre Wurzeln, auf denen es letztendlich landet.",
+  "translatedText": "Das bedeutet, dass es Bereiche in der komplexen Ebene gibt, in denen sich, wenn man den Ausgangswert leicht anpasst, einfach um 1,1 Millionstel oder 1,1 Billionstel zur Seite verschiebt, dies völlig ändern kann, auf welcher der fünf Werte wahren Nullstellen der Punkt landet.",
   "time_range": [
    783.7,
    797.58
@@ -902,7 +902,7 @@
  {
   "input": "We saw some foreshadowing of this kind of chaos with the real graph and the problematic guess shown earlier, but picturing all of this in the complex plane really shines a light on just how unpredictable this kind of root-finding algorithm can be, and how there are whole swaths of initial values where this sort of unpredictability will take place.",
   "model": "nmt",
-  "translatedText": "Wir haben mit dem realen Diagramm und der zuvor gezeigten problematischen Vermutung eine gewisse Vorahnung dieser Art von Chaos gesehen, aber wenn man sich das alles auf der komplexen Ebene vorstellt, wird deutlich, wie unvorhersehbar diese Art von Wurzelfindungsalgorithmus sein kann und wie groß die Wahrscheinlichkeit ist, dass dies der Fall ist Es gibt ganze Schwaden von Anfangswerten, in denen diese Art von Unvorhersehbarkeit auftreten wird.",
+  "translatedText": "Wir haben mit dem reellen Beispiel und der zuvor gezeigten problematischen Vermutung eine gewisse Vorahnung dieser Art von Chaos gesehen, aber wenn man sich das alles auf der komplexen Ebene vorstellt, wird deutlich, wie unvorhersehbar diese Art von Nullstellenfindungsalgorithmus sein kann, es gibt ganze Schwaden von Anfangswerten, in denen diese Art von Unvorhersehbarkeit auftreten wird.",
   "time_range": [
    798.4,
    815.98
@@ -911,7 +911,7 @@
  {
   "input": "Now if I grab one of these roots and change it around, meaning that we're using a different polynomial for the process, you can see how the resulting fractal pattern changes.",
   "model": "nmt",
-  "translatedText": "Wenn ich nun eine dieser Wurzeln nehme und sie verändere, was bedeutet, dass wir für den Prozess ein anderes Polynom verwenden, können Sie sehen, wie sich das resultierende fraktale Muster ändert.",
+  "translatedText": "Wenn ich nun eine dieser Nullstellen nehme und sie verändere, was bedeutet, dass wir für den Prozess ein anderes Polynom verwenden, können ihr sehen, wie sich das resultierende fraktale Muster ändert.",
   "time_range": [
    817.08,
    824.74
@@ -920,7 +920,7 @@
  {
   "input": "And notice for example how the regions around a given root always have the same color, since those are the points that are close enough to the root where this linear approximation scheme works as a way of finding that root with no problem.",
   "model": "nmt",
-  "translatedText": "Und beachten Sie zum Beispiel, dass die Regionen um eine bestimmte Wurzel herum immer die gleiche Farbe haben, da dies die Punkte sind, die nahe genug an der Wurzel liegen, wo dieses lineare Näherungsverfahren als Möglichkeit dient, diese Wurzel problemlos zu finden.",
+  "translatedText": "Und beachtet zum Beispiel, dass die Regionen um eine bestimmte Nullstelle herum immer die gleiche Farbe haben, da dies die Punkte sind, die nahe genug an der Nullstelle liegen, wo dieses lineare Näherungsverfahren als Möglichkeit dient, diese Nullstelle problemlos zu finden.",
   "time_range": [
    825.54,
    837.56
@@ -938,7 +938,7 @@
  {
   "input": "Remember that.",
   "model": "nmt",
-  "translatedText": "Erinnere dich daran.",
+  "translatedText": "Behalte das im Kopf.",
   "time_range": [
    842.72,
    843.32
@@ -947,7 +947,7 @@
  {
   "input": "And it seems like no matter where I place these roots, those fractal boundaries are always there.",
   "model": "nmt",
-  "translatedText": "Und es scheint, als ob diese fraktalen Grenzen immer da sind, egal wo ich diese Wurzeln platziere.",
+  "translatedText": "Und es scheint, als ob diese fraktalen Grenzen immer da sind, egal wo ich diese Nullstellen platziere.",
   "time_range": [
    844.18,
    848.48
@@ -965,7 +965,7 @@
  {
   "input": "Another facet we can tweak here just to better illustrate what's going on is how many steps of Newton's method we're using.",
   "model": "nmt",
-  "translatedText": "Ein weiterer Aspekt, den wir hier anpassen können, um besser zu veranschaulichen, was vor sich geht, ist die Anzahl der Schritte der Newton-Methode, die wir verwenden.",
+  "translatedText": "Ein weiterer Aspekt, den wir hier anpassen können, um besser zu veranschaulichen, was vor sich geht, ist die Anzahl der Schritte des Newtonverfahren, die wir verwenden, zu visualisieren.",
   "time_range": [
    856.8,
    862.28
@@ -974,7 +974,7 @@
  {
   "input": "For example, if I had the computer just take zero steps, meaning it just colors each point of the plane based on whatever root it's already closest to, this is what we'd get.",
   "model": "nmt",
-  "translatedText": "Wenn der Computer beispielsweise nur null Schritte ausführen würde, das heißt, er würde jeden Punkt der Ebene basierend auf der Wurzel, der er bereits am nächsten liegt, einfärben, würden wir Folgendes erhalten.",
+  "translatedText": "Wenn der Computer beispielsweise nur null Schritte ausführen würde, das heißt, er würde jeden Punkt der Ebene basierend auf der Nullstelle, der er bereits am nächsten liegt, einfärben, würden wir Folgendes erhalten.",
   "time_range": [
    862.98,
    871.28
@@ -992,7 +992,7 @@
  {
   "input": "And if we let each point of the plane take a single step of Newton's method, and then color it based on what root that single step result is closest to, here's what we would get.",
   "model": "nmt",
-  "translatedText": "Und wenn wir jeden Punkt der Ebene einen einzelnen Schritt der Newtonschen Methode ausführen lassen und ihn dann basierend auf der Wurzel, der dieses Einzelschrittergebnis am nächsten kommt, einfärben, erhalten wir Folgendes.",
+  "translatedText": "Und wenn wir jeden Punkt der Ebene einen einzelnen Schritt des Newtonverfahren ausführen lassen und ihn dann basierend auf der Nullstelle, der dieses Einzelschrittergebnis am nächsten kommt, einfärben, erhalten wir Folgendes.",
   "time_range": [
    876.06,
    885.2
@@ -1001,7 +1001,7 @@
  {
   "input": "Similarly, if we allow for two steps, we get a slightly more intricate pattern, and so on and so on, where the more steps you allow, the more intricate an image you get, bringing us closer to the original fractal.",
   "model": "nmt",
-  "translatedText": "Wenn wir zwei Schritte zulassen, erhalten wir ein etwas komplizierteres Muster und so weiter. Dabei gilt: Je mehr Schritte Sie zulassen, desto komplexer wird das Bild, was uns dem ursprünglichen Fraktal näher bringt.",
+  "translatedText": "Wenn wir zwei Schritte zulassen, erhalten wir ein etwas komplizierteres Muster und so weiter. Dabei gilt: Je mehr Schritte zugelassen werden, desto komplexer wird das Bild, was uns dem ursprünglichen Fraktal näher bringt.",
   "time_range": [
    890.18,
    901.32
@@ -1010,7 +1010,7 @@
  {
   "input": "And this is important, keep in mind that the true shape we're studying here is not any one of these, it's the limit as we allow for an arbitrarily large number of iterations.",
   "model": "nmt",
-  "translatedText": "Und das ist wichtig. Denken Sie daran, dass die wahre Form, die wir hier untersuchen, keine dieser Formen ist, sondern die Grenze, da wir eine beliebig große Anzahl von Iterationen zulassen.",
+  "translatedText": "Und das ist wichtig. Denkt daran, dass die wahre Form, die wir hier untersuchen, keine dieser einzelnen Formen ist, sondern der Grenzwert, da wir eine beliebig große Anzahl von Iterationen zulassen.",
   "time_range": [
    901.86,
    910.12
@@ -1028,7 +1028,7 @@
  {
   "input": "Maybe you want to try this out with some other polynomials, see how general it is, or maybe you want to dig deeper into what dynamics are exactly possible with these iterated points, or see if there's connections with some other pieces of math that have a similar theme.",
   "model": "nmt",
-  "translatedText": "Vielleicht möchten Sie dies mit einigen anderen Polynomen ausprobieren, sehen, wie allgemein es ist, oder vielleicht möchten Sie tiefer in die genauen Dynamiken eintauchen, die mit diesen iterierten Punkten möglich sind, oder sehen, ob es Zusammenhänge mit einigen anderen mathematischen Teilen gibt, die eine haben ähnliches Thema.",
+  "translatedText": "Vielleicht möchte man das mit einigen anderen Polynomen ausprobieren, die Allgemeinheit überprüfen, oder vielleicht möchte man tiefer in die genauen Dynamiken eintauchen, die mit diesen iterierten Punkten möglich sind, oder sehen, ob es Zusammenhänge mit einigen anderen Gebieten der Mathematik gibt, die ein ähnliches Schema haben.",
   "time_range": [
    917.46,
    930.0
@@ -1037,7 +1037,7 @@
  {
   "input": "But I think the most pertinent question should be something like, what the f*** is going on here?",
   "model": "nmt",
-  "translatedText": "Aber ich denke, die relevanteste Frage sollte etwa lauten: Was zum Teufel ist hier los?",
+  "translatedText": "Aber ich denke, die relevanteste Frage sollte in etwa lauten: Was zum F*** geht hier ab?",
   "time_range": [
    930.9,
    935.88
@@ -1073,7 +1073,7 @@
  {
   "input": "And before seeing this, don't you think a reasonable initial guess might have been that each seed value simply tends towards whichever root it's closest to?",
   "model": "nmt",
-  "translatedText": "Und bevor wir das sehen, glauben Sie nicht, dass eine vernünftige anfängliche Vermutung gewesen wäre, dass jeder Startwert einfach zu der Wurzel tendiert, der er am nächsten liegt?",
+  "translatedText": "Und bevor ihr das gesehen habt, hättet ihr nicht geglaubt, dass eine vernünftige anfängliche Vermutung gewesen wäre, dass jeder Startwert einfach zu der Nullstelle tendiert, der er am nächsten liegt?",
   "time_range": [
    950.18,
    957.76
@@ -1082,7 +1082,7 @@
  {
   "input": "And in that case, you know, if you colored each point based on the root it lands on and move it back to the original position, the final image would look like one of these Voronoi diagrams, with straight line boundaries.",
   "model": "nmt",
-  "translatedText": "Und wenn Sie in diesem Fall jeden Punkt basierend auf der Wurzel, auf der er landet, einfärben und ihn wieder an die ursprüngliche Position verschieben würden, würde das endgültige Bild wie eines dieser Voronoi-Diagramme aussehen, mit geraden Liniengrenzen.",
+  "translatedText": "Und wenn man in diesem Fall jeden Punkt basierend auf der Nullstelle, auf der er landet, einfärbt und ihn wieder an die ursprüngliche Position verschieben würde, würde das endgültige Bild wie eines dieser Voronoi-Diagramme aussehen, mit geraden Liniengrenzen.",
   "time_range": [
    958.32,
    968.16
@@ -1091,7 +1091,7 @@
  {
   "input": "And since I referenced earlier the unsolvability of the quintic, maybe you would wonder if the complexity here has anything to do with that.",
   "model": "nmt",
-  "translatedText": "Und da ich vorhin auf die Unlösbarkeit des Quintikums hingewiesen habe, fragen Sie sich vielleicht, ob die Komplexität hier etwas damit zu tun hat.",
+  "translatedText": "Und da ich vorhin auf die Unlösbarkeit von quintischen Gleichungen hingewiesen habe, fragt ihr euch vielleicht, ob die Komplexität hier etwas damit zu tun hat.",
   "time_range": [
    969.2,
    975.6
@@ -1109,7 +1109,7 @@
  {
   "input": "In fact, using only degree-5 polynomials so far might have been a little misleading.",
   "model": "nmt",
-  "translatedText": "Tatsächlich könnte es ein wenig irreführend gewesen sein, bisher nur Polynome vom Grad 5 zu verwenden.",
+  "translatedText": "Tatsächlich könnte es ein wenig irreführend gewesen sein, bisher nur Polynome fünften Grades zu verwenden.",
   "time_range": [
    979.0799999999999,
    983.36
@@ -1118,7 +1118,7 @@
  {
   "input": "Watch what happens if we play the same game, but with a cubic polynomial, with three roots somewhere in the complex plane.",
   "model": "nmt",
-  "translatedText": "Beobachten Sie, was passiert, wenn wir dasselbe Spiel spielen, aber mit einem kubischen Polynom mit drei Wurzeln irgendwo in der komplexen Ebene.",
+  "translatedText": "Schaut mal, was passiert, wenn wir dasselbe Spiel spielen, aber mit einem kubischen Polynom mit drei Nullstellen irgendwo in der komplexen Ebene.",
   "time_range": [
    984.0,
    989.84
@@ -1127,7 +1127,7 @@
  {
   "input": "Notice how, again, while most points nestle into a root, some of them are kind of flying all over the place more chaotically.",
   "model": "nmt",
-  "translatedText": "Beachten Sie auch hier, dass die meisten Punkte zwar in einer Wurzel verankert sind, einige jedoch chaotischer durch die Gegend fliegen.",
+  "translatedText": "Beachtet auch hier, dass die meisten Punkte zwar in einer Nullstelle verankert sind, einige jedoch chaotisch durch die Gegend fliegen.",
   "time_range": [
    990.86,
    997.38
@@ -1136,7 +1136,7 @@
  {
   "input": "In fact, those ones are the most noticeable ones in an animation like this, with the ones going towards the roots just quietly nestled in in their ending points.",
   "model": "nmt",
-  "translatedText": "Tatsächlich sind es diese, die in einer Animation wie dieser am auffälligsten sind, wobei diejenigen, die zu den Wurzeln gehen, sich einfach ruhig in ihre Endpunkte schmiegen.",
+  "translatedText": "Tatsächlich sind es diese, die in einer Animation wie dieser am auffälligsten sind, wobei diejenigen, die zu den Nullstellen gehen, sich einfach ruhig in ihre Endpunkte schleichen.",
   "time_range": [
    998.04,
    1004.5
@@ -1145,7 +1145,7 @@
  {
   "input": "And again, if we stopped this at some number of iterations and we colored all the points based on what root they're closest to, and roll back the clock, the relevant picture for all possible starting points forms this fractal pattern with infinite detail.",
   "model": "nmt",
-  "translatedText": "Und noch einmal, wenn wir dies bei einer bestimmten Anzahl von Iterationen stoppen und alle Punkte basierend auf der Wurzel, der sie am nächsten liegen, einfärben und die Uhr zurückdrehen, ergibt das relevante Bild für alle möglichen Startpunkte dieses fraktale Muster mit unendlichen Details.",
+  "translatedText": "Und noch einmal, wenn wir dies bei einer bestimmten Anzahl von Iterationen stoppen und alle Punkte basierend auf der Nullstelle, der sie am nächsten liegen, einfärben und die Uhr zurückdrehen, ergibt das relevante Bild für alle möglichen Startpunkte dieses fraktale Muster mit unendlichen Details.",
   "time_range": [
    1005.1600000000001,
    1018.72
@@ -1163,7 +1163,7 @@
  {
   "input": "In that case, each seed value does simply tend towards whichever root it's closest to, the way you might expect.",
   "model": "nmt",
-  "translatedText": "In diesem Fall tendiert jeder Startwert einfach zu der Wurzel, der er am nächsten liegt, wie Sie es vielleicht erwarten würden.",
+  "translatedText": "In diesem Fall tendiert jeder Startwert einfach zu der Nullstelle, der er am nächsten liegt, wie man es vielleicht erwarten würde.",
   "time_range": [
    1029.82,
    1035.36
@@ -1172,7 +1172,7 @@
  {
   "input": "There is a little bit of meandering behavior from all the points that are an equal distance from each root, it's kind of like they're not able to decide which one to go to, but that's just a single line of points, and when we play the game of coloring, the diagram we end up with is decidedly more boring.",
   "model": "nmt",
-  "translatedText": "Es gibt ein leichtes mäandrierendes Verhalten aller Punkte, die den gleichen Abstand von jeder Wurzel haben. Es ist so, als könnten sie sich nicht entscheiden, zu welchem Punkt sie gehen sollen, aber das ist nur eine einzelne Linie von Punkten, und wenn wir Spielen Sie das Malspiel, das Diagramm, das wir am Ende erhalten, ist deutlich langweiliger.",
+  "translatedText": "Es gibt ein leichtes mäandrierendes Verhalten aller Punkte, die den gleichen Abstand von jeder Wurzel haben. Es ist so, als könnten sie sich nicht entscheiden, zu welchem Punkt sie gehen sollen, aber das ist nur eine einzelne Linie von Punkten, und wenn wir das Malspiel spielen, ist das Diagramm, das wir am Ende erhalten deutlich langweiliger.",
   "time_range": [
    1036.32,
    1050.66
@@ -1190,7 +1190,7 @@
  {
   "input": "If you had asked me a month ago, I probably would have shrugged and just said, you know, math is what it is, sometimes the answers look simple, sometimes not, it's not always clear what it would mean to ask why in a setting like this.",
   "model": "nmt",
-  "translatedText": "Wenn Sie mich vor einem Monat gefragt hätten, hätte ich wahrscheinlich mit den Schultern gezuckt und nur gesagt: „Mathe ist eben Mathematik, manchmal sehen die Antworten einfach aus, manchmal nicht. Es ist nicht immer klar, was es bedeuten würde, in einer bestimmten Situation nach dem Warum zu fragen. “ so was.",
+  "translatedText": "Hätte man mich vor einem Monat gefragt, hätte ich wahrscheinlich mit den Schultern gezuckt und nur gesagt: „Mathe ist eben Mathe, manchmal sehen die Antworten einfach aus, manchmal nicht. Es ist nicht immer klar, was es bedeuten würde, in bestimmten Situationen wie dieser hier nach dem Warum zu fragen.“.",
   "time_range": [
    1057.82,
    1068.35
@@ -1199,7 +1199,7 @@
  {
   "input": "But I would have been wrong, there actually is a reason we can give for why this image has to look as complicated as it does.",
   "model": "nmt",
-  "translatedText": "Aber ich hätte mich geirrt, es gibt tatsächlich einen Grund, warum dieses Bild so kompliziert aussehen muss, wie es ist.",
+  "translatedText": "Aber ich hätte mich geirrt, es gibt tatsächlich einen Grund, warum dieses Bild so kompliziert aussieht.",
   "time_range": [
    1068.35,
    1075.27
@@ -1208,7 +1208,7 @@
  {
   "input": "You see, there's a very peculiar property that we can prove this diagram must have.",
   "model": "nmt",
-  "translatedText": "Sehen Sie, wir können beweisen, dass dieses Diagramm eine ganz besondere Eigenschaft haben muss.",
+  "translatedText": "Schaut mal, wir können beweisen, dass dieses Diagramm eine ganz besondere Eigenschaft haben muss.",
   "time_range": [
    1075.93,
    1080.19
@@ -1217,7 +1217,7 @@
  {
   "input": "Focus your attention on just one of the colored regions, say this blue one, in other words, the set of all points that eventually tend towards just one particular root of the polynomial.",
   "model": "nmt",
-  "translatedText": "Konzentrieren Sie Ihre Aufmerksamkeit auf nur einen der farbigen Bereiche, sagen wir diesen blauen, mit anderen Worten, die Menge aller Punkte, die letztendlich nur zu einer bestimmten Wurzel des Polynoms tendieren.",
+  "translatedText": "Konzentrieren mal eure Aufmerksamkeit auf nur einen der farbigen Bereiche, sagen wir diesen blauen, mit anderen Worten, die Menge aller Punkte, die letztendlich nur zu einer bestimmten Wurzel des Polynoms tendieren.",
   "time_range": [
    1080.85,
    1089.97
@@ -1226,7 +1226,7 @@
  {
   "input": "Now consider the boundary of that region, which for the example shown on screen has this kind of nice three-fold symmetry.",
   "model": "nmt",
-  "translatedText": "Betrachten Sie nun die Grenze dieser Region, die für das auf dem Bildschirm gezeigte Beispiel diese schöne dreizählige Symmetrie aufweist.",
+  "translatedText": "Betrachtet nun die Grenze dieser Region, die für das auf dem Bildschirm gezeigte Beispiel diese schöne dreizählige Symmetrie aufweist.",
   "time_range": [
    1090.51,
    1096.43
@@ -1244,7 +1244,7 @@
  {
   "input": "Now when I say the word boundary, you probably have an intuitive sense of what it means, but mathematicians have a pretty clever way to formalize it, and this makes it easier to reason about in the context of more wild sets like our fractal.",
   "model": "nmt",
-  "translatedText": "Wenn ich nun das Wort „Grenze“ sage, haben Sie wahrscheinlich ein intuitives Gespür dafür, was es bedeutet, aber Mathematiker haben eine ziemlich clevere Möglichkeit, es zu formalisieren, und das macht es einfacher, im Kontext wilderer Mengen wie unserem Fraktal darüber nachzudenken.",
+  "translatedText": "Wenn ich nun das Wort „Grenze“ sage, habt ihr wahrscheinlich ein intuitives Gespür dafür, was es bedeutet, aber Mathematiker haben eine ziemlich clevere Möglichkeit, es zu formalisieren, und das macht es einfacher, im Kontext wilderer Mengen wie unserem Fraktal darüber nachzudenken.",
   "time_range": [
    1105.45,
    1115.97
@@ -1253,7 +1253,7 @@
  {
   "input": "We say that a point is on the boundary of a set if when you draw a small circle centered at that point, no matter how small, it will always contain points that are both inside that set and outside.",
   "model": "nmt",
-  "translatedText": "Wir sagen, dass ein Punkt auf der Grenze einer Menge liegt, wenn Sie beim Zeichnen eines kleinen Kreises mit Mittelpunkt an diesem Punkt, egal wie klein er ist, immer Punkte enthalten, die sowohl innerhalb als auch außerhalb dieser Menge liegen.",
+  "translatedText": "Wir sagen, dass ein Punkt auf der Grenze einer Menge liegt, wenn man beim Zeichnen eines kleinen Kreises mit Mittelpunkt an diesem Punkt, egal wie klein der Kreis sein mag, immer Punkte enthalten wird, die sowohl innerhalb als auch außerhalb dieser Menge liegen.",
   "time_range": [
    1116.4299999999998,
    1127.09
@@ -1262,7 +1262,7 @@
  {
   "input": "So if you have a point that's on the interior, a small enough circle would eventually only contain points inside the set, and for a point on the exterior, a small enough circle contains no points of the set at all.",
   "model": "nmt",
-  "translatedText": "Wenn Sie also einen Punkt im Inneren haben, würde ein ausreichend kleiner Kreis letztendlich nur Punkte innerhalb der Menge enthalten, und für einen Punkt im Äußeren enthält ein ausreichend kleiner Kreis überhaupt keine Punkte der Menge.",
+  "translatedText": "Wenn man also ein Punkt im inneren des Kreises wählt, würde ein ausreichend kleiner Kreis letztendlich nur Punkte innerhalb der Menge enthalten, und für einen Punkt im Äußeren enthält ein ausreichend kleiner Kreis überhaupt keine Punkte der Menge.",
   "time_range": [
    1127.89,
    1138.11
@@ -1271,7 +1271,7 @@
  {
   "input": "But when it's on the boundary, what it means to be on the boundary is that your tiny tiny circles will always contain both.",
   "model": "nmt",
-  "translatedText": "Aber wenn es an der Grenze ist, bedeutet es, an der Grenze zu sein, dass Ihre winzigen Kreise immer beides enthalten.",
+  "translatedText": "Aber wenn es an der Grenze ist; An der Grenze zu sein bedeutet, dass eure winzigen Kreise immer beide enthalten werden.",
   "time_range": [
    1138.61,
    1144.55
@@ -1280,7 +1280,7 @@
  {
   "input": "So looking back at our property, one way to read it is to say that if you draw a circle, no matter how small that circle, it either contains all of the colors, which happens when this shared boundary of the colors is inside that circle, or it contains just one color, and this happens when it's in the interior of one of the regions.",
   "model": "nmt",
-  "translatedText": "Wenn wir also auf unser Eigentum zurückblicken, können wir es folgendermaßen lesen: Wenn Sie einen Kreis zeichnen, egal wie klein dieser Kreis ist, enthält er entweder alle Farben, was geschieht, wenn diese gemeinsame Grenze der Farben innerhalb dieses Kreises liegt , oder es enthält nur eine Farbe, und dies geschieht, wenn es sich im Inneren einer der Regionen befindet.",
+  "translatedText": "Wenn wir also auf unsere Eigenschaft zurückblicken, können wir diese folgendermaßen lesen: Wenn man einen Kreis zeichnet, egal wie klein dieser Kreis ist, enthält er entweder alle Farben, was geschieht, wenn diese gemeinsame Grenze der Farben innerhalb dieses Kreises liegt, oder er enthält nur eine Farbe, und dies geschieht, wenn es sich im Inneren einer der Regionen befindet.",
   "time_range": [
    1145.41,
    1164.03
@@ -1289,7 +1289,7 @@
  {
   "input": "In particular, what this implies is you should never be able to find a circle that contains just two of the colors, since that would require that you have points on the boundary between two regions, but not all of them.",
   "model": "nmt",
-  "translatedText": "Dies bedeutet insbesondere, dass Sie niemals in der Lage sein sollten, einen Kreis zu finden, der nur zwei der Farben enthält, da dies voraussetzen würde, dass Sie Punkte auf der Grenze zwischen zwei Regionen haben, aber nicht zwischen allen.",
+  "translatedText": "Dies bedeutet insbesondere, dass man niemals in der Lage sein sollte, einen Kreis zu finden, der nur zwei der Farben enthält, da dies voraussetzen würde, dass Punkte auf der Grenze zwischen zwei Regionen sind, aber nicht zwischen allen.",
   "time_range": [
    1167.05,
    1177.79
@@ -1298,7 +1298,7 @@
  {
   "input": "And before explaining where this fact actually comes from, it's fun to try just wrapping your mind around it a little bit.",
   "model": "nmt",
-  "translatedText": "Und bevor wir erklären, woher diese Tatsache eigentlich kommt, macht es Spaß, sich ein wenig damit auseinanderzusetzen.",
+  "translatedText": "Und bevor wir erklären, woher diese Tatsache eigentlich kommt, ist es durchaus interessant, sich ein wenig damit auseinanderzusetzen.",
   "time_range": [
    1178.95,
    1184.59
@@ -1307,7 +1307,7 @@
  {
   "input": "You could imagine presenting this to someone as a kind of art puzzle, completely out of context, never mentioning Newton's method or anything like that, where you say that the challenge is to construct a picture with at least three colors, maybe we say red, green, and blue, so that the boundary of one color is the boundary of all of them.",
   "model": "nmt",
-  "translatedText": "Man könnte sich vorstellen, dies jemandem als eine Art Kunstpuzzle zu präsentieren, völlig aus dem Zusammenhang gerissen, ohne die Newton-Methode oder etwas in der Art zu erwähnen, wo man sagt, dass die Herausforderung darin besteht, ein Bild mit mindestens drei Farben zu konstruieren, vielleicht sagen wir Rot, Grün und Blau, so dass die Grenze einer Farbe die Grenze aller Farben ist.",
+  "translatedText": "Man könnte sich vorstellen, dies jemandem als eine Art Kunstpuzzle zu präsentieren, völlig aus dem Zusammenhang gerissen, ohne das Newtonverfahren oder etwas in der Art zu erwähnen, wo man sagt, dass die Herausforderung darin besteht, ein Bild mit mindestens drei Farben zu konstruieren, sagen wir Rot, Grün und Blau, so dass die Grenze einer Farbe die Grenze aller Farben ist.",
   "time_range": [
    1184.99,
    1200.57
@@ -1316,7 +1316,7 @@
  {
   "input": "So if you started with something simple like this, that clearly doesn't work, because we have this whole line of points that are on the boundary of green and red, but not touching any blue, and likewise you have these other lines of disallowed points.",
   "model": "nmt",
-  "translatedText": "Wenn Sie also mit etwas Einfachem wie diesem beginnen, funktioniert das eindeutig nicht, weil wir diese ganze Linie von Punkten haben, die auf der Grenze von Grün und Rot liegen, aber kein Blau berühren, und ebenso gibt es diese anderen Linien, die nicht zulässig sind Punkte.",
+  "translatedText": "Wenn man also mit etwas Einfachem wie diesem hier beginnt, funktioniert das eindeutig nicht, weil wir diese ganze Linie von Punkten haben, die auf der Grenze von Grün und Rot liegen, aber kein Blau berühren, und ebenso gibt es diese anderen Linien von Punkten, die nicht zulässig sind.",
   "time_range": [
    1200.95,
    1212.81
@@ -1325,7 +1325,7 @@
  {
   "input": "So to correct that, you might go and add some blue blobs along the boundary, and then likewise add some green blobs between the red and blue, and some red blobs between the green and blue, but of course, now the boundary of those blobs are a problem, for example, touching just blue and red, but no green.",
   "model": "nmt",
-  "translatedText": "Um das zu korrigieren, könnten Sie einige blaue Kleckse entlang der Grenze hinzufügen und dann ebenfalls einige grüne Kleckse zwischen Rot und Blau und einige rote Kleckse zwischen Grün und Blau hinzufügen, aber jetzt natürlich die Grenze dieser Kleckse ein Problem darstellen, wenn beispielsweise nur Blau und Rot, aber kein Grün berührt werden.",
+  "translatedText": "Um das zu korrigieren, könnte man einige blaue Kleckse entlang der Grenze hinzufügen und ebenfalls einige grüne Kleckse zwischen Rot und Blau und einige rote Kleckse zwischen Grün und Blau hinzufügen, aber jetzt stellt natürlich die Grenze dieser Kleckse ein Problem dar, wenn beispielsweise nur Blau und Rot, aber kein Grün berührt werden.",
   "time_range": [
    1213.63,
    1229.07
@@ -1334,7 +1334,7 @@
  {
   "input": "So maybe you go and try to add even smaller blobs, with the relevant third color around those smaller boundaries to help try to correct.",
   "model": "nmt",
-  "translatedText": "Vielleicht versuchen Sie also, noch kleinere Kleckse hinzuzufügen, mit der relevanten dritten Farbe um diese kleineren Grenzen herum, um bei der Korrektur zu helfen.",
+  "translatedText": "Vielleicht versucht man also, noch kleinere Kleckse hinzuzufügen, mit der relevanten dritten Farbe um diese kleineren Grenzen herum, um bei der Korrektur zu helfen.",
   "time_range": [
    1229.6299999999999,
    1236.37
@@ -1343,7 +1343,7 @@
  {
   "input": "And likewise you have to do this for every one of the blobs that you initially added.",
   "model": "nmt",
-  "translatedText": "Und ebenso müssen Sie dies für jeden einzelnen Blob tun, den Sie ursprünglich hinzugefügt haben.",
+  "translatedText": "Und ebenso muss man das für jeden einzelnen Klecks tun, der ursprünglich hinzugefügt wurde.",
   "time_range": [
    1237.31,
    1241.17
@@ -1352,7 +1352,7 @@
  {
   "input": "But then all the boundaries of those tiny blobs are problems of their own, and you would have to somehow keep doing this process forever.",
   "model": "nmt",
-  "translatedText": "Aber dann sind alle Grenzen dieser winzigen Kleckse eigene Probleme, und man müsste diesen Prozess irgendwie für immer fortsetzen.",
+  "translatedText": "Aber dann werden alle Grenzen dieser winzigen Kleckse eigene Probleme, und man müsste diesen Prozess irgendwie für immer fortsetzen.",
   "time_range": [
    1244.45,
    1251.63
@@ -1361,7 +1361,7 @@
  {
   "input": "And if you look at Newton's fractal itself, this sort of blobs on blobs on blobs pattern seems to be exactly what it's doing.",
   "model": "nmt",
-  "translatedText": "Und wenn man sich Newtons Fraktal selbst anschaut, scheint diese Art von Klecks-auf-Klecks-auf-Klecks-Muster genau das zu sein, was es tut.",
+  "translatedText": "Und wenn man sich das Newtonfraktal selbst anschaut, scheint diese Art von Klecks-auf-Klecks-auf-Klecks-Muster genau das zu sein, was es tut.",
   "time_range": [
    1253.57,
    1261.29
@@ -1370,7 +1370,7 @@
  {
   "input": "The main thing I want you to notice is how this property implies you could never have a boundary which is smooth, or even partially smooth on some small segment, since any smooth segment would only be touching two colors.",
   "model": "nmt",
-  "translatedText": "Ich möchte Sie vor allem darauf aufmerksam machen, dass diese Eigenschaft impliziert, dass Sie niemals eine Grenze haben können, die glatt oder auch nur teilweise glatt auf einem kleinen Segment ist, da jedes glatte Segment nur zwei Farben berühren würde.",
+  "translatedText": "Ich möchte vor allem darauf aufmerksam machen, dass diese Eigenschaft impliziert, dass man niemals eine Grenze haben könnte, die glatt oder auch nur teilweise glatt auf einem kleinen Segment ist, da jedes glatte Segment nur zwei Farben berühren würde.",
   "time_range": [
    1266.55,
    1278.09
@@ -1388,7 +1388,7 @@
  {
   "input": "So if you believe the property, it explains why the boundary remains rough no matter how far you zoom in.",
   "model": "nmt",
-  "translatedText": "Wenn Sie also an die Eigenschaft glauben, erklärt sie, warum die Grenze unabhängig von der Vergrößerung rau bleibt.",
+  "translatedText": "Wenn man der Eigenschaft also glaubt, erklärt sie, warum die Grenze unabhängig von der Vergrößerung rau bleibt.",
   "time_range": [
    1283.81,
    1289.55
@@ -1397,7 +1397,7 @@
  {
   "input": "And for those of you who are familiar with the concept of fractal dimension, you can measure the dimension of the particular boundary I'm showing you right now to be around 1.44.",
   "model": "nmt",
-  "translatedText": "Und für diejenigen unter Ihnen, die mit dem Konzept der fraktalen Dimension vertraut sind: Sie können die Dimension der bestimmten Grenze, die ich Ihnen gerade zeige, auf etwa 1 messen.44.",
+  "translatedText": "Und für diejenigen unter euch, die mit dem Konzept von fraktalen Dimensionen vertraut sind: Man kann die Dimension der bestimmten Grenze, die ich gerade zeige, auf etwa 1.44 messen.",
   "time_range": [
    1290.17,
    1298.17
@@ -1406,7 +1406,7 @@
  {
   "input": "Considering what our colors actually represent, remember this isn't just a picture for picture's sake, think about what the property is really telling us.",
   "model": "nmt",
-  "translatedText": "Denken Sie bei der Betrachtung dessen, was unsere Farben tatsächlich darstellen, daran, dass es sich nicht nur um ein Bild um des Bildes willen handelt, sondern darüber, was uns die Immobilie wirklich sagt.",
+  "translatedText": "Behalten wir im Hinterkopf, was unsere Farben tatsächlich darstellen - das hier ist nicht nur ein Bild um ein Bild zu sein - und denkt darüber nach, was uns diese Eigenschaft wirklich sagt.",
   "time_range": [
    1299.89,
    1307.03
@@ -1415,7 +1415,7 @@
  {
   "input": "It says that if you're near a sensitive point where some of the seed values go to one root but other seed values nearby would go to another root, then in fact every possible root has to be accessible from within that small neighborhood.",
   "model": "nmt",
-  "translatedText": "Es besagt, dass, wenn Sie sich in der Nähe eines sensiblen Punktes befinden, an dem einige der Startwerte zu einer Wurzel gehen, andere Startwerte in der Nähe jedoch zu einer anderen Wurzel gehen würden, dann tatsächlich jede mögliche Wurzel von dieser kleinen Nachbarschaft aus zugänglich sein muss.",
+  "translatedText": "Sie besagt, dass, wenn man sich in der Nähe eines sensiblen Punktes befindet, an dem einige der Startwerte zu einer Nullstelle gehen, andere Startwerte in der Nähe jedoch zu einer anderen Nullstelle gehen würden, dann tatsächlich jede mögliche Nullstelle von dieser kleinen Nachbarschaft aus zugänglich sein muss.",
   "time_range": [
    1308.31,
    1320.79
@@ -1424,7 +1424,7 @@
  {
   "input": "For any tiny little circle you draw, either all of the points in that circle tend to just one root, or they tend to all of the roots, but there's never going to be anything in between, just tending to a subset of the roots.",
   "model": "nmt",
-  "translatedText": "Für jeden winzigen kleinen Kreis, den Sie zeichnen, tendieren entweder alle Punkte in diesem Kreis zu nur einer Wurzel, oder sie tendieren zu allen Wurzeln, aber es wird nie etwas dazwischen geben, sondern nur zu einer Teilmenge der Wurzeln tendieren.",
+  "translatedText": "Für jeden achso kleinen Kreis, den man zeichnen kann, tendieren entweder alle Punkte in diesem Kreis zu nur einer Nullstelle, oder sie tendieren zu allen Nullstellen, aber es wird nie etwas dazwischen geben, etwas, was nur zu einer Teilmenge der Nullstellen tendiert.",
   "time_range": [
    1321.53,
    1333.17
@@ -1433,7 +1433,7 @@
  {
   "input": "For a little intuition, I found it enlightening to simply watch a cluster like the one on screen undergo this process.",
   "model": "nmt",
-  "translatedText": "Für ein wenig Intuition fand ich es aufschlussreich, einfach zu beobachten, wie ein Cluster wie der auf dem Bildschirm diesen Prozess durchläuft.",
+  "translatedText": "Für ein wenig Intivituität fand ich es aufschlussreich, einfach zu beobachten, wie ein Cluster wie der auf dem Bildschirm diesen Prozess durchläuft.",
   "time_range": [
    1334.05,
    1339.85
@@ -1442,7 +1442,7 @@
  {
   "input": "It starts off mostly sticking together, but at one iteration they all kind of explode outward, and after that it feels a lot more reasonable that any root is up for grabs.",
   "model": "nmt",
-  "translatedText": "Am Anfang hält es größtenteils zusammen, aber bei einer Iteration explodieren sie alle irgendwie nach außen, und danach fühlt es sich viel vernünftiger an, dass jede Wurzel zu gewinnen ist.",
+  "translatedText": "Am Anfang hält es größtenteils zusammen, aber ab einer Iteration explodieren sie alle in gewisser weise nach außen, und danach fühlt es sich viel vernünftiger an, dass jede Nullstelle zu erhalten ist.",
   "time_range": [
    1340.43,
    1350.33
@@ -1451,7 +1451,7 @@
  {
   "input": "And keep in mind I'm just showing you finitely many points, but in principle you would want to think about what happens to all uncountably infinitely many points inside some small disk.",
   "model": "nmt",
-  "translatedText": "Und denken Sie daran, ich zeige Ihnen nur endlich viele Punkte, aber im Prinzip möchten Sie darüber nachdenken, was mit allen unzähligen unendlich vielen Punkten innerhalb einer kleinen Scheibe passiert.",
+  "translatedText": "Und denkt daran, dass ich nur endlich viele Punkte zeige, aber im Prinzip würdet ihr darüber nachdenken wollen, was mit allen unzählig unendlich vielen Punkten innerhalb eines kleinen Kreisrings passiert.",
   "time_range": [
    1351.37,
    1360.29
@@ -1460,7 +1460,7 @@
  {
   "input": "This property also kind of explains why it's okay for things to look normal in the case of quadratic polynomials with just two roots, because there a smooth boundary is fine, there's only two colors to touch anyway.",
   "model": "nmt",
-  "translatedText": "Diese Eigenschaft erklärt auch, warum es in Ordnung ist, dass die Dinge bei quadratischen Polynomen mit nur zwei Wurzeln normal aussehen, weil dort eine glatte Grenze in Ordnung ist und es ohnehin nur zwei Farben gibt, die berührt werden können.",
+  "translatedText": "Diese Eigenschaft erklärt auch, warum es in Ordnung ist, dass die Dinge bei quadratischen Polynomen mit nur zwei Nullstellen normal aussehen, weil dort eine glatte Grenze in Ordnung ist und es ohnehin nur zwei Farben gibt, die berührt werden können.",
   "time_range": [
    1364.61,
    1376.07
@@ -1469,7 +1469,7 @@
  {
   "input": "To be clear, it doesn't guarantee that the quadratic case would have a smooth boundary, it is perfectly possible to have a fractal boundary between two colors, it just looks like our Newton's method diagram is not doing anything more complicated than it needs to under the constraint of this strange boundary condition.",
   "model": "nmt",
-  "translatedText": "Um es klarzustellen: Es garantiert nicht, dass der quadratische Fall eine glatte Grenze hat. Es ist durchaus möglich, eine fraktale Grenze zwischen zwei Farben zu haben. Es sieht nur so aus, als ob unser Newton-Methodendiagramm nichts komplizierter macht als nötig unter der Einschränkung dieser seltsamen Randbedingung.",
+  "translatedText": "Um das klar zu sagen: Dadurch wird nicht garantiert, dass der quadratische Fall eine glatte Grenze hat. Es ist durchaus möglich, eine fraktale Grenze zwischen zwei Farben zu haben. Es sieht nur so aus, als ob unser Newtonverfahren-Diagramm nichts komplizierter macht als nötig unter der Einschränkung dieser seltsamen Randbedingung.",
   "time_range": [
    1376.83,
    1392.71
@@ -1487,7 +1487,7 @@
  {
   "input": "Where does it even come from?",
   "model": "nmt",
-  "translatedText": "Woher kommt es überhaupt?",
+  "translatedText": "Woher kommt sie überhaupt?",
   "time_range": [
    1400.41,
    1401.51
@@ -1496,7 +1496,7 @@
  {
   "input": "For that I'd like to tell you about a field of math which studies this kind of question, it's called holomorphic dynamics.",
   "model": "nmt",
-  "translatedText": "Dazu möchte ich Ihnen etwas über ein Fachgebiet der Mathematik erzählen, das sich mit dieser Art von Frage beschäftigt: die sogenannte holomorphe Dynamik.",
+  "translatedText": "Dazu möchte ich euch etwas über ein Fachgebiet der Mathematik erzählen, das sich mit dieser Art von Frage beschäftigt: die sogenannte holomorphe Dynamik.",
   "time_range": [
    1402.45,
    1407.63
@@ -1514,7 +1514,7 @@
  {
   "input": "To close things off here, there is something sort of funny to me about the fact that we call this Newton's fractal, despite the fact that Newton had no clue about any of this and could never have possibly played with these images the way that you and I can with modern technology.",
   "model": "nmt",
-  "translatedText": "Zum Abschluss möchte ich sagen, dass es für mich irgendwie komisch ist, dass wir dies Newtons Fraktal nennen, obwohl Newton von all dem keine Ahnung hatte und unmöglich mit diesen Bildern so spielen konnte, wie Sie es getan haben Ich kann mit moderner Technologie.",
+  "translatedText": "Zum Abschluss möchte ich sagen, dass es für mich irgendwie komisch ist, dass wir das hier Newtons Fraktal nennen, obwohl Newton von all dem keine Ahnung hatte und unmöglich mit diesen Bildern so spielen konnte, wie wir es mit moderner Technologie tun können.",
   "time_range": [
    1415.01,
    1428.55
@@ -1523,7 +1523,7 @@
  {
   "input": "And it happens a lot through math that people's names get attached to things well beyond what they could have dreamed of.",
   "model": "nmt",
-  "translatedText": "Und durch die Mathematik kommt es häufig vor, dass die Namen von Menschen mit Dingen in Verbindung gebracht werden, die weit über das hinausgehen, wovon sie hätten träumen können.",
+  "translatedText": "Und in der Mathematik kommt es häufig vor, dass die Namen von Menschen mit Dingen in Verbindung gebracht werden, die weit darüber hinausgehen, wovon sie hätten träumen können.",
   "time_range": [
    1429.05,
    1434.37
@@ -1541,7 +1541,7 @@
  {
   "input": "Fourier himself never once computed a fast Fourier transform, the list goes on.",
   "model": "nmt",
-  "translatedText": "Fourier selbst habe noch nie eine schnelle Fourier-Transformation berechnet, die Liste geht weiter.",
+  "translatedText": "Fourier selbst hat nie eine schnelle Fourier-Transformation berechnet, die Liste geht weiter.",
   "time_range": [
    1440.01,
    1444.69
@@ -1550,7 +1550,7 @@
  {
   "input": "But this overextension of nomenclature carries with it what I think is an inspiring point.",
   "model": "nmt",
-  "translatedText": "Aber diese Überdehnung der Nomenklatur bringt meiner Meinung nach einen inspirierenden Punkt mit sich.",
+  "translatedText": "Aber diese übermäßige Ausweitung bei der Nomenklatur bringt meiner Meinung nach einen inspirierenden Punkt mit sich.",
   "time_range": [
    1444.69,
    1449.95
@@ -1568,7 +1568,7 @@
  {
   "input": "It's not just that Newton had no idea about Newton's fractal.",
   "model": "nmt",
-  "translatedText": "Es ist nicht nur so, dass Newton keine Ahnung von Newtons Fraktal hatte.",
+  "translatedText": "Es ist nicht nur so, dass Newton keine Ahnung von dem Newtonfraktal hatte.",
   "time_range": [
    1461.91,
    1465.15
@@ -1577,7 +1577,7 @@
  {
   "input": "There are probably many other facts about Newton's method, or about all sorts of math that may seem like old news, that come from questions that no one has thought to ask yet, questions that are just sitting there, waiting for someone, like you, to ask them.",
   "model": "nmt",
-  "translatedText": "Es gibt wahrscheinlich viele andere Fakten über Newtons Methode oder über alle Arten von Mathematik, die wie alte Nachrichten erscheinen mögen und auf Fragen beruhen, an die noch niemand gedacht hat, Fragen, die einfach nur da liegen und auf jemanden wie Sie warten. sie zu fragen.",
+  "translatedText": "Es gibt wahrscheinlich viele andere Fakten über das Newtonverfahren oder über alle Arten von Mathematik, die wie alte Nachrichten erscheinen mögen und auf Fragen beruhen, an die noch niemand gedacht hat, Fragen, die einfach nur da liegen und auf jemanden wie dich warten, der sie fragen wird.",
   "time_range": [
    1465.33,
    1478.47
@@ -1586,7 +1586,7 @@
  {
   "input": "For example, if you were to ask about whether this process we've been talking about today ever gets trapped in a cycle, it leads you to a surprising connection with the Mandelbrot set, and we'll talk a bit about that in the next part.",
   "model": "nmt",
-  "translatedText": "Wenn Sie beispielsweise fragen würden, ob dieser Prozess, über den wir heute gesprochen haben, jemals in einem Zyklus gefangen ist, führt Sie das zu einem überraschenden Zusammenhang mit der Mandelbrot-Menge, und darüber werden wir im nächsten Abschnitt etwas sprechen Teil.",
+  "translatedText": "Wenn man beispielsweise fragen würde, ob dieser Prozess, über den wir heute gesprochen haben, jemals in einem Zyklus gefangen wird, führt das zu einem überraschenden Zusammenhang mit der Mandelbrot-Menge, und darüber werden wir im nächsten Teil etwas sprechen.",
   "time_range": [
    1482.87,
    1493.77
@@ -1595,7 +1595,7 @@
  {
   "input": "At the time that I'm posting this, that second part, by the way, is available as an early release to patrons.",
   "model": "nmt",
-  "translatedText": "Zu dem Zeitpunkt, an dem ich dies veröffentliche, ist dieser zweite Teil übrigens als Vorabveröffentlichung für Kunden verfügbar.",
+  "translatedText": "Zu dem Zeitpunkt, an dem ich das veröffentliche, ist der zweite Teil übrigens als Prerelease für Patreons verfügbar.",
   "time_range": [
    1495.03,
    1499.19
@@ -1604,7 +1604,7 @@
  {
   "input": "I always like to give new content a little bit of time there to gather feedback and catch errors.",
   "model": "nmt",
-  "translatedText": "Ich gebe neuen Inhalten dort immer gerne etwas Zeit, um Feedback zu sammeln und Fehler zu erkennen.",
+  "translatedText": "Ich gebe neuem Content dort immer gerne etwas Zeit, um Feedback zu sammeln und Fehler zu erkennen.",
   "time_range": [
    1499.59,
    1503.47
@@ -1622,7 +1622,7 @@
  {
   "input": "And on the topic of patrons, I do just want to say a quick thanks to everyone whose name is on the screen.",
   "model": "nmt",
-  "translatedText": "Und was die Gönner betrifft, möchte ich mich kurz bei allen bedanken, deren Namen auf dem Bildschirm stehen.",
+  "translatedText": "Und wenn wir schon bei Patreons sind, möchte ich mich kurz bei allen bedanken, deren Namen auf dem Bildschirm stehen.",
   "time_range": [
    1506.47,
    1510.33
@@ -1631,7 +1631,7 @@
  {
   "input": "I know that in recent history new videos have been a little slow coming.",
   "model": "nmt",
-  "translatedText": "Ich weiß, dass neue Videos in der jüngeren Geschichte etwas langsam auf den Markt kamen.",
+  "translatedText": "Ich weiß, dass neue Videos in der etwas langsamer erscheinen als zuvor.",
   "time_range": [
    1510.75,
    1513.97
@@ -1658,7 +1658,7 @@
  {
   "input": "I will be talking all about that and announcing winners very shortly, so stay tuned.",
   "model": "nmt",
-  "translatedText": "Ich werde in Kürze darüber sprechen und die Gewinner bekannt geben, also bleiben Sie dran.",
+  "translatedText": "Ich werde bald darüber sprechen und die Gewinner bekannt geben, bleibt also gespannt.",
   "time_range": [
    1525.11,
    1529.03
@@ -1667,7 +1667,7 @@
  {
   "input": "I just want you to know that the plan for the foreseeable future is definitely to shift gears more wholeheartedly back to making new videos, and more than anything I want to say Thanks for your continued support, even during times of trying a few new things.",
   "model": "nmt",
-  "translatedText": "Ich möchte nur, dass Sie wissen, dass der Plan für die absehbare Zukunft auf jeden Fall darin besteht, den Gang wieder voll und ganz auf die Erstellung neuer Videos umzustellen, und vor allem möchte ich mich für Ihre anhaltende Unterstützung bedanken, auch in Zeiten, in denen Sie ein paar neue Dinge ausprobieren.",
+  "translatedText": "Ich möchte nur, dass ihr wisst, dass der Plan für die absehbare Zukunft auf jeden Fall darin besteht, den Gang wieder voll und ganz auf die Erstellung neuer Videos umzustellen, und vor allem möchte ich mich für eure anhaltende Unterstützung bedanken, auch in Zeiten, in denen ich ein paar neue Dinge ausprobiere.",
   "time_range": [
    1529.45,
    1540.65
@@ -1676,7 +1676,7 @@
  {
   "input": "It means a lot to me, it's what keeps the channel going, and I'll do my best to make the new lessons in the pipeline live up to your vote of confidence there.",
   "model": "nmt",
-  "translatedText": "Es bedeutet mir sehr viel, es ist das, was den Kanal am Laufen hält, und ich werde mein Bestes tun, damit die neuen Lektionen in der Pipeline Ihrem Vertrauensbeweis gerecht werden.",
+  "translatedText": "Es bedeutet mir sehr viel, es ist das, was den Kanal am Laufen hält, und ich werde mein Bestes dafür tun, damit die neuen Videos in der Pipeline euren Erwartungen gerecht werden.",
   "time_range": [
    1540.91,
    1547.31

--- a/2021/newtons-fractal/german/sentence_translations.json
+++ b/2021/newtons-fractal/german/sentence_translations.json
@@ -353,7 +353,7 @@
  {
   "input": "But after that, and I find this one of the most fascinating results in all of math, you cannot have an analogous formula to solve polynomials that have a degree 5 or more.",
   "model": "nmt",
-  "translatedText": "Aber danach, und ich finde, dass dies eines der faszinierendsten Ergebnisse in der Mathematik ist, kann man keine analoge Formel mehr haben, um Polynome fünften Grades oder höher zu lösen.",
+  "translatedText": "Aber danach, und ich finde, dass das eines der faszinierendsten Ergebnisse in der Mathematik ist, kann man keine analoge Formel mehr haben, um Polynome fünften Grades oder höher zu lösen.",
   "time_range": [
    304.06,
    313.22
@@ -569,7 +569,7 @@
  {
   "input": "Now as the name suggests, this was a method that Newton used to solve polynomial expressions.",
   "model": "nmt",
-  "translatedText": "Wie der Name schon sagt, war dies ein Verfahren, die Newton zur Lösung von Polynomausdrücken verwendete.",
+  "translatedText": "Wie der Name schon sagt, war das ein Verfahren, die Newton zur Lösung von Polynomausdrücken verwendete.",
   "time_range": [
    484.52,
    488.76
@@ -614,7 +614,7 @@
  {
   "input": "You see, while Newton's method works great if you start near a root, where it converges really quickly, if your initial guess is far from a root, it can have a couple foibles.",
   "model": "nmt",
-  "translatedText": "Schaut mal, während Newtons Methode großartig funktioniert, wenn ihr in der Nähe einer Nullstelle startet, wo sie sehr schnell konvergiert, kann es jedoch ein paar Schwächen geben, wenn eure anfängliche Schätzung weit von einer Nullstelle entfernt ist.",
+  "translatedText": "Schaut mal, während das Newtonverfahren großartig funktioniert, wenn ihr in der Nähe einer Nullstelle startet, wo sie sehr schnell konvergiert, kann es jedoch ein paar Schwächen geben, wenn eure anfängliche Schätzung weit von einer Nullstelle entfernt ist.",
   "time_range": [
    525.38,
    533.96
@@ -677,7 +677,7 @@
  {
   "input": "This is the famous fundamental theorem of algebra.",
   "model": "nmt",
-  "translatedText": "Dies ist der berühmte Fundamentalsatz der Algebra.",
+  "translatedText": "Das ist der berühmte Fundamentalsatz der Algebra.",
   "time_range": [
    600.1,
    602.1
@@ -893,7 +893,7 @@
  {
   "input": "It means that there are regions in the complex plane where if you slightly adjust that seed value, you know, you just kind of bump it to the side by 1,1 millionth or 1,1 trillionth, it can completely change which of the five true roots it ends up landing on.",
   "model": "nmt",
-  "translatedText": "Das bedeutet, dass es Bereiche in der komplexen Ebene gibt, in denen sich, wenn man den Ausgangswert leicht anpasst, einfach um 1,1 Millionstel oder 1,1 Billionstel zur Seite verschiebt, dies völlig ändern kann, auf welcher der fünf Werte wahren Nullstellen der Punkt landet.",
+  "translatedText": "Das bedeutet, dass es Bereiche in der komplexen Ebene gibt, in denen sich, wenn man den Ausgangswert leicht anpasst, einfach um 1,1 Millionstel oder 1,1 Billionstel zur Seite verschiebt, es sich dadurch völlig ändern kann, auf welcher der fünf wahren Nullstellen der Punkt landet.",
   "time_range": [
    783.7,
    797.58
@@ -920,7 +920,7 @@
  {
   "input": "And notice for example how the regions around a given root always have the same color, since those are the points that are close enough to the root where this linear approximation scheme works as a way of finding that root with no problem.",
   "model": "nmt",
-  "translatedText": "Und beachtet zum Beispiel, dass die Regionen um eine bestimmte Nullstelle herum immer die gleiche Farbe haben, da dies die Punkte sind, die nahe genug an der Nullstelle liegen, wo dieses lineare Näherungsverfahren als Möglichkeit dient, diese Nullstelle problemlos zu finden.",
+  "translatedText": "Und beachtet zum Beispiel, dass die Regionen um eine bestimmte Nullstelle herum immer die gleiche Farbe haben, da das die Punkte sind, die nahe genug an der Nullstelle liegen, wo dieses lineare Näherungsverfahren als Möglichkeit dient, diese Nullstelle problemlos zu finden.",
   "time_range": [
    825.54,
    837.56
@@ -1145,7 +1145,7 @@
  {
   "input": "And again, if we stopped this at some number of iterations and we colored all the points based on what root they're closest to, and roll back the clock, the relevant picture for all possible starting points forms this fractal pattern with infinite detail.",
   "model": "nmt",
-  "translatedText": "Und noch einmal, wenn wir dies bei einer bestimmten Anzahl von Iterationen stoppen und alle Punkte basierend auf der Nullstelle, der sie am nächsten liegen, einfärben und die Uhr zurückdrehen, ergibt das relevante Bild für alle möglichen Startpunkte dieses fraktale Muster mit unendlichen Details.",
+  "translatedText": "Und noch einmal, wenn wir das bei einer bestimmten Anzahl von Iterationen stoppen und alle Punkte basierend auf der Nullstelle, der sie am nächsten liegen, einfärben und die Uhr zurückdrehen, ergibt das relevante Bild für alle möglichen Startpunkte dieses fraktale Muster mit unendlichen Details.",
   "time_range": [
    1005.1600000000001,
    1018.72
@@ -1280,7 +1280,7 @@
  {
   "input": "So looking back at our property, one way to read it is to say that if you draw a circle, no matter how small that circle, it either contains all of the colors, which happens when this shared boundary of the colors is inside that circle, or it contains just one color, and this happens when it's in the interior of one of the regions.",
   "model": "nmt",
-  "translatedText": "Wenn wir also auf unsere Eigenschaft zurückblicken, können wir diese folgendermaßen lesen: Wenn man einen Kreis zeichnet, egal wie klein dieser Kreis ist, enthält er entweder alle Farben, was geschieht, wenn diese gemeinsame Grenze der Farben innerhalb dieses Kreises liegt, oder er enthält nur eine Farbe, und dies geschieht, wenn es sich im Inneren einer der Regionen befindet.",
+  "translatedText": "Wenn wir also auf unsere Eigenschaft zurückblicken, können wir diese folgendermaßen lesen: Wenn man einen Kreis zeichnet, egal wie klein dieser Kreis ist, enthält er entweder alle Farben, was geschieht, wenn diese gemeinsame Grenze der Farben innerhalb dieses Kreises liegt, oder er enthält nur eine Farbe, und das geschieht, wenn es sich im Inneren einer der Regionen befindet.",
   "time_range": [
    1145.41,
    1164.03
@@ -1289,7 +1289,7 @@
  {
   "input": "In particular, what this implies is you should never be able to find a circle that contains just two of the colors, since that would require that you have points on the boundary between two regions, but not all of them.",
   "model": "nmt",
-  "translatedText": "Dies bedeutet insbesondere, dass man niemals in der Lage sein sollte, einen Kreis zu finden, der nur zwei der Farben enthält, da dies voraussetzen würde, dass Punkte auf der Grenze zwischen zwei Regionen sind, aber nicht zwischen allen.",
+  "translatedText": "Das bedeutet insbesondere, dass man niemals in der Lage sein sollte, einen Kreis zu finden, der nur zwei der Farben enthält, da das voraussetzen würde, dass Punkte auf der Grenze zwischen zwei Regionen sind, aber nicht zwischen allen.",
   "time_range": [
    1167.05,
    1177.79
@@ -1307,7 +1307,7 @@
  {
   "input": "You could imagine presenting this to someone as a kind of art puzzle, completely out of context, never mentioning Newton's method or anything like that, where you say that the challenge is to construct a picture with at least three colors, maybe we say red, green, and blue, so that the boundary of one color is the boundary of all of them.",
   "model": "nmt",
-  "translatedText": "Man könnte sich vorstellen, dies jemandem als eine Art Kunstpuzzle zu präsentieren, völlig aus dem Zusammenhang gerissen, ohne das Newtonverfahren oder etwas in der Art zu erwähnen, wo man sagt, dass die Herausforderung darin besteht, ein Bild mit mindestens drei Farben zu konstruieren, sagen wir Rot, Grün und Blau, so dass die Grenze einer Farbe die Grenze aller Farben ist.",
+  "translatedText": "Man könnte sich vorstellen, das jemandem als eine Art Kunstpuzzle zu präsentieren, völlig aus dem Zusammenhang gerissen, ohne das Newtonverfahren oder etwas in der Art zu erwähnen, wo man sagt, dass die Herausforderung darin besteht, ein Bild mit mindestens drei Farben zu konstruieren, sagen wir Rot, Grün und Blau, so dass die Grenze einer Farbe die Grenze aller Farben ist.",
   "time_range": [
    1184.99,
    1200.57
@@ -1514,7 +1514,7 @@
  {
   "input": "To close things off here, there is something sort of funny to me about the fact that we call this Newton's fractal, despite the fact that Newton had no clue about any of this and could never have possibly played with these images the way that you and I can with modern technology.",
   "model": "nmt",
-  "translatedText": "Zum Abschluss möchte ich sagen, dass es für mich irgendwie komisch ist, dass wir das hier Newtons Fraktal nennen, obwohl Newton von all dem keine Ahnung hatte und unmöglich mit diesen Bildern so spielen konnte, wie wir es mit moderner Technologie tun können.",
+  "translatedText": "Zum Abschluss möchte ich sagen, dass es für mich irgendwie komisch ist, dass wir das hier Newtonfraktal nennen, obwohl Newton von all dem keine Ahnung hatte und unmöglich mit diesen Bildern so spielen konnte, wie wir es mit moderner Technologie tun können.",
   "time_range": [
    1415.01,
    1428.55

--- a/2021/newtons-fractal/german/sentence_translations.json
+++ b/2021/newtons-fractal/german/sentence_translations.json
@@ -2,7 +2,7 @@
  {
   "input": "You've seen the title, so you know this is leading to a certain fractal.",
   "model": "nmt",
-  "translatedText": "Ihr habt den Titel gesehen und weißt daher, dass es zu einem Fraktal kommen wird.",
+  "translatedText": "Du hast den Titel gesehen und weißt daher, dass es zu einem Fraktal kommen wird.",
   "time_range": [
    2.459999999999999,
    5.58
@@ -56,7 +56,7 @@
  {
   "input": "The starting point here will be to assume that you have some kind of polynomial, and that you want to know when it equals zero.",
   "model": "nmt",
-  "translatedText": "Der Ausgangspunkt hier ist die Annahme, dass ihr eine Art Polynom habt und wissen möchtet, wann dessen Wert gleich Null ist.",
+  "translatedText": "Der Ausgangspunkt hier ist die Annahme, dass du eine Art Polynom hast und wissen möchtet, wann dessen Wert gleich Null ist.",
   "time_range": [
    48.0,
    53.9
@@ -65,7 +65,7 @@
  {
   "input": "For the one graph here, you can visually see there's three different places where it crosses the x-axis, and you can kind of eyeball what those values might be.",
   "model": "nmt",
-  "translatedText": "Bei diesem Graph hier könnt ihr visuell erkennen, dass es drei verschiedene Stellen gibt, an denen er die x-Achse schneidet, und ihr könnt diese Werte ungefähr herauslesen.",
+  "translatedText": "Bei diesem Graph hier kannst du visuell erkennen, dass es drei verschiedene Stellen gibt, an denen er die x-Achse schneidet, und du kannst diese Werte ungefähr herauslesen.",
   "time_range": [
    54.32,
    61.76
@@ -164,7 +164,7 @@
  {
   "input": "And any of you who've messed around with vector graphics, maybe in some design software, would be well familiar with these kinds of curves.",
   "model": "nmt",
-  "translatedText": "Und jeder von euch, der sich mit Vektorgrafik beschäftigt hat, vielleicht in einer Design-Software, ist mit solchen Kurven sehr vertraut.",
+  "translatedText": "Und falls du dich mit Vektorgrafik beschäftigt hast, vielleicht in einer Design-Software, bist du mit solchen Kurven sehr vertraut.",
   "time_range": [
    113.4,
    119.7
@@ -218,7 +218,7 @@
  {
   "input": "You would think of it as a parametric curve that has some parameter t.",
   "model": "nmt",
-  "translatedText": "Ihr könntet es euch als eine parametrische Kurve vorstellen, die einen Parameter t hat.",
+  "translatedText": "Du könntest es dir als eine parametrische Kurve vorstellen, die einen Parameter t hat.",
   "time_range": [
    156.7,
    159.92
@@ -227,7 +227,7 @@
  {
   "input": "Now one thing that you could do to figure out this distance is to compute the distance between your pixel and a bunch of sample points on that curve, and then figure out the smallest.",
   "model": "nmt",
-  "translatedText": "Um diesen Abstand zu ermitteln, könnte man nun den Abstand zwischen eurem Pixel und einer Reihe von Beispielpunkten auf dieser Kurve berechnen und dann den kleinsten ermitteln.",
+  "translatedText": "Um diesen Abstand zu ermitteln, könnte man nun den Abstand zwischen deinem Pixel und einer Reihe von Beispielpunkten auf dieser Kurve berechnen und dann den kleinsten ermitteln.",
   "time_range": [
    161.08,
    169.02
@@ -263,7 +263,7 @@
  {
   "input": "And if this were meant to be a full lesson on rendering vector graphics, we could expand all that out and embrace the mess, but right now the only salient point that I want to highlight is that in principle, this function, whose minimum you want to know, is some polynomial.",
   "model": "nmt",
-  "translatedText": "Und wäre das ein vollständiges Video zum Rendern von Vektorgrafiken, könnten wir das alles erweitern und uns auf das Durcheinander einlassen, aber im Moment ist der einzige Punkt, den ich hervorheben möchte, dass im Prinzip diese Funktion, dessen Tiefpunkt ihr wissen wollt, ein Polynom ist.",
+  "translatedText": "Und wäre das ein vollständiges Video zum Rendern von Vektorgrafiken, könnten wir das alles erweitern und uns auf das Durcheinander einlassen, aber im Moment ist der einzige Punkt, den ich hervorheben möchte, dass im Prinzip diese Funktion, dessen Tiefpunkt du wissen willst, ein Polynom ist.",
   "time_range": [
    187.82,
    200.78
@@ -299,7 +299,7 @@
  {
   "input": "Of course we could draw 100 other examples from 100 other disciplines, I just want you to keep in mind that as we seek the roots of polynomials, even though we always display it in a way that's cleanly abstracted away from the messiness of any real-world problem, the task is hardly just an academic one.",
   "model": "nmt",
-  "translatedText": "Natürlich könnten wir 100 weitere Beispiele aus 100 anderen Disziplinen heranziehen. Ich möchte nur, dass ihr bedenkt, dass wir bei der Suche nach den Nullstellen von Polynomen, auch wenn wir sie immer auf eine Weise darstellen, die von den Problemen der echten Welt wegabstrahiert ist, es nicht nur eine rein akademische Aufgabe ist.",
+  "translatedText": "Natürlich könnten wir 100 weitere Beispiele aus 100 anderen Disziplinen heranziehen. Ich möchte nur, dass du bedenkst, dass wir bei der Suche nach den Nullstellen von Polynomen, auch wenn wir sie immer auf eine Weise darstellen, die von den Problemen der echten Welt wegabstrahiert ist, es nicht nur eine rein akademische Aufgabe ist.",
   "time_range": [
    230.96,
    246.1
@@ -308,7 +308,7 @@
  {
   "input": "But again, ask yourself, how do you actually compute one of those roots?",
   "model": "nmt",
-  "translatedText": "Aber fragt euch noch einmal: Wie berechnet man eigentlich eine dieser Nullstellen?",
+  "translatedText": "Aber frag dich noch einmal: Wie berechnet man eigentlich eine dieser Nullstellen?",
   "time_range": [
    246.1,
    250.4
@@ -317,7 +317,7 @@
  {
   "input": "If whatever problem you're working on leads you to a quadratic function, then happy days, you can use the quadratic formula we all know and love.",
   "model": "nmt",
-  "translatedText": "Wenn das Problem, an dem ihr gerade arbeitet, zu einer quadratischen Funktion führt, dann könnt ihr euch glücklich schätzen, ihr könnt die einfache a-b-c-Formel verwenden.",
+  "translatedText": "Wenn das Problem, an dem du gerade arbeitest, zu einer quadratischen Funktion führt, dann kannst du dich glücklich schätzen, du kannst die einfache a-b-c-Formel verwenden.",
   "time_range": [
    252.12,
    260.54
@@ -380,7 +380,7 @@
  {
   "input": "A common one, and the main topic for you and me today, is Newton's method.",
   "model": "nmt",
-  "translatedText": "Ein dabei häufig genutzter Algorithmus, und das Hauptthema für euch und mich heute, ist das Newtonverfahren.",
+  "translatedText": "Ein dabei häufig genutzter Algorithmus, und das Hauptthema für dich und mich heute, ist das Newtonverfahren.",
   "time_range": [
    343.24,
    347.1
@@ -389,7 +389,7 @@
  {
   "input": "And yes, this is what will lead us to the fractals, but I want you to pay attention to just how innocent and benign the whole procedure seems at first.",
   "model": "nmt",
-  "translatedText": "Und ja, das ist es, was uns zu den Fraktalen führen wird, aber ich möchte, dass ihr darauf achtet, wie unschuldig und harmlos das ganze Verfahren zunächst erscheint.",
+  "translatedText": "Und ja, das ist es, was uns zu den Fraktalen führen wird, aber ich möchte, dass du darauf achtest, wie unschuldig und harmlos das ganze Verfahren zunächst erscheint.",
   "time_range": [
    347.62,
    354.52
@@ -407,7 +407,7 @@
  {
   "input": "Almost certainly, the output of your polynomial at x0 is not 0, so you haven't found a solution, it's some other value visible as the height of this graph at that point.",
   "model": "nmt",
-  "translatedText": "Mit ziemlicher Sicherheit ist die Ausgabe eures Polynoms bei x0 nicht 0, ihr habt also keine Lösung gefunden, sondern einen anderen Wert, der als Höhe dieses Graphen an diesem Punkt sichtbar ist.",
+  "translatedText": "Mit ziemlicher Sicherheit ist die Ausgabe deines Polynoms bei x0 nicht 0, du hast also keine Lösung gefunden, sondern einen anderen Wert, der als Höhe dieses Graphen an diesem Punkt sichtbar ist.",
   "time_range": [
    359.66,
    367.78
@@ -434,7 +434,7 @@
  {
   "input": "Now assuming this tangent line is a decent approximation of the function in the loose vicinity of some true root, the place where this approximation equals 0 should take you closer to that true root.",
   "model": "nmt",
-  "translatedText": "Nehmen wir nun an, dass diese Tangente eine gute Näherung der Funktion in der losen Umgebung einer wahren Nullstelle darstellt. Die Stelle, an der diese Näherung gleich 0 ist, sollte euch näher an diese wahre Nullstelle bringen.",
+  "translatedText": "Nehmen wir nun an, dass diese Tangente eine gute Näherung der Funktion in der losen Umgebung einer wahren Nullstelle darstellt. Die Stelle, an der diese Näherung gleich 0 ist, sollte dich näher an diese wahre Nullstelle bringen.",
   "time_range": [
    383.1,
    392.86
@@ -443,7 +443,7 @@
  {
   "input": "As long as you're able to take a derivative of this function, and with polynomials you'll always be able to do that, you can concretely compute the slope of this line.",
   "model": "nmt",
-  "translatedText": "Solange ihr in der Lage seid, eine Ableitung dieser Funktion zu bilden, und das ist mit Polynomen immer möglich, könnt ihr die Steigung dieser Geraden konkret berechnen.",
+  "translatedText": "Solange du in der Lage bist, eine Ableitung dieser Funktion zu bilden, und das ist mit Polynomen immer möglich, kannst du die Steigung dieser Geraden konkret berechnen.",
   "time_range": [
    393.9,
    401.12
@@ -452,7 +452,7 @@
  {
   "input": "So here's where the active viewers among you might want to pause and ask, how do you figure out the difference between the current guess and the improved guess?",
   "model": "nmt",
-  "translatedText": "Hier möchten die aktiven Zuschauer unter euch vielleicht innehalten und fragen: Wie findet man den Unterschied zwischen der aktuellen Schätzung und der verbesserten Schätzung heraus?",
+  "translatedText": "Hier möchtest du als aktiver Zuschauer vielleicht innehalten und fragen: Wie findet man den Unterschied zwischen der aktuellen Schätzung und der verbesserten Schätzung heraus?",
   "time_range": [
    402.1,
    408.3
@@ -488,7 +488,7 @@
  {
   "input": "If we kind of rearrange this equation here, this gives you a super concrete way that you can compute that step size.",
   "model": "nmt",
-  "translatedText": "Wenn wir diese Gleichung hier irgendwie umstellen, erhaltet ihr eine sehr konkrete Möglichkeit, diese Schrittgröße zu berechnen.",
+  "translatedText": "Wenn du diese Gleichung hier irgendwie umstellst, erhälst du eine sehr konkrete Möglichkeit, diese Schrittgröße zu berechnen.",
   "time_range": [
    425.84,
    431.4
@@ -506,7 +506,7 @@
  {
   "input": "And after that, you can just repeat the process.",
   "model": "nmt",
-  "translatedText": "Und danach könnt ihr den Vorgang einfach wiederholen.",
+  "translatedText": "Und danach kannst du den Vorgang einfach wiederholen.",
   "time_range": [
    438.4,
    440.98
@@ -515,7 +515,7 @@
  {
   "input": "You compute the value of this function and the slope at this new guess, which gives you a new linear approximation, and then you make the next guess, x2, wherever that tangent line crosses the x-axis.",
   "model": "nmt",
-  "translatedText": "Ihr berechnet den Wert dieser Funktion und die Steigung bei dieser neuen Schätzung, wodurch ihr eine neue lineare Näherung erhaltet, und dann gebt ihr eure nächste Schätzung, x2 dort, wo diese Tangente die x-Achse schneidet.",
+  "translatedText": "Du berechnest den Wert dieser Funktion und die Steigung bei dieser neuen Schätzung, wodurch du eine neue lineare Näherung erhälst, und dann gibst du deine nächste Schätzung, x2 dort ab, wo diese Tangente die x-Achse schneidet.",
   "time_range": [
    441.52,
    452.08
@@ -524,7 +524,7 @@
  {
   "input": "And then apply the same calculation to x2, and this gives you x3.",
   "model": "nmt",
-  "translatedText": "Wendet dann dieselbe Berechnung auf x2 an, und ihr erhaltet x3.",
+  "translatedText": "Wende dann dieselbe Berechnung auf x2 an, und du erhälst x3.",
   "time_range": [
    452.78,
    455.98
@@ -533,7 +533,7 @@
  {
   "input": "And before too long, you find yourself extremely close to a true root, pretty much as close as you could ever want to be.",
   "model": "nmt",
-  "translatedText": "Und schon bald seid ihr einer wahren Nullstelle so nahe, wie ihr es euch nur wünschen könnt.",
+  "translatedText": "Und schon bald bist du einer wahren Nullstelle so nahe, wie du es dir nur wünschen könntest.",
   "time_range": [
    456.44,
    462.18
@@ -587,7 +587,7 @@
  {
   "input": "These days it's a common topic in calculus classes.",
   "model": "nmt",
-  "translatedText": "Heutzutage ist das ein häufiges Thema beim behandeln von Differentialrechnung.",
+  "translatedText": "Heutzutage ist das ein häufiges Thema beim behandeln von Infinitesimalrechnung.",
   "time_range": [
    502.64,
    504.92
@@ -614,7 +614,7 @@
  {
   "input": "You see, while Newton's method works great if you start near a root, where it converges really quickly, if your initial guess is far from a root, it can have a couple foibles.",
   "model": "nmt",
-  "translatedText": "Schaut mal, während das Newtonverfahren großartig funktioniert, wenn ihr in der Nähe einer Nullstelle startet, wo sie sehr schnell konvergiert, kann es jedoch ein paar Schwächen geben, wenn eure anfängliche Schätzung weit von einer Nullstelle entfernt ist.",
+  "translatedText": "Schau mal, während das Newtonverfahren großartig funktioniert, wenn du in der Nähe einer Nullstelle startest, wo sie sehr schnell konvergiert, kann es jedoch ein paar Schwächen geben, wenn deine anfängliche Schätzung weit von einer Nullstelle entfernt ist.",
   "time_range": [
    525.38,
    533.96
@@ -632,7 +632,7 @@
  {
   "input": "Notice how the sequence of new guesses that we're getting kind of bounces around the local minimum of this function sitting above the x-axis.",
   "model": "nmt",
-  "translatedText": "Seht ihr, wie die Folge neuer Schätzungen, die wir erhalten, um den lokalen Tiefpunkt dieser Funktion, die über der x-Achse liegt, herumspringt?",
+  "translatedText": "Siehst du, wie die Folge neuer Schätzungen, die wir erhalten, um den lokalen Tiefpunkt dieser Funktion, die über der x-Achse liegt, herumspringt?",
   "time_range": [
    547.4,
    554.56
@@ -668,7 +668,7 @@
  {
   "input": "Even if a polynomial like the one shown here has only a single real number root, you'll always be able to factor this polynomial into five terms like this if you allow these roots to potentially be complex numbers.",
   "model": "nmt",
-  "translatedText": "Selbst wenn ein Polynom wie das hier gezeigte nur eine einzige reelle Nullstelle hat, könnt ihr dieses Polynom immer in fünf Terme wie hier zerlegen, wenn ihr zulasst, dass diese Nullstellen möglicherweise komplexe Zahlen sind.",
+  "translatedText": "Selbst wenn ein Polynom wie das hier gezeigte nur eine einzige reelle Nullstelle hat, kannst du dieses Polynom immer in fünf Terme wie hier zerlegen, wenn du zulässt, dass diese Nullstellen möglicherweise komplexe Zahlen sind.",
   "time_range": [
    588.38,
    599.62
@@ -740,7 +740,7 @@
  {
   "input": "We're figuring out where a linear approximation of the function around your guess would equal zero, and then you use that zero of the linear approximation as your next guess.",
   "model": "nmt",
-  "translatedText": "Wir finden heraus, wo eine lineare Näherung der Funktion um die Schätzung herum gleich Null wäre, und dann verwendet man diese Nullstelle der linearen Näherung als Ihre nächste Schätzung.",
+  "translatedText": "Man findet heraus, wo eine lineare Näherung der Funktion um die Schätzung herum gleich Null wäre, und dann verwendet man diese Nullstelle der linearen Näherung als Ihre nächste Schätzung.",
   "time_range": [
    651.18,
    661.18
@@ -812,7 +812,7 @@
  {
   "input": "In particular, notice how the ones that are trapped on the positive real number line?",
   "model": "nmt",
-  "translatedText": "Achtet mal insbesondere auf diejenigen, die auf der Achse der positiven reellen Zahlen gefangen sind.",
+  "translatedText": "Achte mal insbesondere auf diejenigen, die auf der Achse der positiven reellen Zahlen gefangen sind.",
   "time_range": [
    701.0,
    705.66
@@ -839,7 +839,7 @@
  {
   "input": "Now as I've done it here, this isn't quite enough resolution to get the full story, so let me show you what it would look like if we started with an even finer grid of initial guesses and played the same game, applying Newton's method a whole bunch of times, letting each root march forward, coloring each dot based on what root it lands on, then rolling back the clock to see where it originally came from.",
   "model": "nmt",
-  "translatedText": "So wie ich es hier gemacht habe reicht jedoch die Auflösung nicht ganz aus, um die ganze Geschichte zu verstehen. Lasst mich euch also zeigen, wie es aussehen würde, wenn wir mit einem noch feineren Raster anfänglicher Vermutungen beginnen und dasselbe Spiel spielen würden, also das Newtonverfahren mehrere Male anwenden, sodass wir jede Nullstelle vorwärts wandern lassen, färben jeden Punkt entsprechend der Nullstelle, auf der er landet, und drehen dann die Uhr zurück, um zu sehen, woher sie ursprünglich kamen.",
+  "translatedText": "So wie ich es hier gemacht habe reicht jedoch die Auflösung nicht ganz aus, um die ganze Geschichte zu verstehen. Lass mich dir also zeigen, wie es aussehen würde, wenn wir mit einem noch feineren Raster anfänglicher Vermutungen beginnen und dasselbe Spiel spielen würden, also das Newtonverfahren mehrere Male anwenden, sodass wir jede Nullstelle vorwärts wandern lassen, färben jeden Punkt entsprechend der Nullstelle, auf der er landet, und drehen dann die Uhr zurück, um zu sehen, woher sie ursprünglich kamen.",
   "time_range": [
    729.24,
    748.76
@@ -866,7 +866,7 @@
  {
   "input": "And at this level of detail the color scheme is a little jarring to my eye at least, so let me calm it down a little.",
   "model": "nmt",
-  "translatedText": "Und bei diesem Detaillierungsgrad ist das Farbschema zumindest für mein Auge ein wenig irritierend, also lasst mich einen Gang zurückschalten.",
+  "translatedText": "Und bei diesem Detaillierungsgrad ist das Farbschema zumindest für mein Auge ein wenig irritierend, also lass mich einen Gang zurückschalten.",
   "time_range": [
    760.16,
    765.5
@@ -875,7 +875,7 @@
  {
   "input": "Really whatever resolution I try to use to show this to you here could never possibly be enough, because the finer details of the shape we get go on with endless complexity.",
   "model": "nmt",
-  "translatedText": "Ganz gleich, welche Auflösung ich zu verwenden versuche, um euch das hier zu zeigen, sie könnte niemals ausreichen, da die feineren Details der Form, die wir erhalten, unendlich komplex sind.",
+  "translatedText": "Ganz gleich, welche Auflösung ich zu verwenden versuche, um dir das hier zu zeigen, sie könnte niemals ausreichen, da die feineren Details der Form, die wir erhalten, unendlich komplex sind.",
   "time_range": [
    766.32,
    775.9
@@ -884,7 +884,7 @@
  {
   "input": "But take a moment to think about what this is actually saying.",
   "model": "nmt",
-  "translatedText": "Aber nehmt euch einen Moment Zeit, darüber nachzudenken, was das eigentlich bedeutet.",
+  "translatedText": "Aber nehm dir einen Moment Zeit, darüber nachzudenken, was das eigentlich bedeutet.",
   "time_range": [
    781.76,
    783.7
@@ -911,7 +911,7 @@
  {
   "input": "Now if I grab one of these roots and change it around, meaning that we're using a different polynomial for the process, you can see how the resulting fractal pattern changes.",
   "model": "nmt",
-  "translatedText": "Wenn ich nun eine dieser Nullstellen nehme und sie verändere, was bedeutet, dass wir für den Prozess ein anderes Polynom verwenden, könnt ihr sehen, wie sich das resultierende fraktale Muster ändert.",
+  "translatedText": "Wenn ich nun eine dieser Nullstellen nehme und sie verändere, was bedeutet, dass wir für den Prozess ein anderes Polynom verwenden, kannst du sehen, wie sich das resultierende fraktale Muster ändert.",
   "time_range": [
    817.08,
    824.74
@@ -920,7 +920,7 @@
  {
   "input": "And notice for example how the regions around a given root always have the same color, since those are the points that are close enough to the root where this linear approximation scheme works as a way of finding that root with no problem.",
   "model": "nmt",
-  "translatedText": "Und beachtet zum Beispiel, dass die Regionen um eine bestimmte Nullstelle herum immer die gleiche Farbe haben, da das die Punkte sind, die nahe genug an der Nullstelle liegen, wo dieses lineare Näherungsverfahren als Möglichkeit dient, diese Nullstelle problemlos zu finden.",
+  "translatedText": "Und beachte zum Beispiel, dass die Regionen um eine bestimmte Nullstelle herum immer die gleiche Farbe haben, da das die Punkte sind, die nahe genug an der Nullstelle liegen, wo dieses lineare Näherungsverfahren als Möglichkeit dient, diese Nullstelle problemlos zu finden.",
   "time_range": [
    825.54,
    837.56
@@ -938,7 +938,7 @@
  {
   "input": "Remember that.",
   "model": "nmt",
-  "translatedText": "Behaltet das im Kopf.",
+  "translatedText": "Behalte das im Kopf.",
   "time_range": [
    842.72,
    843.32
@@ -1010,7 +1010,7 @@
  {
   "input": "And this is important, keep in mind that the true shape we're studying here is not any one of these, it's the limit as we allow for an arbitrarily large number of iterations.",
   "model": "nmt",
-  "translatedText": "Und das ist wichtig. Denkt daran, dass die wahre Form, die wir hier untersuchen, keine dieser einzelnen Formen ist, sondern der Grenzwert, da wir eine beliebig große Anzahl von Iterationen zulassen.",
+  "translatedText": "Und das ist wichtig. Denk daran, dass die wahre Form, die wir hier untersuchen, keine dieser einzelnen Formen ist, sondern der Grenzwert, da wir eine beliebig große Anzahl von Iterationen zulassen.",
   "time_range": [
    901.86,
    910.12
@@ -1073,7 +1073,7 @@
  {
   "input": "And before seeing this, don't you think a reasonable initial guess might have been that each seed value simply tends towards whichever root it's closest to?",
   "model": "nmt",
-  "translatedText": "Und bevor ihr das gesehen habt, hättet ihr nicht geglaubt, dass eine vernünftige anfängliche Vermutung gewesen wäre, dass jeder Startwert einfach zu der Nullstelle tendiert, der er am nächsten liegt?",
+  "translatedText": "Und bevor du das gesehen hast, hättest du nicht geglaubt, dass eine vernünftige anfängliche Vermutung gewesen wäre, dass jeder Startwert einfach zu der Nullstelle tendiert, der er am nächsten liegt?",
   "time_range": [
    950.18,
    957.76
@@ -1091,7 +1091,7 @@
  {
   "input": "And since I referenced earlier the unsolvability of the quintic, maybe you would wonder if the complexity here has anything to do with that.",
   "model": "nmt",
-  "translatedText": "Und da ich vorhin auf die Unlösbarkeit von quintischen Gleichungen hingewiesen habe, fragt ihr euch vielleicht, ob die Komplexität hier etwas damit zu tun hat.",
+  "translatedText": "Und da ich vorhin auf die Unlösbarkeit von quintischen Gleichungen hingewiesen habe, fragst du dich vielleicht, ob die Komplexität hier etwas damit zu tun hat.",
   "time_range": [
    969.2,
    975.6
@@ -1118,7 +1118,7 @@
  {
   "input": "Watch what happens if we play the same game, but with a cubic polynomial, with three roots somewhere in the complex plane.",
   "model": "nmt",
-  "translatedText": "Schaut mal, was passiert, wenn wir dasselbe Spiel spielen, aber mit einem kubischen Polynom mit drei Nullstellen irgendwo in der komplexen Ebene.",
+  "translatedText": "Schau mal, was passiert, wenn wir dasselbe Spiel spielen, aber mit einem kubischen Polynom mit drei Nullstellen irgendwo in der komplexen Ebene.",
   "time_range": [
    984.0,
    989.84
@@ -1127,7 +1127,7 @@
  {
   "input": "Notice how, again, while most points nestle into a root, some of them are kind of flying all over the place more chaotically.",
   "model": "nmt",
-  "translatedText": "Beachtet auch hier, dass die meisten Punkte zwar in einer Nullstelle verankert sind, einige jedoch chaotisch durch die Gegend fliegen.",
+  "translatedText": "Beachte auch hier, dass die meisten Punkte zwar in einer Nullstelle verankert sind, einige jedoch chaotisch durch die Gegend fliegen.",
   "time_range": [
    990.86,
    997.38
@@ -1208,7 +1208,7 @@
  {
   "input": "You see, there's a very peculiar property that we can prove this diagram must have.",
   "model": "nmt",
-  "translatedText": "Schaut mal, wir können beweisen, dass dieses Diagramm eine ganz besondere Eigenschaft haben muss.",
+  "translatedText": "Denn wir können beweisen, dass dieses Diagramm eine ganz besondere Eigenschaft haben muss.",
   "time_range": [
    1075.93,
    1080.19
@@ -1217,7 +1217,7 @@
  {
   "input": "Focus your attention on just one of the colored regions, say this blue one, in other words, the set of all points that eventually tend towards just one particular root of the polynomial.",
   "model": "nmt",
-  "translatedText": "Konzentriert mal eure Aufmerksamkeit auf nur einen der farbigen Bereiche, sagen wir diesen blauen, mit anderen Worten, die Menge aller Punkte, die letztendlich nur zu einer bestimmten Nullstelle des Polynoms tendieren.",
+  "translatedText": "Konzentrier mal deine Aufmerksamkeit auf nur einen der farbigen Bereiche, sagen wir diesen blauen, mit anderen Worten, die Menge aller Punkte, die letztendlich nur zu einer bestimmten Nullstelle des Polynoms tendieren.",
   "time_range": [
    1080.85,
    1089.97
@@ -1226,7 +1226,7 @@
  {
   "input": "Now consider the boundary of that region, which for the example shown on screen has this kind of nice three-fold symmetry.",
   "model": "nmt",
-  "translatedText": "Betrachtet nun die Grenze dieser Region, die für das auf dem Bildschirm gezeigte Beispiel diese schöne dreizählige Symmetrie aufweist.",
+  "translatedText": "Betrachte nun die Grenze dieser Region, die für das auf dem Bildschirm gezeigte Beispiel diese schöne dreizählige Symmetrie aufweist.",
   "time_range": [
    1090.51,
    1096.43
@@ -1244,7 +1244,7 @@
  {
   "input": "Now when I say the word boundary, you probably have an intuitive sense of what it means, but mathematicians have a pretty clever way to formalize it, and this makes it easier to reason about in the context of more wild sets like our fractal.",
   "model": "nmt",
-  "translatedText": "Wenn ich nun das Wort „Grenze“ sage, habt ihr wahrscheinlich ein intuitives Gespür dafür, was es bedeutet, aber Mathematiker und Mathematikerinnen haben eine ziemlich clevere Möglichkeit, es zu formalisieren, und das macht es einfacher, im Kontext wilderer Mengen wie unserem Fraktal darüber nachzudenken.",
+  "translatedText": "Wenn ich nun das Wort „Grenze“ sage, hast du wahrscheinlich ein intuitives Gespür dafür, was es bedeutet, aber Mathematiker und Mathematikerinnen haben eine ziemlich clevere Möglichkeit, es zu formalisieren, und das macht es einfacher, im Kontext wilderer Mengen wie unserem Fraktal darüber nachzudenken.",
   "time_range": [
    1105.45,
    1115.97
@@ -1271,7 +1271,7 @@
  {
   "input": "But when it's on the boundary, what it means to be on the boundary is that your tiny tiny circles will always contain both.",
   "model": "nmt",
-  "translatedText": "Aber wenn es an der Grenze ist; An der Grenze zu sein bedeutet, dass eure winzigen Kreise immer beide enthalten werden.",
+  "translatedText": "Aber wenn es an der Grenze ist; An der Grenze zu sein bedeutet, dass deine winzigen Kreise immer beide enthalten werden.",
   "time_range": [
    1138.61,
    1144.55
@@ -1298,7 +1298,7 @@
  {
   "input": "And before explaining where this fact actually comes from, it's fun to try just wrapping your mind around it a little bit.",
   "model": "nmt",
-  "translatedText": "Und bevor wir erklären, woher diese Tatsache eigentlich kommt, ist es durchaus interessant, sich ein wenig damit auseinanderzusetzen.",
+  "translatedText": "Und bevor ich erkläre, woher diese Tatsache eigentlich kommt, ist es durchaus interessant, sich ein wenig damit auseinanderzusetzen.",
   "time_range": [
    1178.95,
    1184.59
@@ -1397,7 +1397,7 @@
  {
   "input": "And for those of you who are familiar with the concept of fractal dimension, you can measure the dimension of the particular boundary I'm showing you right now to be around 1.44.",
   "model": "nmt",
-  "translatedText": "Und für diejenigen unter euch, die mit dem Konzept von fraktalen Dimensionen vertraut sind: Man kann die Dimension der bestimmten Grenze, die ich gerade zeige, auf etwa 1.44 messen.",
+  "translatedText": "Und falls du mit dem Konzept von fraktalen Dimensionen vertraut bist: Man kann die Dimension der bestimmten Grenze, die ich gerade zeige, auf etwa 1.44 messen.",
   "time_range": [
    1290.17,
    1298.17
@@ -1406,7 +1406,7 @@
  {
   "input": "Considering what our colors actually represent, remember this isn't just a picture for picture's sake, think about what the property is really telling us.",
   "model": "nmt",
-  "translatedText": "Behalten wir im Hinterkopf, was unsere Farben tatsächlich darstellen - das hier ist nicht nur ein Bild um ein Bild zu sein - und denkt darüber nach, was uns diese Eigenschaft wirklich sagt.",
+  "translatedText": "Behalten wir im Hinterkopf, was unsere Farben tatsächlich darstellen - das hier ist nicht nur ein Bild um ein Bild zu sein - und denk darüber nach, was uns diese Eigenschaft wirklich sagt.",
   "time_range": [
    1299.89,
    1307.03
@@ -1451,7 +1451,7 @@
  {
   "input": "And keep in mind I'm just showing you finitely many points, but in principle you would want to think about what happens to all uncountably infinitely many points inside some small disk.",
   "model": "nmt",
-  "translatedText": "Und denkt daran, dass ich nur endlich viele Punkte zeige, aber im Prinzip würdet ihr darüber nachdenken wollen, was mit allen unzählig unendlich vielen Punkten innerhalb eines kleinen Kreisrings passiert.",
+  "translatedText": "Und denk daran, dass ich nur endlich viele Punkte zeige, aber im Prinzip würdest du darüber nachdenken wollen, was mit allen unzählig unendlich vielen Punkten innerhalb eines kleinen Kreisrings passiert.",
   "time_range": [
    1351.37,
    1360.29
@@ -1496,7 +1496,7 @@
  {
   "input": "For that I'd like to tell you about a field of math which studies this kind of question, it's called holomorphic dynamics.",
   "model": "nmt",
-  "translatedText": "Dazu möchte ich euch etwas über ein Fachgebiet der Mathematik erzählen, das sich mit dieser Art von Frage beschäftigt: die sogenannte holomorphe Dynamik.",
+  "translatedText": "Dazu möchte ich dir etwas über ein Fachgebiet der Mathematik erzählen, das sich mit dieser Art von Frage beschäftigt: die sogenannte holomorphe Dynamik.",
   "time_range": [
    1402.45,
    1407.63
@@ -1577,7 +1577,7 @@
  {
   "input": "There are probably many other facts about Newton's method, or about all sorts of math that may seem like old news, that come from questions that no one has thought to ask yet, questions that are just sitting there, waiting for someone, like you, to ask them.",
   "model": "nmt",
-  "translatedText": "Es gibt wahrscheinlich viele andere Fakten über das Newtonverfahren oder über alle Arten von Mathematik, die wie alte Nachrichten erscheinen mögen und auf Fragen beruhen, an die noch niemand gedacht hat, Fragen, die einfach nur da liegen und auf jemanden wie dich warten, der sie fragen wird.",
+  "translatedText": "Es gibt wahrscheinlich viele andere Fakten über das Newtonverfahren oder über alle Arten von Mathematik, die wie alte Nachrichten erscheinen mögen und auf Fragen beruhen, an die noch niemand gedacht hat, Fragen, die einfach nur da liegen und auf jemanden wie dich warten, der sie stellen wird.",
   "time_range": [
    1465.33,
    1478.47
@@ -1640,7 +1640,7 @@
  {
   "input": "Part of this has to do with other projects that have been in the works.",
   "model": "nmt",
-  "translatedText": "Ein Teil davon hängt mit anderen Projekten zusammen, die bereits in der Arbeit sind.",
+  "translatedText": "Ein Teil davon hängt mit anderen Projekten zusammen, an denen ich arbeite.",
   "time_range": [
    1514.41,
    1516.75
@@ -1658,7 +1658,7 @@
  {
   "input": "I will be talking all about that and announcing winners very shortly, so stay tuned.",
   "model": "nmt",
-  "translatedText": "Ich werde bald darüber sprechen und die Gewinner bekannt geben, bleibt also gespannt.",
+  "translatedText": "Ich werde bald darüber sprechen und die Gewinner bekannt geben, bleib also gespannt.",
   "time_range": [
    1525.11,
    1529.03
@@ -1667,7 +1667,7 @@
  {
   "input": "I just want you to know that the plan for the foreseeable future is definitely to shift gears more wholeheartedly back to making new videos, and more than anything I want to say Thanks for your continued support, even during times of trying a few new things.",
   "model": "nmt",
-  "translatedText": "Ich möchte nur, dass ihr wisst, dass der Plan für die absehbare Zukunft auf jeden Fall darin besteht, den Gang wieder voll und ganz auf die Erstellung neuer Videos umzustellen, und vor allem möchte ich mich für eure anhaltende Unterstützung bedanken, auch in Zeiten, in denen ich ein paar neue Dinge ausprobiere.",
+  "translatedText": "Ich möchte nur, dass du weist, dass der Plan für die absehbare Zukunft auf jeden Fall darin besteht, den Gang wieder voll und ganz auf die Erstellung neuer Videos umzustellen, und vor allem möchte ich mich für die anhaltende Unterstützung bedanken, auch in Zeiten, in denen ich ein paar neue Dinge ausprobiere.",
   "time_range": [
    1529.45,
    1540.65
@@ -1676,7 +1676,7 @@
  {
   "input": "It means a lot to me, it's what keeps the channel going, and I'll do my best to make the new lessons in the pipeline live up to your vote of confidence there.",
   "model": "nmt",
-  "translatedText": "Es bedeutet mir sehr viel; Es ist das, was den Kanal am Laufen hält, und ich werde mein Bestes dafür tun, damit die neuen Videos in der Pipeline euren Erwartungen gerecht werden.",
+  "translatedText": "Es bedeutet mir sehr viel; Es ist das, was den Kanal am Laufen hält, und ich werde mein Bestes dafür tun, damit die neuen Videos in der Pipeline den Erwartungen gerecht werden.",
   "time_range": [
    1540.91,
    1547.31

--- a/2021/newtons-fractal/german/sentence_translations.json
+++ b/2021/newtons-fractal/german/sentence_translations.json
@@ -2,7 +2,7 @@
  {
   "input": "You've seen the title, so you know this is leading to a certain fractal.",
   "model": "nmt",
-  "translatedText": "Ihr habt den Titel gesehen und weißt daher, dass es zu einem Fraktal führen wird.",
+  "translatedText": "Ihr habt den Titel gesehen und weißt daher, dass es zu einem Fraktal kommen wird.",
   "time_range": [
    2.459999999999999,
    5.58
@@ -11,7 +11,7 @@
  {
   "input": "And actually it's an infinite family of fractals.",
   "model": "nmt",
-  "translatedText": "Und eigentlich ist es eine unendliche Familie von Fraktalen.",
+  "translatedText": "Und eigentlich ist es ja sogar eine unendliche Familie von Fraktalen.",
   "time_range": [
    5.92,
    7.94
@@ -38,7 +38,7 @@
  {
   "input": "Well, okay, maybe that's part of it, but the real story here has a much more pragmatic starting point than the story behind a lot of other fractals.",
   "model": "nmt",
-  "translatedText": "Okay, vielleicht ist das ein Teil davon, aber die wahre Geschichte hier hat einen viel pragmatischeren Ausgangspunkt als die Geschichte hinter vielen anderen Fraktalen.",
+  "translatedText": "Okay, vielleicht ist es ein Teil davon, aber die wahre Geschichte hier hat einen viel pragmatischeren Ausgangspunkt als die Geschichte hinter vielen anderen Fraktalen.",
   "time_range": [
    19.06,
    25.6
@@ -47,7 +47,7 @@
  {
   "input": "And more than that, the final images that we get to will become a lot more meaningful if we make an effort to understand why, given what they represent, they kind of have to look as complicated as they do, and what this complexity reflects about an algorithm that is used all over the place in engineering.",
   "model": "nmt",
-  "translatedText": "Und darüber hinaus werden die endgültigen Bilder, die wir erhalten, viel aussagekräftiger, wenn wir uns bemühen zu verstehen, warum sie angesichts dessen, was sie darstellen, irgendwie so kompliziert aussehen müssen, wie sie sind, und was diese Komplexität über einen Algorithmus aussagt, der in der Technik überall eingesetzt wird.",
+  "translatedText": "Und darüber hinaus werden die endgültigen Bilder, die wir erhalten, viel aussagekräftiger, wenn wir uns bemühen zu verstehen, warum sie angesichts dessen, was sie darstellen, irgendwie so kompliziert aussehen müssen, und was diese Komplexität über einen Algorithmus aussagt, der in der Technik überall eingesetzt wird.",
   "time_range": [
    26.18,
    41.62
@@ -92,7 +92,7 @@
  {
   "input": "Now this is the kind of question where if you're already bought into math, maybe it's interesting enough in its own right to move forward.",
   "model": "nmt",
-  "translatedText": "Das ist die Art von Frage, bei der man, wenn man bereits mit Mathematik vertraut ist, vielleicht an sich schon genug Interesse besteht, um weiterzumachen.",
+  "translatedText": "Das ist die Art von Frage, bei der, wenn man bereits mit Mathematik vertraut ist, vielleicht an und für sich schon genug Interesse besteht, um weiterzumachen.",
   "time_range": [
    67.44,
    72.58
@@ -146,7 +146,7 @@
  {
   "input": "When a computer renders text on the screen, those fonts are typically not defined using pixel values.",
   "model": "nmt",
-  "translatedText": "Wenn ein Computer Text auf dem Bildschirm darstellt, werden diese Schriftarten normalerweise nicht anhand von Pixelwerten definiert.",
+  "translatedText": "Wenn ein Computer Text auf dem Bildschirm darstellt, werden diese Schriften normalerweise nicht anhand von Pixelwerten definiert.",
   "time_range": [
    101.16,
    107.04
@@ -191,7 +191,7 @@
  {
   "input": "But if you step back and really think about it, it's an interesting puzzle to figure out how each one of the pixels knows whether it should be colored in or not just based on the pure mathematical curve.",
   "model": "nmt",
-  "translatedText": "Aber wenn man einen Schritt zurücktritt und wirklich darüber nachdenkt, ist es ein interessantes Rätsel, herauszufinden, wie jedes einzelne Pixel allein aufgrund der rein mathematischen Kurve weiß, ob es eingefärbt werden soll oder nicht.",
+  "translatedText": "Aber wenn man kurz innehält und wirklich darüber nachdenkt, ist es ein interessantes Rätsel, herauszufinden, wie jedes einzelne Pixel allein aufgrund der rein mathematischen Kurve weiß, ob es eingefärbt werden soll oder nicht.",
   "time_range": [
    135.32,
    144.88
@@ -227,7 +227,7 @@
  {
   "input": "Now one thing that you could do to figure out this distance is to compute the distance between your pixel and a bunch of sample points on that curve, and then figure out the smallest.",
   "model": "nmt",
-  "translatedText": "Um diesen Abstand zu ermitteln, könnte man nun den Abstand zwischen deinem Pixel und einer Reihe von Beispielpunkten auf dieser Kurve berechnen und dann den kleinsten ermitteln.",
+  "translatedText": "Um diesen Abstand zu ermitteln, könnte man nun den Abstand zwischen eurem Pixel und einer Reihe von Beispielpunkten auf dieser Kurve berechnen und dann den kleinsten ermitteln.",
   "time_range": [
    161.08,
    169.02
@@ -281,7 +281,7 @@
  {
   "input": "What you do is figure out the slope of this function graph, which is to say its derivative, again some polynomial, and you ask, when does that equal zero?",
   "model": "nmt",
-  "translatedText": "Was man tut, ist, die Steigung dieses Funktionsgraphen herauszufinden, also seine Ableitung, welches wieder ein Polynom ist, und man fragt sich, wann ist dieses Polynom Null?",
+  "translatedText": "Was man tut, ist, die Steigung dieses Funktionsgraphen herauszufinden, also seine Ableitung, welches wieder ein Polynom ist, und man fragt sich, wann hat dieses Polynom den Wert Null?",
   "time_range": [
    209.34,
    217.7
@@ -335,7 +335,7 @@
  {
   "input": "Now, when your problem leads you to a higher order polynomial, things start to get trickier.",
   "model": "nmt",
-  "translatedText": "Wenn Ihr Problem Sie nun zu einem Polynom höheren Grades führt, wird es schwieriger.",
+  "translatedText": "Wenn euer Problem euch nun zu einem Polynom höheren Grades führt, wird es schwieriger.",
   "time_range": [
    283.42,
    287.6
@@ -380,7 +380,7 @@
  {
   "input": "A common one, and the main topic for you and me today, is Newton's method.",
   "model": "nmt",
-  "translatedText": "Ein dabei häufig genutzter Algorithmus, und das Hauptthema für euch und mich heute ist das Newtonverfahren.",
+  "translatedText": "Ein dabei häufig genutzter Algorithmus, und das Hauptthema für euch und mich heute, ist das Newtonverfahren.",
   "time_range": [
    343.24,
    347.1
@@ -407,7 +407,7 @@
  {
   "input": "Almost certainly, the output of your polynomial at x0 is not 0, so you haven't found a solution, it's some other value visible as the height of this graph at that point.",
   "model": "nmt",
-  "translatedText": "Mit ziemlicher Sicherheit ist die Ausgabe eures Polynoms bei x0 nicht 0, ihr habt also keine Lösung gefunden, sondern einen anderen Wert, der als Höhe dieses Diagramms an diesem Punkt sichtbar ist.",
+  "translatedText": "Mit ziemlicher Sicherheit ist die Ausgabe eures Polynoms bei x0 nicht 0, ihr habt also keine Lösung gefunden, sondern einen anderen Wert, der als Höhe dieses Graphen an diesem Punkt sichtbar ist.",
   "time_range": [
    359.66,
    367.78
@@ -425,7 +425,7 @@
  {
   "input": "In other words, if you were to draw a tangent line to the graph at this point, when does that tangent line cross the x-axis?",
   "model": "nmt",
-  "translatedText": "Mit anderen Worten: Wenn man an diesem Punkt eine Tangente zum Diagramm zeichnen würde, wann schneidet diese Tangente die x-Achse?",
+  "translatedText": "Mit anderen Worten: Wenn man an diesem Punkt eine Tangente zum Graphen zeichnen würde, wann schneidet diese Tangente die x-Achse?",
   "time_range": [
    376.02,
    381.82
@@ -542,7 +542,7 @@
  {
   "input": "It's always worth gut checking that a formula actually makes sense, and in this case, hopefully it does.",
   "model": "nmt",
-  "translatedText": "Es lohnt sich immer, aus dem Bauch heraus zu prüfen, ob eine Formel tatsächlich Sinn macht, und in diesem Fall ist das hoffentlich der Fall.",
+  "translatedText": "Es lohnt sich immer, aus dem Bauch heraus zu prüfen, ob eine Formel tatsächlich Sinn macht, und hier ist das hoffentlich der Fall.",
   "time_range": [
    464.76000000000005,
    469.5
@@ -569,7 +569,7 @@
  {
   "input": "Now as the name suggests, this was a method that Newton used to solve polynomial expressions.",
   "model": "nmt",
-  "translatedText": "Wie der Name schon sagt, war das ein Verfahren, die Newton zur Lösung von Polynomausdrücken verwendete.",
+  "translatedText": "Wie der Name schon sagt, war das ein Verfahren, das Newton zur Lösung von Polynomausdrücken verwendete.",
   "time_range": [
    484.52,
    488.76
@@ -587,7 +587,7 @@
  {
   "input": "These days it's a common topic in calculus classes.",
   "model": "nmt",
-  "translatedText": "Heutzutage ist es ein häufiges Thema beim behandeln von Differentialrechnung.",
+  "translatedText": "Heutzutage ist das ein häufiges Thema beim behandeln von Differentialrechnung.",
   "time_range": [
    502.64,
    504.92
@@ -632,7 +632,7 @@
  {
   "input": "Notice how the sequence of new guesses that we're getting kind of bounces around the local minimum of this function sitting above the x-axis.",
   "model": "nmt",
-  "translatedText": "Seht ihr, wie die Folge neuer Schätzungen, die wir erhalten, um das lokale Minimum dieser Funktion, die über der x-Achse liegt, herumspringt?",
+  "translatedText": "Seht ihr, wie die Folge neuer Schätzungen, die wir erhalten, um den lokalen Tiefpunkt dieser Funktion, die über der x-Achse liegt, herumspringt?",
   "time_range": [
    547.4,
    554.56
@@ -668,7 +668,7 @@
  {
   "input": "Even if a polynomial like the one shown here has only a single real number root, you'll always be able to factor this polynomial into five terms like this if you allow these roots to potentially be complex numbers.",
   "model": "nmt",
-  "translatedText": "Selbst wenn ein Polynom wie das hier gezeigte nur eine einzige reelle Nullstelle hat, können Sie dieses Polynom immer in fünf Terme wie hier zerlegen, wenn Sie zulassen, dass diese Nullstellen möglicherweise komplexe Zahlen sind.",
+  "translatedText": "Selbst wenn ein Polynom wie das hier gezeigte nur eine einzige reelle Nullstelle hat, könnt ihr dieses Polynom immer in fünf Terme wie hier zerlegen, wenn ihr zulasst, dass diese Nullstellen möglicherweise komplexe Zahlen sind.",
   "time_range": [
    588.38,
    599.62
@@ -758,7 +758,7 @@
  {
   "input": "And indeed, with at least the one I'm showing here after a few iterations, you can see that we land on a value whose corresponding output is essentially zero.",
   "model": "nmt",
-  "translatedText": "Und tatsächlich kann man zumindest bei dem, den ich hier zeige, nach ein paar Iterationen erkennen, dass wir bei einem Wert landen, dessen entsprechende Ausgabe im Wesentlichen Null ist.",
+  "translatedText": "Und tatsächlich kann man zumindest bei dem, was ich hier zeige, nach ein paar Iterationen erkennen, dass wir bei einem Wert landen, dessen entsprechende Ausgabe im Wesentlichen Null ist.",
   "time_range": [
    666.98,
    674.5
@@ -893,7 +893,7 @@
  {
   "input": "It means that there are regions in the complex plane where if you slightly adjust that seed value, you know, you just kind of bump it to the side by 1,1 millionth or 1,1 trillionth, it can completely change which of the five true roots it ends up landing on.",
   "model": "nmt",
-  "translatedText": "Das bedeutet, dass es Bereiche in der komplexen Ebene gibt, in denen sich, wenn man den Ausgangswert leicht anpasst, einfach um 1,1 Millionstel oder 1,1 Billionstel zur Seite verschiebt, es sich dadurch völlig ändern kann, auf welcher der fünf wahren Nullstellen der Punkt landet.",
+  "translatedText": "Es bedeutet, dass es Bereiche in der komplexen Ebene gibt, in denen sich, wenn man den Ausgangswert leicht anpasst, einfach um 1,1 Millionstel oder 1,1 Billionstel zur Seite verschiebt, es sich dadurch völlig ändern kann, auf welcher der fünf wahren Nullstellen der Punkt landet.",
   "time_range": [
    783.7,
    797.58
@@ -911,7 +911,7 @@
  {
   "input": "Now if I grab one of these roots and change it around, meaning that we're using a different polynomial for the process, you can see how the resulting fractal pattern changes.",
   "model": "nmt",
-  "translatedText": "Wenn ich nun eine dieser Nullstellen nehme und sie verändere, was bedeutet, dass wir für den Prozess ein anderes Polynom verwenden, können ihr sehen, wie sich das resultierende fraktale Muster ändert.",
+  "translatedText": "Wenn ich nun eine dieser Nullstellen nehme und sie verändere, was bedeutet, dass wir für den Prozess ein anderes Polynom verwenden, könnt ihr sehen, wie sich das resultierende fraktale Muster ändert.",
   "time_range": [
    817.08,
    824.74
@@ -938,7 +938,7 @@
  {
   "input": "Remember that.",
   "model": "nmt",
-  "translatedText": "Behalte das im Kopf.",
+  "translatedText": "Behaltet das im Kopf.",
   "time_range": [
    842.72,
    843.32
@@ -974,7 +974,7 @@
  {
   "input": "For example, if I had the computer just take zero steps, meaning it just colors each point of the plane based on whatever root it's already closest to, this is what we'd get.",
   "model": "nmt",
-  "translatedText": "Wenn der Computer beispielsweise nur null Schritte ausführen würde, das heißt, er würde jeden Punkt der Ebene basierend auf der Nullstelle, der er bereits am nächsten liegt, einfärben, würden wir Folgendes erhalten.",
+  "translatedText": "Wenn der Computer beispielsweise nur Null Schritte ausführen würde, das heißt, er würde jeden Punkt der Ebene basierend auf der Nullstelle, der er bereits am nächsten liegt, einfärben, würden wir Folgendes erhalten.",
   "time_range": [
    862.98,
    871.28
@@ -1154,7 +1154,7 @@
  {
   "input": "However, quadratic polynomials with only two roots are different.",
   "model": "nmt",
-  "translatedText": "Quadratische Polynome mit nur zwei Wurzeln sind jedoch unterschiedlich.",
+  "translatedText": "Quadratische Polynome mit nur zwei Nullstellen sind jedoch unterschiedlich.",
   "time_range": [
    1025.8400000000001,
    1029.38
@@ -1172,7 +1172,7 @@
  {
   "input": "There is a little bit of meandering behavior from all the points that are an equal distance from each root, it's kind of like they're not able to decide which one to go to, but that's just a single line of points, and when we play the game of coloring, the diagram we end up with is decidedly more boring.",
   "model": "nmt",
-  "translatedText": "Es gibt ein leichtes mäandrierendes Verhalten aller Punkte, die den gleichen Abstand von jeder Wurzel haben. Es ist so, als könnten sie sich nicht entscheiden, zu welchem Punkt sie gehen sollen, aber das ist nur eine einzelne Linie von Punkten, und wenn wir das Malspiel spielen, ist das Diagramm, das wir am Ende erhalten deutlich langweiliger.",
+  "translatedText": "Es gibt ein leichtes mäandrierendes Verhalten aller Punkte, die den gleichen Abstand von jeder Nullstelle haben. Es ist so, als könnten sie sich nicht entscheiden, zu welchem Punkt sie gehen sollen, aber das ist nur eine einzelne Linie von Punkten, und wenn wir das Malspiel spielen, ist das Diagramm, das wir am Ende erhalten deutlich langweiliger.",
   "time_range": [
    1036.32,
    1050.66
@@ -1217,7 +1217,7 @@
  {
   "input": "Focus your attention on just one of the colored regions, say this blue one, in other words, the set of all points that eventually tend towards just one particular root of the polynomial.",
   "model": "nmt",
-  "translatedText": "Konzentrieren mal eure Aufmerksamkeit auf nur einen der farbigen Bereiche, sagen wir diesen blauen, mit anderen Worten, die Menge aller Punkte, die letztendlich nur zu einer bestimmten Wurzel des Polynoms tendieren.",
+  "translatedText": "Konzentriert mal eure Aufmerksamkeit auf nur einen der farbigen Bereiche, sagen wir diesen blauen, mit anderen Worten, die Menge aller Punkte, die letztendlich nur zu einer bestimmten Nullstelle des Polynoms tendieren.",
   "time_range": [
    1080.85,
    1089.97
@@ -1244,7 +1244,7 @@
  {
   "input": "Now when I say the word boundary, you probably have an intuitive sense of what it means, but mathematicians have a pretty clever way to formalize it, and this makes it easier to reason about in the context of more wild sets like our fractal.",
   "model": "nmt",
-  "translatedText": "Wenn ich nun das Wort „Grenze“ sage, habt ihr wahrscheinlich ein intuitives Gespür dafür, was es bedeutet, aber Mathematiker haben eine ziemlich clevere Möglichkeit, es zu formalisieren, und das macht es einfacher, im Kontext wilderer Mengen wie unserem Fraktal darüber nachzudenken.",
+  "translatedText": "Wenn ich nun das Wort „Grenze“ sage, habt ihr wahrscheinlich ein intuitives Gespür dafür, was es bedeutet, aber Mathematiker und Mathematikerinnen haben eine ziemlich clevere Möglichkeit, es zu formalisieren, und das macht es einfacher, im Kontext wilderer Mengen wie unserem Fraktal darüber nachzudenken.",
   "time_range": [
    1105.45,
    1115.97
@@ -1280,7 +1280,7 @@
  {
   "input": "So looking back at our property, one way to read it is to say that if you draw a circle, no matter how small that circle, it either contains all of the colors, which happens when this shared boundary of the colors is inside that circle, or it contains just one color, and this happens when it's in the interior of one of the regions.",
   "model": "nmt",
-  "translatedText": "Wenn wir also auf unsere Eigenschaft zurückblicken, können wir diese folgendermaßen lesen: Wenn man einen Kreis zeichnet, egal wie klein dieser Kreis ist, enthält er entweder alle Farben, was geschieht, wenn diese gemeinsame Grenze der Farben innerhalb dieses Kreises liegt, oder er enthält nur eine Farbe, und das geschieht, wenn es sich im Inneren einer der Regionen befindet.",
+  "translatedText": "Wenn wir also auf unsere Eigenschaft zurückblicken, können wir diese folgendermaßen verstehen: Wenn man einen Kreis zeichnet, egal wie klein dieser Kreis ist, enthält er entweder alle Farben, was geschieht, wenn diese gemeinsame Grenze der Farben innerhalb dieses Kreises liegt, oder er enthält nur eine Farbe, und das geschieht, wenn es sich im Inneren einer der Regionen befindet.",
   "time_range": [
    1145.41,
    1164.03
@@ -1442,7 +1442,7 @@
  {
   "input": "It starts off mostly sticking together, but at one iteration they all kind of explode outward, and after that it feels a lot more reasonable that any root is up for grabs.",
   "model": "nmt",
-  "translatedText": "Am Anfang hält es größtenteils zusammen, aber ab einer Iteration explodieren sie alle in gewisser weise nach außen, und danach fühlt es sich viel vernünftiger an, dass jede Nullstelle zu erhalten ist.",
+  "translatedText": "Am Anfang hält es größtenteils zusammen, aber ab einer Iteration explodieren sie alle in gewisser Weise nach außen, und danach fühlt es sich viel vernünftiger an, dass jede Nullstelle zu erhalten ist.",
   "time_range": [
    1340.43,
    1350.33
@@ -1460,7 +1460,7 @@
  {
   "input": "This property also kind of explains why it's okay for things to look normal in the case of quadratic polynomials with just two roots, because there a smooth boundary is fine, there's only two colors to touch anyway.",
   "model": "nmt",
-  "translatedText": "Diese Eigenschaft erklärt auch, warum es in Ordnung ist, dass die Dinge bei quadratischen Polynomen mit nur zwei Nullstellen normal aussehen, weil dort eine glatte Grenze in Ordnung ist und es ohnehin nur zwei Farben gibt, die berührt werden können.",
+  "translatedText": "Diese Eigenschaft erklärt auch, warum es in Ordnung ist, dass die Dinge bei quadratischen Polynomen mit nur zwei Nullstellen normal aussehen, weil dort eine glatte Grenze in Ordnung ist, es gibt ohnehin nur zwei Farben, die berührt werden können.",
   "time_range": [
    1364.61,
    1376.07
@@ -1469,7 +1469,7 @@
  {
   "input": "To be clear, it doesn't guarantee that the quadratic case would have a smooth boundary, it is perfectly possible to have a fractal boundary between two colors, it just looks like our Newton's method diagram is not doing anything more complicated than it needs to under the constraint of this strange boundary condition.",
   "model": "nmt",
-  "translatedText": "Um das klar zu sagen: Dadurch wird nicht garantiert, dass der quadratische Fall eine glatte Grenze hat. Es ist durchaus möglich, eine fraktale Grenze zwischen zwei Farben zu haben. Es sieht nur so aus, als ob unser Newtonverfahren-Diagramm nichts komplizierter macht als nötig unter der Einschränkung dieser seltsamen Randbedingung.",
+  "translatedText": "Um das klar zu sagen: Dadurch wird nicht garantiert, dass der quadratische Fall eine glatte Grenze hat. Es ist durchaus möglich, eine fraktale Grenze zwischen zwei Farben zu haben. Es sieht nur so aus, als ob unser Newtonverfahrens-Diagramm nichts komplizierter macht als nötig unter der Einschränkung dieser seltsamen Randbedingung.",
   "time_range": [
    1376.83,
    1392.71
@@ -1505,7 +1505,7 @@
  {
   "input": "And I think we've covered enough ground today and there's certainly enough left to tell, so it makes sense to pull that out as a separate video.",
   "model": "nmt",
-  "translatedText": "Und ich denke, wir haben heute genug abgedeckt und es gibt auf jeden Fall noch genug zu erzählen, daher macht es Sinn, das als separates Video herauszubringen.",
+  "translatedText": "Und ich denke, wir haben heute genug abgedeckt und es gibt auf jeden Fall noch genug zu erzählen, daher macht es Sinn, das in einem seperaten Video zu behandeln.",
   "time_range": [
    1408.41,
    1414.35
@@ -1532,7 +1532,7 @@
  {
   "input": "Hamiltonians are central to quantum mechanics, despite Hamilton knowing nothing about quantum mechanics.",
   "model": "nmt",
-  "translatedText": "Hamilton-Operatoren sind für die Quantenmechanik von zentraler Bedeutung, obwohl Hamilton nichts über Quantenmechanik weiß.",
+  "translatedText": "Hamilton-Operatoren sind für die Quantenmechanik von zentraler Bedeutung, obwohl Hamilton nichts über Quantenmechanik wusste.",
   "time_range": [
    1434.81,
    1439.43
@@ -1541,7 +1541,7 @@
  {
   "input": "Fourier himself never once computed a fast Fourier transform, the list goes on.",
   "model": "nmt",
-  "translatedText": "Fourier selbst hat nie eine schnelle Fourier-Transformation berechnet, die Liste geht weiter.",
+  "translatedText": "Fourier selbst hat nie eine schnelle Fourier-Transformation durchgeführt, die Liste geht weiter.",
   "time_range": [
    1440.01,
    1444.69
@@ -1559,7 +1559,7 @@
  {
   "input": "It reflects how even the simple ideas, ones that could be discovered centuries ago, often hold within them some new angle or a new domain of relevance that can sit waiting to be discovered hundreds of years later.",
   "model": "nmt",
-  "translatedText": "Es spiegelt wider, dass selbst die einfachen Ideen, die schon vor Jahrhunderten entdeckt werden konnten, oft einen neuen Blickwinkel oder einen neuen Bereich von Relevanz in sich bergen, der Hunderte von Jahren später darauf warten kann, entdeckt zu werden.",
+  "translatedText": "Es spiegelt wieder, dass selbst die einfachen Ideen, die schon vor Jahrhunderten entdeckt werden konnten, oft einen neuen Blickwinkel oder einen neuen Bereich von Relevanz in sich tragen, der Hunderte von Jahren später darauf wartet, entdeckt zu werden.",
   "time_range": [
    1450.53,
    1461.37
@@ -1622,7 +1622,7 @@
  {
   "input": "And on the topic of patrons, I do just want to say a quick thanks to everyone whose name is on the screen.",
   "model": "nmt",
-  "translatedText": "Und wenn wir schon bei Patreons sind, möchte ich mich kurz bei allen bedanken, deren Namen auf dem Bildschirm stehen.",
+  "translatedText": "Und wenn wir schon bei Patreons sind, möchte ich mich kurz bei allen bedanken, deren Namen auf dem Bildschirm zu sehen sind.",
   "time_range": [
    1506.47,
    1510.33
@@ -1631,7 +1631,7 @@
  {
   "input": "I know that in recent history new videos have been a little slow coming.",
   "model": "nmt",
-  "translatedText": "Ich weiß, dass neue Videos in der etwas langsamer erscheinen als zuvor.",
+  "translatedText": "Ich weiß, dass neue Videos etwas langsamer erscheinen als zuvor.",
   "time_range": [
    1510.75,
    1513.97
@@ -1640,7 +1640,7 @@
  {
   "input": "Part of this has to do with other projects that have been in the works.",
   "model": "nmt",
-  "translatedText": "Ein Teil davon hängt mit anderen Projekten zusammen, die bereits in Arbeit sind.",
+  "translatedText": "Ein Teil davon hängt mit anderen Projekten zusammen, die bereits in der Arbeit sind.",
   "time_range": [
    1514.41,
    1516.75
@@ -1676,7 +1676,7 @@
  {
   "input": "It means a lot to me, it's what keeps the channel going, and I'll do my best to make the new lessons in the pipeline live up to your vote of confidence there.",
   "model": "nmt",
-  "translatedText": "Es bedeutet mir sehr viel, es ist das, was den Kanal am Laufen hält, und ich werde mein Bestes dafür tun, damit die neuen Videos in der Pipeline euren Erwartungen gerecht werden.",
+  "translatedText": "Es bedeutet mir sehr viel; Es ist das, was den Kanal am Laufen hält, und ich werde mein Bestes dafür tun, damit die neuen Videos in der Pipeline euren Erwartungen gerecht werden.",
   "time_range": [
    1540.91,
    1547.31

--- a/2021/newtons-fractal/german/title.json
+++ b/2021/newtons-fractal/german/title.json
@@ -1,4 +1,4 @@
 {
- "translatedText": "Von Newtons Methode zu Newtons Fraktal (von dem Newton nichts wusste)",
+ "translatedText": "Vom Newtonverfahren zum Newtonfraktal (von dem Newton nichts wusste)",
  "input": "From Newton’s method to Newton’s fractal (which Newton knew nothing about)"
 }


### PR DESCRIPTION
### Changes

- Used an informal "Ihr" or "Du" instead of the (in my opinion way too formal) "Sie"
- More informality, like favoring "das" over "dies"
- Some cultural Stuff (like not presenting the quadratic formula as something the viewer will know from heart, since german children are commonly taught the reduced quadratic formula)
- Replaced some Idioms that don't make sense in German
- Replaced instances where "root" in the context of a polynomial was mentioned to "Nullstelle" instead of "Wurzel", since while a valid translation, it runs the risk of being confusing
- And a lot of more minor things

### Notes

This still may be improved upon, but it should be a step up from the previous translation (which was error prone, to say the least).