### PR TITLE
[Korean] pi-was-628 title

### DIFF
--- a/2018/pi-was-628/korean/title.json
+++ b/2018/pi-was-628/korean/title.json
@@ -1,4 +1,4 @@
 {
- "translatedText": "파이는 거의 6.283185였죠...",
+ "translatedText": "파이가 6.28318...이 될뻔했던 이유",
  "input": "How pi was almost 6.283185..."
 }


### PR DESCRIPTION
파이는 거의 6.283185였죠... -> 파이가 6.28318...이 될뻔했던 이유
translation
how pi was almost 6.283185 (as in how pi's value was close to 6.283185) ->How pi almost became 6.28318...