### PR TITLE
Update sentence_translations.json

### DIFF
--- a/2023/gaussian-integral/german/sentence_translations.json
+++ b/2023/gaussian-integral/german/sentence_translations.json
@@ -2,7 +2,7 @@
  {
   "input": "You may have heard the phrase, the unreasonable effectiveness of mathematics in the natural sciences.",
   "model": "nmt",
-  "translatedText": "Sie haben vielleicht schon einmal den Satz gehört, dass die Mathematik in den Naturwissenschaften unangemessen wirksam sei.",
+  "translatedText": "Sie haben vielleicht schon einmal das Zitat von der ungeheuren Effektivität der Mathematik gehört.",
   "time_range": [
    0.0,
    4.38
@@ -11,7 +11,7 @@
  {
   "input": "This was the title of a paper by the physicist Eugene Wigner, but even more fun than the title is the way that he chooses to open it.",
   "model": "nmt",
-  "translatedText": "Dies war der Titel einer Arbeit des Physikers Eugene Wigner, aber noch lustiger als der Titel ist die Art und Weise, wie er sie eröffnet.",
+  "translatedText": "Dies war der Titel eines Aufsatzes des Physikers Eugene Wigner, aber noch interessanter als der Titel ist Wigners Einführung.",
   "time_range": [
    5.08,
    11.5
@@ -20,7 +20,7 @@
  {
   "input": "The paper begins, quote, There is a story about two friends who were classmates in high school, talking about their jobs.",
   "model": "nmt",
-  "translatedText": "Der Aufsatz beginnt mit folgendem Zitat: „Es gibt eine Geschichte über zwei Freunde, die in der High School Klassenkameraden waren und über ihre Arbeit sprachen.",
+  "translatedText": "Der Aufsatz beginnt so: Es gibt eine Geschichte über zwei Freunde, die früher in der High School Klassenkameraden waren und sich über ihre heutigen Jobs unterhalten.",
   "time_range": [
    11.64,
    18.06
@@ -29,7 +29,7 @@
  {
   "input": "One of them became a statistician and was working on population trends.",
   "model": "nmt",
-  "translatedText": "“ Einer von ihnen wurde Statistiker und beschäftigte sich mit Bevölkerungstrends.",
+  "translatedText": "Einer von ihnen wurde Statistiker und beschäftigt sich mit Bevölkerungstrends.",
   "time_range": [
    18.62,
    21.66
@@ -38,7 +38,7 @@
  {
   "input": "They showed a reprint to their former classmate, and the reprint started, as usual, with the Gaussian distribution.",
   "model": "nmt",
-  "translatedText": "Sie zeigten ihrem ehemaligen Klassenkameraden einen Nachdruck, und der Nachdruck begann wie üblich mit der Gaußverteilung.",
+  "translatedText": "Er zeigt seinem ehemaligen Klassenkameraden eine seiner Arbeiten, und die beginnt wie üblich mit der Gaußverteilung.",
   "time_range": [
    22.06,
    27.58
@@ -47,7 +47,7 @@
  {
   "input": "The statistician explained to the former classmate the meaning of the symbols for the actual population, the average population, and so on.",
   "model": "nmt",
-  "translatedText": "Der Statistiker erklärte dem ehemaligen Klassenkameraden die Bedeutung der Symbole für die tatsächliche Bevölkerung, die Durchschnittsbevölkerung usw.",
+  "translatedText": "Der Statistiker erklärt dem ehemaligen Klassenkameraden die Bedeutung der Symbole für die tatsächliche Bevölkerung, die Durchschnittsbevölkerung usw.",
   "time_range": [
    27.58,
    34.7
@@ -56,7 +56,7 @@
  {
   "input": "The classmate was a bit incredulous and was not quite sure whether the statistician was pulling their leg.",
   "model": "nmt",
-  "translatedText": "Der Klassenkamerad war etwas ungläubig und war sich nicht ganz sicher, ob der Statistiker ihn verärgerte.",
+  "translatedText": "Der Klassenkamerad ist etwas ungläubig, und er ist sich nicht ganz sicher, ob der Statistiker ihn auf den Arm nehmen will.",
   "time_range": [
    35.14,
    39.84
@@ -65,7 +65,7 @@
  {
   "input": "How can you know that?",
   "model": "nmt",
-  "translatedText": "Wie kannst du das wissen?",
+  "translatedText": "„Wie kannst du das wissen?“",
   "time_range": [
    40.22,
    41.12
@@ -74,7 +74,7 @@
  {
   "input": "was the query.",
   "model": "nmt",
-  "translatedText": "war die Frage.",
+  "translatedText": "fragt der Klassenkamerad.",
   "time_range": [
    41.26,
    41.76
@@ -83,7 +83,7 @@
  {
   "input": "And what is this symbol over here?",
   "model": "nmt",
-  "translatedText": "Und was ist dieses Symbol hier?",
+  "translatedText": "„Und was ist dieses Symbol hier?“",
   "time_range": [
    42.28,
    43.76
@@ -92,7 +92,7 @@
  {
   "input": "Oh, said the statistician, this is pi.",
   "model": "nmt",
-  "translatedText": "Oh, sagte der Statistiker, das ist Pi.",
+  "translatedText": "„Oh“, sagt der Statistiker, „das ist Pi.“",
   "time_range": [
    44.38,
    46.82
@@ -101,7 +101,7 @@
  {
   "input": "What is that?",
   "model": "nmt",
-  "translatedText": "Was ist das?",
+  "translatedText": "„Was ist das?“",
   "time_range": [
    47.34,
    47.9
@@ -110,7 +110,7 @@
  {
   "input": "The ratio of the circumference of a circle to its diameter.",
   "model": "nmt",
-  "translatedText": "Das Verhältnis des Umfangs eines Kreises zu seinem Durchmesser.",
+  "translatedText": "„Das Verhältnis des Umfangs eines Kreises zu seinem Durchmesser.“",
   "time_range": [
    48.6,
    51.08
@@ -119,7 +119,7 @@
  {
   "input": "Well, now you're pushing the joke too far, said the classmate.",
   "model": "nmt",
-  "translatedText": "„Nun, jetzt treibst du den Witz zu weit“, sagte der Klassenkamerad.",
+  "translatedText": "„Also jetzt treibst du es aber zu weit“, sagt der Klassenkamerad.",
   "time_range": [
    52.0,
    54.42
@@ -128,7 +128,7 @@
  {
   "input": "Surely the population has nothing to do with the circumference of a circle.",
   "model": "nmt",
-  "translatedText": "Sicherlich hat die Bevölkerungszahl nichts mit dem Umfang eines Kreises zu tun.",
+  "translatedText": "„Sicherlich hat die Bevölkerungszahl nichts mit dem Umfang eines Kreises zu tun.“",
   "time_range": [
    54.42,
    57.96
@@ -137,7 +137,7 @@
  {
   "input": "In the paper, Wigner then goes on to talk about the more general phenomenon of concepts and pure math seeming to find applications that extend strangely beyond what their definitions would suggest.",
   "model": "nmt",
-  "translatedText": "In der Arbeit spricht Wigner dann über das allgemeinere Phänomen, dass Konzepte und reine Mathematik scheinbar Anwendungen finden, die seltsamerweise über das hinausgehen, was ihre Definitionen vermuten lassen.",
+  "translatedText": "In seinem Artikel spricht Wigner dann über das allgemeinere Phänomen, dass Konzepte und reine Mathematik scheinbar Anwendungen finden, die seltsamerweise über das hinausgehen, was ihre Definitionen vermuten lassen.",
   "time_range": [
    59.28,
    68.48
@@ -155,7 +155,7 @@
  {
   "input": "You see, there is a very beautiful and classic proof that explains the pi inside the formula for a normal distribution.",
   "model": "nmt",
-  "translatedText": "Sehen Sie, es gibt einen sehr schönen und klassischen Beweis, der den Pi in der Formel für eine Normalverteilung erklärt.",
+  "translatedText": "Sehen Sie, es gibt einen sehr schönen und klassischen Beweis, der das Auftauchen von Pi in der Formel für eine Normalverteilung erklärt.",
   "time_range": [
    75.24,
    80.84
@@ -164,7 +164,7 @@
  {
   "input": "And despite there being a number of other really great explanations online, see some links in the description, I cannot help but indulge in the pleasure of reanimating it here.",
   "model": "nmt",
-  "translatedText": "Und obwohl es online noch eine Reihe anderer wirklich toller Erklärungen gibt (siehe einige Links in der Beschreibung), kann ich nicht umhin, mich dem Vergnügen hinzugeben, es hier wieder zum Leben zu erwecken.",
+  "translatedText": "Und obwohl es online noch eine Reihe anderer wirklich toller Erklärungen gibt (siehe einige Links in der Beschreibung), bin ich der Versuchung erlegen, den Beweis in animierter Form zu präsentieren.",
   "time_range": [
    80.84,
    89.72
@@ -173,7 +173,7 @@
  {
   "input": "For one thing, there is a fun side note that I didn't learn until recently about how you can use this proof to derive the volumes of higher dimensional spheres.",
   "model": "nmt",
-  "translatedText": "Zum einen gibt es eine lustige Randbemerkung darüber, wie man diesen Beweis nutzen kann, um die Volumina höherdimensionaler Kugeln abzuleiten, die ich erst vor kurzem erfahren habe.",
+  "translatedText": "Zum einen möchte ich einen Weg zeigen, wie man mit Hilfe des Beweises die Volumina höherdimensionaler Kugeln ableiten kann. Davon habe ich selbst erst kürzlich erfahren.",
   "time_range": [
    90.42,
    97.36
@@ -182,7 +182,7 @@
  {
   "input": "But much more importantly than that, what I really want to do is try to go beyond the classic proof.",
   "model": "nmt",
-  "translatedText": "Aber viel wichtiger ist, dass ich wirklich versuchen möchte, über den klassischen Beweis hinauszugehen.",
+  "translatedText": "Aber vor allem möchte ich wirklich versuchen, über den klassischen Beweis hinauszugehen.",
   "time_range": [
    98.28,
    103.0
@@ -200,7 +200,7 @@
  {
   "input": "What I want to ask is, can we find an explanation that would satisfy their disbelief?",
   "model": "nmt",
-  "translatedText": "Was ich fragen möchte, ist: Können wir eine Erklärung finden, die ihren Unglauben befriedigen würde?",
+  "translatedText": "Was ich herausfinden möchte, ist: Können wir eine Erklärung finden, die seinen Unglauben befriedigen würde?",
   "time_range": [
    106.38,
    110.7
@@ -209,7 +209,7 @@
  {
   "input": "You see, they're not just asking for some pure math proof about a function that was handed down to them on high.",
   "model": "nmt",
-  "translatedText": "Sehen Sie, sie verlangen nicht nur einen rein mathematischen Beweis für eine Funktion, die ihnen von oben überliefert wurde.",
+  "translatedText": "Sehen Sie, er erwartet nicht nur einen rein mathematischen Beweis für eine Funktion, die ihm sozusagen von einer höheren Authorität zugeworfen wurde.",
   "time_range": [
    110.84,
    115.98
@@ -218,7 +218,7 @@
  {
   "input": "The friend's incredulity was that circles should have anything to do with population statistics.",
   "model": "nmt",
-  "translatedText": "Der Freund war ungläubig, dass Kreise irgendetwas mit Bevölkerungsstatistiken zu tun haben sollten.",
+  "translatedText": "Der Freund ist ungläubig, dass Kreise irgendetwas mit Bevölkerungsstatistiken zu tun haben sollten.",
   "time_range": [
    116.54,
    121.58
@@ -245,7 +245,7 @@
  {
   "input": "And when you strip away all of the different parameters and the constants, the basic function that describes the bell curve shape is e to the negative x squared.",
   "model": "nmt",
-  "translatedText": "Und wenn Sie alle verschiedenen Parameter und Konstanten entfernen, ist die Grundfunktion, die die Form der Glockenkurve beschreibt, e hoch zum negativen x im Quadrat.",
+  "translatedText": "Und wenn Sie alle verschiedenen Parameter und Konstanten entfernen, ist die Grundfunktion, die die Form der Glockenkurve beschreibt, e hoch minus x Quadrat.",
   "time_range": [
    137.26,
    145.28
@@ -272,7 +272,7 @@
  {
   "input": "In the full formula that you would see, say, in a stats book, this gets mixed together with some of the other constants, but in its purest form that pi originates from the area underneath this curve.",
   "model": "nmt",
-  "translatedText": "In der vollständigen Formel, die Sie beispielsweise in einem Statistikbuch sehen würden, wird dies mit einigen anderen Konstanten vermischt, aber in seiner reinsten Form stammt Pi aus dem Bereich unterhalb dieser Kurve.",
+  "translatedText": "In der vollständigen Formel, die Sie beispielsweise in einem Statistikbuch sehen würden, kommen einige andere Konstanten dazu, aber in der einfachsten Variante der Formel stammt Pi aus dem Bereich unterhalb dieser Kurve.",
   "time_range": [
    167.24,
    178.1
@@ -299,7 +299,7 @@
  {
   "input": "We need to also answer why is it that this function e to the negative x squared is so special in the first place?",
   "model": "nmt",
-  "translatedText": "Wir müssen auch beantworten, warum diese Funktion e zum negativen x im Quadrat überhaupt so besonders ist?",
+  "translatedText": "Wir müssen auch beantworten, warum diese Funktion e hoch minus x Quadrat überhaupt so besonders ist.",
   "time_range": [
    190.44,
    195.86
@@ -308,7 +308,7 @@
  {
   "input": "I mean, there are lots of different formulas you could write down that would give a shape that, you know, vaguely bulges in the middle and tapers out on either side.",
   "model": "nmt",
-  "translatedText": "Ich meine, es gibt viele verschiedene Formeln, die man aufschreiben könnte, um eine Form zu erhalten, die sich, wie Sie wissen, in der Mitte leicht ausbeult und auf beiden Seiten spitz zuläuft.",
+  "translatedText": "Ich meine, es gibt viele verschiedene Formeln, die man aufschreiben könnte, um eine Form zu erhalten, die sich in der Mitte leicht ausbeult und sich auf beiden Seiten abflacht.",
   "time_range": [
    195.86,
    204.1
@@ -326,7 +326,7 @@
  {
   "input": "To phrase our goal another way, can we find a connection between the proof that shows why pi shows up and the central limit theorem, which, as we talked about in the last video, is the thing that explains when you can expect a normal distribution to arise in nature?",
   "model": "nmt",
-  "translatedText": "Um unser Ziel anders auszudrücken: Können wir einen Zusammenhang zwischen dem Beweis, der zeigt, warum Pi auftaucht, und dem zentralen Grenzwertsatz finden, der, wie wir im letzten Video besprochen haben, erklärt, wann man mit einer Normalverteilung rechnen kann? in der Natur entstehen?",
+  "translatedText": "Um unser Ziel anders auszudrücken: Können wir einen Zusammenhang zwischen dem Beweis, der zeigt, warum Pi auftaucht, und dem zentralen Grenzwertsatz finden, der, wie wir im letzten Video besprochen haben, erklärt, wann man in der Praxis mit einer Normalverteilung rechnen kann?",
   "time_range": [
    209.74,
    224.04
@@ -335,7 +335,7 @@
  {
   "input": "So with all of that as the goal, first things first, let's dig into the classic and very beautiful proof.",
   "model": "nmt",
-  "translatedText": "Mit all dem als Ziel und dem Wichtigsten zuerst wollen wir uns mit dem klassischen und sehr schönen Beweis befassen.",
+  "translatedText": "Mit diesen Zielen im Blick, lassen Sie uns zuerst den klassischen und sehr schönen Beweis betrachten.",
   "time_range": [
    224.7,
    229.28
@@ -344,7 +344,7 @@
  {
   "input": "All right, when you want to find the area underneath a curve, the tool for doing that is an integral.",
   "model": "nmt",
-  "translatedText": "Nun gut, wenn Sie die Fläche unter einer Kurve ermitteln möchten, ist das Werkzeug dafür ein Integral.",
+  "translatedText": "Wenn Sie die Fläche unter einer Kurve ermitteln möchten, ist das Werkzeug dafür ein Integral.",
   "time_range": [
    231.76,
    236.76
@@ -353,7 +353,7 @@
  {
   "input": "As a quick reminder for how you might read this notation, you might imagine approximating that area with many different rectangles under the curve, where the height of each such rectangle is the value of the function above that point, in this case, e to the negative x squared for a certain input x, and the width is some little number that we're calling dx.",
   "model": "nmt",
-  "translatedText": "Als kurze Erinnerung daran, wie Sie diese Notation lesen könnten, können Sie sich vorstellen, diesen Bereich mit vielen verschiedenen Rechtecken unter der Kurve zu approximieren, wobei die Höhe jedes solchen Rechtecks der Wert der Funktion über diesem Punkt ist, in diesem Fall e bis zum negatives x im Quadrat für eine bestimmte Eingabe x, und die Breite ist eine kleine Zahl, die wir dx nennen.",
+  "translatedText": "Als kurze Erinnerung: das Integral einer Funktion können Sie sich so vorstellen, dass dieser Bereich mit vielen verschiedenen Rechtecken unter der Kurve approximiert wird. Dabei ist die Höhe jedes solchen Rechtecks der Wert der Funktion über diesem Punkt, in diesem Fall von e hoch minus x Quadrat für eine bestimmte Eingabe x, und die Breite der Rechtecke ist eine kleine Zahl, die wir dx nennen.",
   "time_range": [
    237.26,
    253.8
@@ -362,7 +362,7 @@
  {
   "input": "We need to add up the areas of all these rectangles, for values of x ranging from negative infinity up to infinity, and the use of that notation dx is kind of meant to imply you shouldn't think of any specific width, but instead you ask, as the chosen width for your rectangles gets thinner and thinner, what does this sum of all those areas approach?",
   "model": "nmt",
-  "translatedText": "Wir müssen die Flächen aller dieser Rechtecke addieren, für x-Werte im Bereich von negativ unendlich bis unendlich, und die Verwendung der Notation dx soll gewissermaßen implizieren, dass Sie nicht an eine bestimmte Breite denken sollten, sondern an Sie Fragen Sie: Wie nähert sich die Summe all dieser Flächen an, wenn die gewählte Breite für Ihre Rechtecke immer dünner wird?",
+  "translatedText": "Wir müssen die Flächen aller dieser Rechtecke addieren, für x-Werte im Bereich von minus unendlich bis unendlich, und die Verwendung der Schreibweise dx bedeutet, dass Sie nicht an eine bestimmte Breite denken sollten, sondern dass es darum geht, welchem Wert sich die Summe all dieser Flächen annähert, wenn die gewählte Breite für Ihre Rechtecke immer kleiner wird.",
   "time_range": [
    254.42,
    271.84
@@ -371,7 +371,7 @@
  {
   "input": "Of course, all of that is just notation unless you provide a way to answer that question, and the magic of calculus is that it provides just that, at least usually.",
   "model": "nmt",
-  "translatedText": "Natürlich ist das alles nur Notation, es sei denn, Sie bieten eine Möglichkeit, diese Frage zu beantworten, und der Zauber der Infinitesimalrechnung besteht darin, dass sie zumindest normalerweise genau das bietet.",
+  "translatedText": "Natürlich ist das alles nur Notation, es sei denn, Sie haben eine Möglichkeit, diese Frage zu beantworten, und der Zauber der Infinitesimalrechnung besteht darin, dass sie zumindest meistens genau das bietet.",
   "time_range": [
    272.38,
    280.38
@@ -380,7 +380,7 @@
  {
   "input": "You see, usually the procedure here would be to find some function whose derivative is equal to the stuff we have on the inside, e to the negative x squared.",
   "model": "nmt",
-  "translatedText": "Normalerweise besteht das Verfahren hier darin, eine Funktion zu finden, deren Ableitung gleich dem Inhalt ist, den wir im Inneren haben, also e dem negativen x im Quadrat.",
+  "translatedText": "Normalerweise besteht das Verfahren hier darin, eine Funktion zu finden, deren Ableitung gleich dem Ausdruck zwischen Integralzeichen und dx ist, also e hoch minus x Quadrat.",
   "time_range": [
    280.86,
    288.56
@@ -407,7 +407,7 @@
  {
   "input": "It's a little weird and beyond the scope of what I want to talk about here, but basically, even though there exists an antiderivative, it is a well-defined function, you cannot express what that antiderivative is using all our usual tools, like polynomial expressions, trig functions, exponentials, or any way to mix them together.",
   "model": "nmt",
-  "translatedText": "Es ist ein wenig seltsam und würde den Rahmen dessen sprengen, worüber ich hier sprechen möchte, aber grundsätzlich handelt es sich, auch wenn es eine Stammfunktion gibt, um eine wohldefinierte Funktion, und Sie können nicht mit allen unseren üblichen Werkzeugen, wie z. B. einem Polynom, ausdrücken, was diese Stammfunktion ist Ausdrücke, trigonometrische Funktionen, Exponentialfunktionen oder jede andere Möglichkeit, sie miteinander zu kombinieren.",
+  "translatedText": "Es ist ein wenig kompliziert und würde den Rahmen dieses Videos sprengen, aber kurz gesagt: auch wenn es zu e hoch minus x Quadrat eine wohldefinierte Stammfunktion gibt, kann man diese Stammfunktion nicht mit allen unseren üblichen Werkzeugen, wie z. B. Polynomen, trigonometrischen Funktionen, Exponentialfunktionen oder beliebigen Kombinationen davon ausdrücken.",
   "time_range": [
    298.74,
    314.66
@@ -416,7 +416,7 @@
  {
   "input": "So finding this area requires a bit of cleverness.",
   "model": "nmt",
-  "translatedText": "Es erfordert also ein wenig Geschick, diesen Bereich zu finden.",
+  "translatedText": "Es erfordert also ein wenig Geschick, die Fläche unter e hoch minus x Quadrat zu finden.",
   "time_range": [
    315.26,
    317.52
@@ -452,7 +452,7 @@
  {
   "input": "You could rightly ask, why would you do that?",
   "model": "nmt",
-  "translatedText": "Man könnte sich zu Recht fragen: Warum sollten Sie das tun?",
+  "translatedText": "Man könnte sich zu Recht fragen: Warum sollten wir das tun?",
   "time_range": [
    332.36,
    334.34
@@ -470,7 +470,7 @@
  {
   "input": "And I'll admit, it's not terribly motivated right now, other than to say, watch what happens when we just try it.",
   "model": "nmt",
-  "translatedText": "Und ich gebe zu, es ist im Moment nicht besonders motiviert, außer zu sagen: Beobachten Sie, was passiert, wenn wir es einfach versuchen.",
+  "translatedText": "Und ich gebe zu, das ist im Moment nicht besonders gut begründet. Ich kann nur sagen: Beobachten Sie, was passiert, wenn wir es einfach versuchen.",
   "time_range": [
    336.32,
    341.24
@@ -479,7 +479,7 @@
  {
   "input": "And in general, with hard problems, it's never a bad idea to try solving cousins of the problem, since that can help you get a little bit of momentum and insight.",
   "model": "nmt",
-  "translatedText": "Und im Allgemeinen ist es bei schwierigen Problemen nie eine schlechte Idee, zu versuchen, Verwandte des Problems zu lösen, da Ihnen das dabei helfen kann, ein wenig Schwung und Einsicht zu erlangen.",
+  "translatedText": "Und im Allgemeinen ist es bei schwierigen Problemen nie eine schlechte Idee, zu versuchen, ein verwandtes Problem zu lösen, da Ihnen das dabei helfen kann, ein wenig Schwung und Einsicht zu erlangen.",
   "time_range": [
    341.24,
    348.64
@@ -488,7 +488,7 @@
  {
   "input": "To be clear on how this higher dimensional function is defined, it takes in two different inputs, x and y, which we might think of as a point on the xy-plane.",
   "model": "nmt",
-  "translatedText": "Um klarzustellen, wie diese höherdimensionale Funktion definiert ist, nimmt sie zwei verschiedene Eingaben auf, x und y, die wir uns als Punkt auf der xy-Ebene vorstellen könnten.",
+  "translatedText": "Diese höherdimensionale Funktion ist wie folgt definiert: Sie nimmt zwei verschiedene Eingaben auf, x und y, die wir uns als Punkt auf der xy-Ebene vorstellen können.",
   "time_range": [
    349.56,
    357.12
@@ -497,7 +497,7 @@
  {
   "input": "And the way to think about it is to consider the distance from that point to the origin, which I'll label as r, and then to plug in that distance to our original bell curve function, we take e to the negative r squared.",
   "model": "nmt",
-  "translatedText": "Und die Art und Weise, darüber nachzudenken, besteht darin, den Abstand von diesem Punkt zum Ursprung zu betrachten, den ich als r bezeichne, und diesen Abstand dann in unsere ursprüngliche Glockenkurvenfunktion einzubinden, indem wir e zum negativen r-Quadrat setzen.",
+  "translatedText": "Betrachten wir den Abstand r von diesem Punkt zum Ursprung. Diesen Abstand setzen wir dann in unsere ursprüngliche Glockenkurvenfunktion einzubinden, indem wir sie als e hoch minus r Quadrat schreiben.",
   "time_range": [
    357.46,
    368.42
@@ -515,7 +515,7 @@
  {
   "input": "So by the Pythagorean theorem, x squared plus y squared equals r squared.",
   "model": "nmt",
-  "translatedText": "Nach dem Satz des Pythagoras ist x im Quadrat plus y im Quadrat gleich r im Quadrat.",
+  "translatedText": "Nach dem Satz des Pythagoras ist x Quadrat plus y Quadrat gleich r Quadrat.",
   "time_range": [
    372.82,
    376.14
@@ -524,7 +524,7 @@
  {
   "input": "So in the function I have written, where you see x squared plus y squared, you can think in the back of your mind, that's really the square of the distance from the point to the origin.",
   "model": "nmt",
-  "translatedText": "In der Funktion, die ich geschrieben habe, wo Sie x zum Quadrat plus y zum Quadrat sehen, können Sie im Hinterkopf denken, dass das in Wirklichkeit das Quadrat der Entfernung vom Punkt zum Ursprung ist.",
+  "translatedText": "In der höherdimensionalen Glockenfunktion können Sie sich mitdenken, dass, wo immer Sie x Quadrat plus y Quadrat sehen, in Wirklichkeit das Quadrat der Entfernung vom Punkt zum Ursprung gemeint ist.",
   "time_range": [
    376.8,
    384.46
@@ -551,7 +551,7 @@
  {
   "input": "Math tends to reward you when you respect its symmetries, so for our question of computing the volume underneath this surface, what we're going to do is respect that symmetry, and imagine integrating together a bunch of thin little cylinders underneath that surface.",
   "model": "nmt",
-  "translatedText": "Mathe belohnt Sie tendenziell, wenn Sie ihre Symmetrien respektieren. Für unsere Frage der Berechnung des Volumens unter dieser Oberfläche werden wir also diese Symmetrie respektieren und uns vorstellen, wie wir eine Reihe dünner kleiner Zylinder unter dieser Oberfläche zusammenfügen.",
+  "translatedText": "In der Mathematik ist es oft hilfreich, wenn Sie auf solche Symmetrien achten. Für unsere Frage der Berechnung des Volumens unter dieser Oberfläche werden wir also diese Symmetrie nutzen und uns vorstellen, wie wir eine Reihe dünner kleiner Zylinder unter dieser Oberfläche zusammenfügen.",
   "time_range": [
    400.48,
    413.48
@@ -560,7 +560,7 @@
  {
   "input": "Here, making this a little more quantitative, let's focus on just one of those cylindrical shells, where its area is going to be the circumference of that shell times the height.",
   "model": "nmt",
-  "translatedText": "Um dies etwas quantitativer zu gestalten, konzentrieren wir uns hier nur auf eine dieser zylindrischen Schalen, deren Fläche dem Umfang dieser Schale mal der Höhe entspricht.",
+  "translatedText": "Um einer Berechnung näher zu kommen, konzentrieren wir uns hier nur auf eine dieser zylindrischen Schalen, deren Fläche dem Umfang dieser Schale mal der Höhe entspricht.",
   "time_range": [
    414.38,
    423.1
@@ -569,7 +569,7 @@
  {
   "input": "You might imagine it as something like the label on a soup can that we can unwrap into a rectangle.",
   "model": "nmt",
-  "translatedText": "Man könnte es sich wie das Etikett einer Suppendose vorstellen, die wir zu einem Rechteck auspacken können.",
+  "translatedText": "Man könnte es sich wie das Etikett einer Suppendose vorstellen, das wir zu einem Rechteck ausrollen können.",
   "time_range": [
    423.5,
    428.1
@@ -587,7 +587,7 @@
  {
   "input": "And then the height of our cylinder, the other side of our rectangle, is the height of the surface at this point, which by definition is the value of our function associated with that radius, which like I said earlier you can think of as e to the negative r squared.",
   "model": "nmt",
-  "translatedText": "Und dann ist die Höhe unseres Zylinders, die andere Seite unseres Rechtecks, die Höhe der Oberfläche an diesem Punkt, was per Definition der Wert unserer Funktion ist, die diesem Radius zugeordnet ist, den Sie sich, wie ich bereits sagte, als e vorstellen können zum negativen r im Quadrat.",
+  "translatedText": "Und die Höhe unseres Zylinders, die andere Seite unseres Rechtecks, ist gleich der Höhe der Oberfläche an diesem Punkt, was per Definition der Wert unserer Funktion ist, die diesem Radius zugeordnet ist, den Sie sich, wie ich bereits sagte, als e hoch minus r Quadrat vorstellen können.",
   "time_range": [
    435.16,
    447.7
@@ -596,7 +596,7 @@
  {
   "input": "The real way you want to think about this is to give that cylinder a little bit of thickness, which we'll call dr, so that the volume that it represents is approximately that area we just looked at multiplied by this thickness dr.",
   "model": "nmt",
-  "translatedText": "Die eigentliche Art und Weise, wie Sie darüber nachdenken möchten, besteht darin, diesem Zylinder eine kleine Dicke zu geben, die wir dr nennen, sodass das Volumen, das er darstellt, ungefähr der Fläche entspricht, die wir gerade betrachtet haben, multipliziert mit dieser Dicke dr.",
+  "translatedText": "Weiterhin müssen wir uns diesen Zylinder mit einer kleinen Dicke denken, die wir dr nennen, sodass das Volumen, das er darstellt, ungefähr der Fläche entspricht, die wir gerade betrachtet haben, multipliziert mit dieser Dicke dr.",
   "time_range": [
    447.7,
    460.98
@@ -641,7 +641,7 @@
  {
   "input": "First let me clean up a little by factoring the pi outside that integral.",
   "model": "nmt",
-  "translatedText": "Lassen Sie mich zunächst ein wenig aufräumen, indem ich den Pi außerhalb dieses Integrals faktorisiere.",
+  "translatedText": "Lassen Sie mich zunächst ein wenig aufräumen, indem ich den Pi als Faktor außerhalb dieses Integrals schreibe.",
   "time_range": [
    491.14,
    494.0
@@ -650,7 +650,7 @@
  {
   "input": "Now the stuff inside that integral, having picked up this term 2r, does have an antiderivative.",
   "model": "nmt",
-  "translatedText": "Nun hat der Inhalt dieses Integrals, nachdem er diesen Term 2r aufgegriffen hat, tatsächlich eine Stammfunktion.",
+  "translatedText": "Nun hat der Inhalt dieses Integrals, nachdem er mit dem Term 2r geschrieben wird, tatsächlich eine Stammfunktion.",
   "time_range": [
    494.56,
    500.54
@@ -659,7 +659,7 @@
  {
   "input": "We can now apply the usual tactics of calculus.",
   "model": "nmt",
-  "translatedText": "Wir können nun die üblichen Taktiken der Infinitesimalrechnung anwenden.",
+  "translatedText": "Wir können nun die üblichen Techniken der Infinitesimalrechnung anwenden.",
   "time_range": [
    500.74,
    502.98
@@ -668,7 +668,7 @@
  {
   "input": "Specifically, that whole inside expression is the derivative of negative e to the negative r squared.",
   "model": "nmt",
-  "translatedText": "Insbesondere ist dieser gesamte innere Ausdruck die Ableitung des negativen e zum negativen r im Quadrat.",
+  "translatedText": "Insbesondere ist dieser gesamte innere Ausdruck die Ableitung von minus e hoch minus r Quadrat.",
   "time_range": [
    503.64000000000004,
    509.34
@@ -677,7 +677,7 @@
  {
   "input": "And so, those of you comfortable with calculus know what to do from here.",
   "model": "nmt",
-  "translatedText": "Und so wissen diejenigen unter Ihnen, die sich mit Infinitesimalrechnung auskennen, was von hier aus zu tun ist.",
+  "translatedText": "Und so wissen diejenigen unter Ihnen, die sich mit Infinitesimalrechnung auskennen, was jetzt zu tun ist.",
   "time_range": [
    510.16,
    513.14
@@ -686,7 +686,7 @@
  {
   "input": "We take that antiderivative and plug in the upper bound, which is negative infinity squared, and that gives us 0, or speaking a little bit more precisely, if you consider the limit of this expression as the input approaches infinity, the limiting value is 0, and we subtract off the value of that antiderivative at the lower bound, 0, which in this case is negative 1.",
   "model": "nmt",
-  "translatedText": "Wir nehmen diese Stammfunktion und setzen die Obergrenze ein, die negativ unendlich im Quadrat ist, und das ergibt 0, oder etwas genauer ausgedrückt: Wenn Sie die Grenze dieses Ausdrucks betrachten, wenn sich die Eingabe der Unendlichkeit nähert, ist der Grenzwert 0 , und wir subtrahieren den Wert dieser Stammfunktion an der Untergrenze, 0, die in diesem Fall negativ 1 ist.",
+  "translatedText": "Wir nehmen diese Stammfunktion und setzen die Obergrenze ein, also minus unendlich zum Quadrat, und erhalten 0, oder etwas genauer ausgedrückt: Wenn Sie die Grenze dieses Ausdrucks betrachten, wenn sich die Eingabe der Unendlichkeit nähert, ist der Grenzwert 0 , und wir subtrahieren davon den Wert dieser Stammfunktion an der Untergrenze, 0, die in diesem Fall minus 1 ist.",
   "time_range": [
    513.38,
    532.5
@@ -695,7 +695,7 @@
  {
   "input": "So all in all, the whole integral just works out to be 1, which means all we're left with is that factor out in front, pi.",
   "model": "nmt",
-  "translatedText": "Alles in allem ergibt sich also für das gesamte Integral der Wert 1, was bedeutet, dass uns nur noch der Faktor Pi übrig bleibt.",
+  "translatedText": "Letztlich ergibt sich also für das gesamte Integral der Wert 1, was bedeutet, dass uns nur noch der Faktor Pi übrig bleibt.",
   "time_range": [
    532.98,
    539.0
@@ -749,7 +749,7 @@
  {
   "input": "You see, the more general way to approach volumes underneath surfaces is to think of chopping it up into slices that are all parallel to one of the axes.",
   "model": "nmt",
-  "translatedText": "Sie sehen, die allgemeinere Art, sich Volumina unter Oberflächen zu nähern, besteht darin, sie in Scheiben zu zerlegen, die alle parallel zu einer der Achsen sind.",
+  "translatedText": "Sie sehen, die allgemeinere Art, Volumina unter Oberflächen zu bestimmen, besteht darin, sie in Scheiben zu zerlegen, die alle parallel zu einer der Achsen sind.",
   "time_range": [
    571.4,
    578.88
@@ -776,7 +776,7 @@
  {
   "input": "You might notice it looks just like a bell curve, and if we write out the function, this should actually make a lot of sense.",
   "model": "nmt",
-  "translatedText": "Sie werden vielleicht bemerken, dass es wie eine Glockenkurve aussieht, und wenn wir die Funktion ausschreiben, sollte dies tatsächlich sehr viel Sinn ergeben.",
+  "translatedText": "Sie werden vielleicht bemerken, dass er wie eine Glockenkurve aussieht, und wenn wir die Funktion ausschreiben, sollte dies tatsächlich sehr viel Sinn ergeben.",
   "time_range": [
    588.34,
    593.76
@@ -785,7 +785,7 @@
  {
   "input": "You could just plug in y equals 0, but to help see what happens with other slices, notice how, thanks to the rules of exponentiation, we could also write our function as e to the negative x squared times e to the negative y squared.",
   "model": "nmt",
-  "translatedText": "Sie könnten einfach y gleich 0 einsetzen, aber um zu sehen, was mit anderen Slices passiert, beachten Sie, dass wir dank der Potenzierungsregeln unsere Funktion auch als e zum negativen x zum Quadrat mal e zum negativen y zum Quadrat schreiben könnten.",
+  "translatedText": "Sie könnten einfach y gleich 0 einsetzen, aber um zu sehen, was mit anderen Schnitten passiert, beachten Sie, dass wir dank der Potenz-Rechenregeln unsere Funktion auch als e hoch minus x Quadrat mal e hoch minus y Quadrat schreiben könnten.",
   "time_range": [
    593.98,
    605.08
@@ -794,7 +794,7 @@
  {
   "input": "It factors out nicely.",
   "model": "nmt",
-  "translatedText": "Es kommt gut zur Geltung.",
+  "translatedText": "Das lässt sich gut in Faktoren zerlegen.",
   "time_range": [
    605.16,
    606.48
@@ -803,7 +803,7 @@
  {
   "input": "On this slice, that e to the negative y squared is just a number, specifically the number 1.",
   "model": "nmt",
-  "translatedText": "Auf diesem Ausschnitt ist das e zum negativen y im Quadrat nur eine Zahl, insbesondere die Zahl 1.",
+  "translatedText": "Bei diesem Schnitt ist das e hoch minus y Quadrat nur eine Zahl, nämlich 1.",
   "time_range": [
    607.28,
    612.28
@@ -812,7 +812,7 @@
  {
   "input": "So this is the same graph we've seen before, e to the negative x squared, meaning that the area of this slice is exactly the thing that we're looking for.",
   "model": "nmt",
-  "translatedText": "Das ist also derselbe Graph, den wir zuvor gesehen haben, e hoch zum negativen x im Quadrat, was bedeutet, dass die Fläche dieses Segments genau das ist, was wir suchen.",
+  "translatedText": "Das ist also derselbe Graph, den wir zuvor gesehen haben, e hoch minus x Quadrat, was bedeutet, dass die Fläche dieses Schnittes genau das ist, was wir suchen.",
   "time_range": [
    612.84,
    620.08
@@ -830,7 +830,7 @@
  {
   "input": "What's nice is there's nothing really special about this particular slice.",
   "model": "nmt",
-  "translatedText": "Das Schöne ist, dass dieses spezielle Stück nichts wirklich Besonderes ist.",
+  "translatedText": "Das Schöne ist, dass dieser spezielle Schnitt nichts wirklich Besonderes ist.",
   "time_range": [
    623.98,
    627.1
@@ -839,7 +839,7 @@
  {
   "input": "If we chose a different slice corresponding to a different y value, it corresponds to multiplying this curve by a different number.",
   "model": "nmt",
-  "translatedText": "Wenn wir ein anderes Segment auswählen, das einem anderen y-Wert entspricht, entspricht dies der Multiplikation dieser Kurve mit einer anderen Zahl.",
+  "translatedText": "Wenn wir einen anderen Schnitt wählen, der einem anderen y-Wert entspricht, entspricht dies der Multiplikation dieser Kurve mit einer anderen Zahl.",
   "time_range": [
    627.64,
    634.08
@@ -857,7 +857,7 @@
  {
   "input": "That's pretty cool.",
   "model": "nmt",
-  "translatedText": "Das ist ziemlich toll.",
+  "translatedText": "Das ist ziemlich cool.",
   "time_range": [
    642.54,
    643.72
@@ -884,7 +884,7 @@
  {
   "input": "Now, to think about the volume underneath this whole surface, here's another way we could phrase it.",
   "model": "nmt",
-  "translatedText": "Nun, um über das Volumen unter dieser gesamten Oberfläche nachzudenken, können wir es anders ausdrücken.",
+  "translatedText": "Das Volumen unter dieser gesamten Oberfläche können wir jetzt auch anders ausdrücken.",
   "time_range": [
    662.04,
    666.76
@@ -893,7 +893,7 @@
  {
   "input": "We're going to compute another integral that ranges from y equals negative infinity up to infinity, where the term inside that integral tells us the area of each one of those slices.",
   "model": "nmt",
-  "translatedText": "Wir werden ein weiteres Integral berechnen, das von y gleich minus Unendlich bis unendlich reicht, wobei der Term innerhalb dieses Integrals uns die Fläche jedes einzelnen dieser Abschnitte angibt.",
+  "translatedText": "Wir werden ein weiteres Integral berechnen, das von y gleich minus Unendlich bis unendlich reicht, wobei der Term innerhalb dieses Integrals uns die Fläche jedes einzelnen dieser Schnitte angibt.",
   "time_range": [
    666.96,
    676.14
@@ -902,7 +902,7 @@
  {
   "input": "And when we multiply it by a little thickness dy, you might think of it as giving each one of those slices a little bit of volume.",
   "model": "nmt",
-  "translatedText": "Und wenn wir es mit etwas Dicke dy multiplizieren, könnte man sich das so vorstellen, als würde man jeder dieser Scheiben ein wenig Volumen verleihen.",
+  "translatedText": "Und wenn wir die Fläche mit einer kleinen Dicke dy multiplizieren, könnte man sich das so vorstellen, als würde man jeder dieser Scheiben ein wenig Volumen verleihen.",
   "time_range": [
    676.78,
    682.7
@@ -911,7 +911,7 @@
  {
   "input": "And remember, that term c sitting in front represents the thing we want to know, which itself is an integral, a suspiciously similar-looking integral.",
   "model": "nmt",
-  "translatedText": "Und denken Sie daran, dass der Begriff c, der vorne steht, das darstellt, was wir wissen wollen, was selbst ein Integral ist, ein verdächtig ähnlich aussehendes Integral.",
+  "translatedText": "Und denken Sie daran, dass der Faktor c selbst für den zu ermittelnden Wert eines Integrals steht, eines verdächtig ähnlich aussehenden Integrals.",
   "time_range": [
    683.18,
    691.84
@@ -920,7 +920,7 @@
  {
   "input": "See, if we take the expression on the top and we factor out that constant c, because it's just a number, it doesn't depend on y, the thing we're left with, the integral we need to compute, is exactly the mystery constant, the thing we don't know.",
   "model": "nmt",
-  "translatedText": "Sehen Sie, wenn wir den Ausdruck oben nehmen und die Konstante c herausrechnen, weil sie nur eine Zahl ist und nicht von y abhängt, bleibt uns genau das Integral, das wir berechnen müssen Geheimniskonstante, das, was wir nicht wissen.",
+  "translatedText": "Sehen Sie, wenn wir den Ausdruck oben nehmen und die Konstante c als Faktor herausziehen, weil sie nur eine Zahl ist und nicht von y abhängt, dann ist das Integral, dessen Wert wir bestimmen wollen, gerade gleich der Mystery-Konstante, die wir nicht kennen.",
   "time_range": [
    692.58,
    704.84
@@ -938,7 +938,7 @@
  {
   "input": "Out of context, this might seem very unhelpful, it's just relating one thing we don't know to another thing we don't know, except we've already computed the volume under this surface, we know that it's equal to pi.",
   "model": "nmt",
-  "translatedText": "Außerhalb des Zusammenhangs mag das sehr wenig hilfreich erscheinen, es geht lediglich darum, eine Sache, die wir nicht wissen, mit einer anderen Sache in Beziehung zu setzen, die wir nicht kennen, außer dass wir das Volumen unter dieser Oberfläche bereits berechnet haben und wissen, dass es gleich Pi ist.",
+  "translatedText": "Außerhalb des Zusammenhangs mag das sehr wenig hilfreich erscheinen, es geht lediglich darum, eine Sache, die wir nicht wissen, mit einer anderen Sache in Beziehung zu setzen, die wir nicht kennen. Aber wir haben das Volumen unter dieser Oberfläche bereits berechnet, dass es gleich Pi ist.",
   "time_range": [
    712.46,
    722.3
@@ -947,7 +947,7 @@
  {
   "input": "Therefore, the mystery constant we want to know, the area underneath this bell curve, must be the square root of pi.",
   "model": "nmt",
-  "translatedText": "Deshalb muss die mysteriöse Konstante, die wir wissen wollen, die Fläche unter dieser Glockenkurve, die Quadratwurzel von Pi sein.",
+  "translatedText": "Deshalb muss die mysteriöse Konstante, deren Wert wir wissen wollen, die Fläche unter dieser Glockenkurve, gleich der Quadratwurzel von Pi sein.",
   "time_range": [
    723.06,
    728.82
@@ -965,7 +965,7 @@
  {
   "input": "For one thing, it feels a little bit like a trick, something that just happened to work, without offering much of a sense for how you could have rediscovered it yourself.",
   "model": "nmt",
-  "translatedText": "Zum einen fühlt es sich ein wenig wie ein Trick an, etwas, das zufällig funktioniert hat, ohne dass man einen Eindruck davon vermittelt, wie man es selbst hätte wiederentdecken können.",
+  "translatedText": "Zum einen fühlt es sich ein wenig wie ein Trick an, etwas, das zufällig funktioniert hat, ohne dass man einen Eindruck davon vermittelt, wie man es selbst hätte entdecken können.",
   "time_range": [
    734.86,
    742.8
@@ -974,7 +974,7 @@
  {
   "input": "Also, if we think back to our imagined statistician's friend, it doesn't really answer their question, which was what do circles have to do with population statistics?",
   "model": "nmt",
-  "translatedText": "Wenn wir außerdem an den Freund unseres imaginären Statistikers zurückdenken, beantwortet das nicht wirklich seine Frage: „Was haben Kreise mit Bevölkerungsstatistiken zu tun?",
+  "translatedText": "Wenn wir außerdem an den Freund unseres imaginären Statistikers zurückdenken, beantwortet das nicht wirklich seine Frage: „Was haben Kreise mit Bevölkerungsstatistiken zu tun?“",
   "time_range": [
    743.42,
    751.8
@@ -983,7 +983,7 @@
  {
   "input": "Like I said, it's the first step, not the last, and as our next step, let's see if we can unpack why this proof is not quite as wild and arbitrary as you might first think, and how it relates to an explanation for where this function e to the negative x squared is coming from in the first place.",
   "model": "nmt",
-  "translatedText": "“ Wie gesagt, es ist der erste Schritt, nicht der letzte, und als nächstes wollen wir herausfinden, warum dieser Beweis nicht ganz so wild und willkürlich ist, wie Sie vielleicht zunächst denken, und wie er mit einer Erklärung für das Wo zusammenhängt Diese Funktion e zum negativen x im Quadrat kommt überhaupt erst zustande.",
+  "translatedText": "“ Wie gesagt war der erste Schritt, nicht der letzte, und als nächstes wollen wir herausfinden, warum dieser Beweis nicht ganz so wild und willkürlich ist, wie Sie vielleicht zunächst denken, und wie er mit dem Ursprung der Funktion e hoch minus x Quadrat zusammenhängt.",
   "time_range": [
    752.54,
    766.6
@@ -992,7 +992,7 @@
  {
   "input": "John Herschel was this mathematician slash scientist slash inventor who really did all sorts of things throughout the 19th century.",
   "model": "nmt",
-  "translatedText": "John Herschel war dieser Mathematiker, Wissenschaftler und Erfinder, der im 19. Jahrhundert wirklich alles Mögliche tat.",
+  "translatedText": "John Herschel war ein Mathematiker, Wissenschaftler und Erfinder, der im 19. Jahrhundert wirklich an vielen verschiedenen Themen arbeitete.",
   "time_range": [
    771.66,
    779.06
@@ -1001,7 +1001,7 @@
  {
   "input": "He made contributions in chemistry, astronomy, photography, botany, he invented the blueprint and named many of the moons in our solar system, and in the midst of all of this, he also offered a very elegant little derivation for the Gaussian distribution in 1850.",
   "model": "nmt",
-  "translatedText": "Er leistete Beiträge in den Bereichen Chemie, Astronomie, Fotografie und Botanik, er erfand den Bauplan und benannte viele der Monde in unserem Sonnensystem, und inmitten all dessen bot er 1850 auch eine sehr elegante kleine Ableitung für die Gaußsche Verteilung an.",
+  "translatedText": "Er leistete Beiträge in den Bereichen Chemie, Astronomie, Fotografie und Botanik, er erfand die Technik der Blaupause und benannte viele der Monde in unserem Sonnensystem, und inmitten all dessen bot er 1850 auch eine sehr elegante kleine Ableitung für die Gaußsche Verteilung an.",
   "time_range": [
    779.4,
    793.66
@@ -1010,7 +1010,7 @@
  {
   "input": "The setup is to imagine that you want to describe some kind of probability distribution in two-dimensional space.",
   "model": "nmt",
-  "translatedText": "Der Aufbau besteht darin, sich vorzustellen, dass Sie eine Art Wahrscheinlichkeitsverteilung im zweidimensionalen Raum beschreiben möchten.",
+  "translatedText": "Stellen Sie sich vor, dass Sie eine Art Wahrscheinlichkeitsverteilung im zweidimensionalen Raum beschreiben möchten.",
   "time_range": [
    795.0,
    800.08
@@ -1028,7 +1028,7 @@
  {
   "input": "What Herschel showed is that if you want this distribution to satisfy two pretty reasonable seeming properties, your hand is unexpectedly forced, and even if you had never heard of a Gaussian in your life, you would be inexorably drawn to use a function with the shape e to the negative x squared plus y squared.",
   "model": "nmt",
-  "translatedText": "Was Herschel gezeigt hat, ist, dass Sie, wenn Sie möchten, dass diese Verteilung zwei recht vernünftig erscheinende Eigenschaften erfüllt, unerwartet gezwungen sind, und selbst wenn Sie noch nie in Ihrem Leben von einer Gaußschen Verteilung gehört hätten, würden Sie unweigerlich dazu tendieren, eine Funktion mit der Form zu verwenden e zum negativen x-Quadrat plus y-Quadrat.",
+  "translatedText": "Herschel hat folgendes gezeigt: Wenn Sie möchten, dass diese Verteilung zwei recht vernünftig erscheinende Eigenschaften erfüllt, dann sind Sie unerwartet gezwungen, eine Funktion mit der Form e hoch x-Quadrat plus y-Quadrat zu verwenden, selbst wenn Sie noch nie in Ihrem Leben von einer Gaußschen Verteilung gehört hätten.",
   "time_range": [
    805.06,
    820.56
@@ -1037,7 +1037,7 @@
  {
   "input": "You do have one degree of freedom to control the spread of that distribution, and of course there's going to be some constant sitting in front to make sure it's normalized, but the point is that we're forced into this very specific kind of bell curve shape.",
   "model": "nmt",
-  "translatedText": "Sie haben einen Freiheitsgrad, um die Ausbreitung dieser Verteilung zu steuern, und natürlich wird es eine ständige Überwachung geben, um sicherzustellen, dass sie normalisiert wird, aber der Punkt ist, dass wir in diese ganz bestimmte Art von Glockenkurve gezwungen werden Form.",
+  "translatedText": "Sie haben einen Freiheitsgrad, um die Breite dieser Verteilung zu steuern, und natürlich wird es einen konstanten Faktor geben, um sicherzustellen, dass die Dichtefunktion normalisiert ist. Aber der Punkt ist, dass wir in diese ganz bestimmte Art von Glockenkurve gezwungen werden.",
   "time_range": [
    821.14,
    832.62
@@ -1064,7 +1064,7 @@
  {
   "input": "Mathematically, this means that the function describing your probability distribution, which I'll call f2 since it takes in two inputs x and y, well it can be expressed as some single variable function of the radius r.",
   "model": "nmt",
-  "translatedText": "Mathematisch bedeutet dies, dass die Funktion, die Ihre Wahrscheinlichkeitsverteilung beschreibt, die ich f2 nenne, da sie zwei Eingaben x und y berücksichtigt, nun, sie kann als eine einzelne variable Funktion des Radius r ausgedrückt werden.",
+  "translatedText": "Mathematisch bedeutet dies, dass die Funktion, die Ihre Wahrscheinlichkeitsverteilung beschreibt, die ich f2 nenne, da sie zwei Eingaben x und y berücksichtigt, auch als Funktion mit nur einer Variable, nämlich dem Radius r ausgedrückt werden kann.",
   "time_range": [
    852.72,
    864.62
@@ -1073,7 +1073,7 @@
  {
   "input": "And just to spell it out, r is the distance between the point xy and the origin, the square root of x squared plus y squared.",
   "model": "nmt",
-  "translatedText": "Und um es mal deutlich auszudrücken: r ist der Abstand zwischen dem Punkt xy und dem Ursprung, die Quadratwurzel aus x im Quadrat plus y im Quadrat.",
+  "translatedText": "Und um es deutlich auszudrücken: r ist der Abstand zwischen dem Punkt xy und dem Ursprung, die Quadratwurzel aus x Quadrat plus y Quadrat.",
   "time_range": [
    865.28,
    871.82
@@ -1082,7 +1082,7 @@
  {
   "input": "Property number two is that the x and y coordinates of each point are independent from each other, which is to say if you learn the x coordinate of a point, it would give you no information about the y coordinate.",
   "model": "nmt",
-  "translatedText": "Eigenschaft Nummer zwei ist, dass die x- und y-Koordinaten jedes Punkts unabhängig voneinander sind. Das heißt, wenn Sie die x-Koordinate eines Punktes lernen, erhalten Sie keine Informationen über die y-Koordinate.",
+  "translatedText": "Eigenschaft Nummer zwei ist, dass die x- und y-Koordinaten jedes Punkts unabhängig voneinander sind. Das heißt, wenn Sie die x-Koordinate eines Punktes kennen, erhalten Sie daraus keine Informationen über die y-Koordinate.",
   "time_range": [
    873.1,
    883.62
@@ -1091,7 +1091,7 @@
  {
   "input": "The way this looks as an equation is that our function, which describes the probability density around each point on the xy plane, can be factored into two different parts, one of which can be purely written in terms of x, this is the distribution of the x coordinate, I'm giving it the name g, and the other part is purely in terms of y, this would be the distribution for the y coordinate, which I'm temporarily calling h.",
   "model": "nmt",
-  "translatedText": "Als Gleichung sieht dies so aus, dass unsere Funktion, die die Wahrscheinlichkeitsdichte um jeden Punkt auf der xy-Ebene beschreibt, in zwei verschiedene Teile zerlegt werden kann, von denen einer rein in Bezug auf x geschrieben werden kann, dies ist die Verteilung von die x-Koordinate, ich nenne sie g, und der andere Teil bezieht sich rein auf y, das wäre die Verteilung für die y-Koordinate, die ich vorübergehend h nenne.",
+  "translatedText": "Als Gleichung sieht dies so aus, dass unsere Funktion, die die Wahrscheinlichkeitsdichte um jeden Punkt auf der xy-Ebene beschreibt, in zwei verschiedene Teile zerlegt werden kann. Einer dieser Teile kann rein in Bezug auf x geschrieben werden, dies ist die Verteilung der x-Koordinate, ich nenne sie g. Der andere Teil bezieht sich rein auf y, das wäre die Verteilung für die y-Koordinate, die ich vorübergehend h nenne.",
   "time_range": [
    885.1,
    906.0
@@ -1154,7 +1154,7 @@
  {
   "input": "So these functions f and g are basically the same thing, just up to some constant multiple.",
   "model": "nmt",
-  "translatedText": "Diese Funktionen f und g sind also im Grunde dasselbe, nur bis auf ein konstantes Vielfaches.",
+  "translatedText": "Diese Funktionen f und g sind also im Grunde dasselbe, abgesehen von einer multiplikativen Konstante.",
   "time_range": [
    943.12,
    947.5
@@ -1163,7 +1163,7 @@
  {
   "input": "And you know what?",
   "model": "nmt",
-  "translatedText": "Und weisst du was?",
+  "translatedText": "Und wissen Sie was?",
   "time_range": [
    948.9,
    949.84
@@ -1181,7 +1181,7 @@
  {
   "input": "And what I'm going to do, which might feel a little bit cheeky, is just assume that that is the case.",
   "model": "nmt",
-  "translatedText": "Und ich werde einfach annehmen, dass das der Fall ist, was sich vielleicht etwas frech anfühlt.",
+  "translatedText": "Und ich werde einfach annehmen, dass das der Fall ist, was sich vielleicht etwas vorschnell anfühlt.",
   "time_range": [
    956.7,
    961.6
@@ -1208,7 +1208,7 @@
  {
   "input": "But that's no big deal, because in the end we can just rescale to make sure the area under the curve is one, like we always do with probability distributions.",
   "model": "nmt",
-  "translatedText": "Aber das ist keine große Sache, denn am Ende können wir einfach neu skalieren, um sicherzustellen, dass die Fläche unter der Kurve eins ist, wie wir es immer mit Wahrscheinlichkeitsverteilungen tun.",
+  "translatedText": "Aber das ist keine großes Problem, denn am Ende können wir einfach neu skalieren, um sicherzustellen, dass die Fläche unter der Kurve eins ist, wie wir es immer mit Wahrscheinlichkeitsverteilungen tun.",
   "time_range": [
    969.84,
    976.96
@@ -1217,7 +1217,7 @@
  {
   "input": "Now, if f and g are the same thing, this gives us a very nice little equation purely in terms of the function f.",
   "model": "nmt",
-  "translatedText": "Wenn nun f und g dasselbe sind, erhalten wir eine sehr schöne kleine Gleichung, die nur die Funktion f betrifft.",
+  "translatedText": "Wenn nun f und g dasselbe sind, erhalten wir eine sehr schöne kleine Gleichung, die nur von der Funktion f abhängt.",
   "time_range": [
    977.52,
    983.84
@@ -1262,7 +1262,7 @@
  {
   "input": "But Herschel's two different properties evidently imply something kind of funny about it, which is that if we take the x and y coordinates of that point on the plane and evaluate this function on them separately, taking f of x times f of y, it should give us the same result.",
   "model": "nmt",
-  "translatedText": "Aber Herschels zwei unterschiedliche Eigenschaften implizieren offensichtlich etwas Komisches daran, nämlich dass, wenn wir die x- und y-Koordinaten dieses Punktes auf der Ebene nehmen und diese Funktion separat für sie auswerten, indem wir f von x mal f von y nehmen, dies der Fall sein sollte geben uns das gleiche Ergebnis.",
+  "translatedText": "Aber Herschels zwei unterschiedliche Eigenschaften implizieren etwas Bemerkenswertes: Wenn wir f für die x- und die y-Koordinate dieses Punktes separat bestimmen und f von x mal f von y ausrechnen, sollten wir das gleiche Ergebnis erhalten.",
   "time_range": [
    1001.66,
    1015.82
@@ -1271,7 +1271,7 @@
  {
   "input": "Or if you prefer, we could expand out the meaning of that distance r as the square root of x squared plus y squared, and this is what our key equation looks like.",
   "model": "nmt",
-  "translatedText": "Oder wenn Sie es vorziehen, könnten wir die Bedeutung dieses Abstands r als Quadratwurzel aus x zum Quadrat plus y zum Quadrat erweitern, und so sieht unsere Schlüsselgleichung aus.",
+  "translatedText": "Oder wir könnten die Bedeutung dieses Abstands r als Quadratwurzel aus x Quadrat plus y Quadrat explizit hinschreiben, und dann sieht unsere Schlüsselgleichung so aus.",
   "time_range": [
    1016.26,
    1024.18
@@ -1289,7 +1289,7 @@
  {
   "input": "We're not solving for an unknown number.",
   "model": "nmt",
-  "translatedText": "Wir lösen nicht nach einer unbekannten Zahl.",
+  "translatedText": "Wir ermitteln nicht eine unbekannte Zahl.",
   "time_range": [
    1028.98,
    1031.04
@@ -1307,7 +1307,7 @@
  {
   "input": "In the back of your mind, you can think we already know one function that satisfies this property, e to the negative x squared, and as a sanity check you might verify for yourself that it does satisfy that.",
   "model": "nmt",
-  "translatedText": "Im Hinterkopf können Sie denken, wir kennen bereits eine Funktion, die diese Eigenschaft erfüllt, nämlich e zum negativen x im Quadrat, und als Plausibilitätsprüfung könnten Sie selbst überprüfen, ob sie diese Eigenschaft erfüllt.",
+  "translatedText": "Sie wissen natürlich, dass wir bereits eine Funktion kennen, die diese Eigenschaft erfüllt, nämlich e hoch minus x im Quadrat, und als Plausibilitätsprüfung könnten Sie selbst überprüfen, ob sie diese Eigenschaft erfüllt.",
   "time_range": [
    1040.48,
    1050.38
@@ -1334,7 +1334,7 @@
  {
   "input": "First, it's nice to introduce a little helper function that I'll call h of x, which will be defined as our mystery function evaluated at the square root of x.",
   "model": "nmt",
-  "translatedText": "Zunächst ist es schön, eine kleine Hilfsfunktion vorzustellen, die ich h von x nenne und die als unsere Mystery-Funktion definiert wird, die an der Quadratwurzel von x ausgewertet wird.",
+  "translatedText": "Zunächst führen wir eine Hilfsfunktion ein, die ich h von x nenne und die als der Wert unserer Mystery-Funktion an der Stelle Quadratwurzel von x definiert wird.",
   "time_range": [
    1064.08,
    1071.96
@@ -1343,7 +1343,7 @@
  {
   "input": "Said another way, h of x squared is the same thing as f of x.",
   "model": "nmt",
-  "translatedText": "Anders ausgedrückt ist h von x im Quadrat dasselbe wie f von x.",
+  "translatedText": "Anders ausgedrückt ist h von x Quadrat dasselbe wie f von x.",
   "time_range": [
    1072.4,
    1076.02
@@ -1352,7 +1352,7 @@
  {
   "input": "For example, in the back of your mind where you know that e to the negative x squared will happen to be one of the answers, this little helper function h would be e to the negative x.",
   "model": "nmt",
-  "translatedText": "Wenn Sie beispielsweise im Hinterkopf wissen, dass e zum negativen x im Quadrat zufällig eine der Antworten sein wird, wäre diese kleine Hilfsfunktion h e zum negativen x.",
+  "translatedText": "Wenn Sie an unsere Funktion e hoch minus x Quadrat denken, die zufällig eine der Antworten sein wird, wäre diese Hilfsfunktion h gerade gleich e hoch minus x.",
   "time_range": [
    1076.7,
    1085.36
@@ -1379,7 +1379,7 @@
  {
   "input": "Because now what it's saying is if you take two arbitrary positive numbers and you add them up and evaluate h, it's the same thing as evaluating h on them separately and then multiplying the results.",
   "model": "nmt",
-  "translatedText": "Denn jetzt heißt es: Wenn man zwei beliebige positive Zahlen nimmt, sie addiert und h auswertet, ist das dasselbe, als würde man h für sie separat auswerten und dann die Ergebnisse multiplizieren.",
+  "translatedText": "Denn jetzt sagt unsere Gleichung folgendes aus: Wenn man zwei beliebige positive Zahlen nimmt, sie addiert und h bestimmt, ist das dasselbe, als würde man h für sie separat ausrechnen und dann die Ergebnisse multiplizieren.",
   "time_range": [
    1094.64,
    1104.56
@@ -1397,7 +1397,7 @@
  {
   "input": "Some of you might see where this is going, but let's take a moment to walk through why this forces our hand.",
   "model": "nmt",
-  "translatedText": "Einige von Ihnen verstehen vielleicht, wohin das führt, aber nehmen wir uns einen Moment Zeit, um herauszufinden, warum uns das zum Handeln zwingt.",
+  "translatedText": "Einige von Ihnen verstehen vielleicht, wohin das führt, aber nehmen wir uns einen Moment Zeit, um herauszufinden, warum das unseren Lösungsraum beschränkt.",
   "time_range": [
    1108.06,
    1112.94
@@ -1406,7 +1406,7 @@
  {
   "input": "As a next step, you might want to pause and convince yourself that if this property is true for the sum of two numbers, this property also must be true if we add up an arbitrary number of inputs.",
   "model": "nmt",
-  "translatedText": "Als nächsten Schritt möchten Sie vielleicht innehalten und sich davon überzeugen, dass diese Eigenschaft, wenn sie für die Summe zweier Zahlen wahr ist, auch wahr sein muss, wenn wir eine beliebige Anzahl von Eingaben addieren.",
+  "translatedText": "Als nächsten Schritt sollten Sie am besten das Video stoppen und sich davon überzeugen, dass diese Eigenschaft, wenn sie für die Summe zweier Zahlen wahr ist, auch wahr sein muss, wenn wir eine beliebige Anzahl von Eingaben addieren.",
   "time_range": [
    1112.94,
    1123.88
@@ -1415,7 +1415,7 @@
  {
   "input": "To get a feel for why this is so constraining, think about plugging in a whole number, something like h of 5.",
   "model": "nmt",
-  "translatedText": "Um ein Gefühl dafür zu bekommen, warum dies so einschränkend ist, denken Sie darüber nach, eine ganze Zahl einzugeben, etwa h von 5.",
+  "translatedText": "Um ein Gefühl dafür zu bekommen, warum die oben genannte Eigenschaft den Lösungsraum beschränkt, lassen Sie uns h für ganze Zahlen betrachten, etwa h von 5.",
   "time_range": [
    1125.3,
    1130.52
@@ -1424,7 +1424,7 @@
  {
   "input": "Because you can write 5 as 1 plus 1 plus 1 plus 1 plus 1, this key property means that it must equal h of 1 multiplied by itself 5 times.",
   "model": "nmt",
-  "translatedText": "Da Sie 5 als 1 plus 1 plus 1 plus 1 plus 1 schreiben können, bedeutet diese Schlüsseleigenschaft, dass sie gleich h von 1 multipliziert mit sich selbst 5-mal sein muss.",
+  "translatedText": "Da Sie 5 als 1 plus 1 plus 1 plus 1 plus 1 schreiben können, bedeutet diese Schlüsseleigenschaft, dass sie gleich h von 1 sein muss, jedoch 5 mal mit sich selbst multipliziert.",
   "time_range": [
    1131.3,
    1140.18
@@ -1460,7 +1460,7 @@
  {
   "input": "As a little mini exercise here, see if you can pause and take a moment to convince yourself that the same is true for a rational input, that if you plug in p over q to this function, it must look like this base b raised to the power p over q.",
   "model": "nmt",
-  "translatedText": "Versuchen Sie hier als kleine Mini-Übung, ob Sie innehalten und sich einen Moment Zeit nehmen können, um sich davon zu überzeugen, dass das Gleiche auch für eine rationale Eingabe gilt, dass, wenn Sie p über q in diese Funktion einfügen, es so aussehen muss, als ob diese Basis b angehoben wird die Potenz p über q.",
+  "translatedText": "Eine kleine Mini-Übung: Stoppen Sie das Video und nehmen Sie sich einen Moment Zeit, um sich davon zu überzeugen, dass das Gleiche auch für eine rationale Eingabe gilt, dass also, wenn Sie p durch q in diese Funktion einsetzen, das Ergebnis gleich Basis b hoch p durch q ist.",
   "time_range": [
    1156.08,
    1169.06
@@ -1469,7 +1469,7 @@
  {
   "input": "And as a hint, you might want to think about adding that input to itself q different times.",
   "model": "nmt",
-  "translatedText": "Und als Hinweis: Vielleicht möchten Sie darüber nachdenken, diese Eingabe mehrmals zu sich selbst hinzuzufügen.",
+  "translatedText": "Und als Hinweis: Was passiert, wenn man die Eingabe p durch q genau q mal zu sich selbst addiert?",
   "time_range": [
    1170.48,
    1175.2
@@ -1478,7 +1478,7 @@
  {
   "input": "And then because rational numbers are dense in the real number line, if we make one more pretty reasonable assumption that we only care about continuous functions, this is enough to force your hand completely and say that h has to be an exponential function, b to the power x, for all real number inputs x.",
   "model": "nmt",
-  "translatedText": "Und weil rationale Zahlen in der reellen Zahlengeraden dicht sind, reicht es aus, wenn wir noch eine ziemlich vernünftige Annahme machen, dass wir uns nur um stetige Funktionen kümmern, um Ihre Hand vollständig zu zwingen und zu sagen, dass h eine Exponentialfunktion sein muss, b to die Potenz x für alle reellen Zahleneingaben x.",
+  "translatedText": "Und weil rationale Zahlen in der reellen Zahlengeraden dicht sind, reicht es aus, wenn wir noch eine ziemlich vernünftige Annahme machen, nämlich dass wir uns nur um stetige Funktionen kümmern, um als einzig mögliche Lösung zu erhalten, dass h eine Exponentialfunktion sein muss, b hoch x für alle reellen Zahleneingaben x.",
   "time_range": [
    1178.62,
    1194.58
@@ -1487,7 +1487,7 @@
  {
   "input": "I guess to be more precise I should say for all positive real inputs.",
   "model": "nmt",
-  "translatedText": "Genauer gesagt würde ich sagen: für alle positiven realen Eingaben.",
+  "translatedText": "Genauer gesagt würde ich sagen: für alle positiven reellen Eingaben.",
   "time_range": [
    1195.3,
    1198.3
@@ -1496,7 +1496,7 @@
  {
   "input": "The way we defined h, it's only taking in positive numbers.",
   "model": "nmt",
-  "translatedText": "So wie wir h definiert haben, nimmt es nur positive Zahlen auf.",
+  "translatedText": "So wie wir h definiert haben, ist es nur für positive Zahlen definiert.",
   "time_range": [
    1198.3,
    1201.52
@@ -1505,7 +1505,7 @@
  {
   "input": "Now, as we've gone over before, instead of writing down exponential functions as some base raised to the power x, mathematicians often like to write them as e to the power of some constant c times x.",
   "model": "nmt",
-  "translatedText": "Wie wir bereits erwähnt haben, schreiben Mathematiker Exponentialfunktionen oft lieber als e hoch mit einer Konstante c mal x, anstatt sie als eine mit x potenzierte Basis aufzuschreiben.",
+  "translatedText": "Wie wir bereits erwähnt haben, schreiben Mathematiker Exponentialfunktionen oft lieber als e hoch einer Konstante c mal x, anstatt sie als eine mit x potenzierte Basis aufzuschreiben.",
   "time_range": [
    1202.5,
    1212.78
@@ -1523,7 +1523,7 @@
  {
   "input": "And so this means that our target function f has to look like e to the power of some constant times x squared.",
   "model": "nmt",
-  "translatedText": "Und das bedeutet, dass unsere Zielfunktion f wie e hoch mit einigen konstanten Zeiten x im Quadrat aussehen muss.",
+  "translatedText": "Und das bedeutet, dass unsere Zielfunktion f wie e hoch Konstante mal x Quadrat aussehen muss.",
   "time_range": [
    1225.64,
    1232.48
@@ -1532,7 +1532,7 @@
  {
   "input": "The beauty is that that function is no longer something that was merely handed down to us from on high.",
   "model": "nmt",
-  "translatedText": "Das Schöne ist, dass uns diese Funktion nicht mehr nur von oben übertragen wurde.",
+  "translatedText": "Das Schöne ist, dass uns diese Funktion nicht mehr nur von oben herabgereicht wurde.",
   "time_range": [
    1233.6,
    1238.12
@@ -1541,7 +1541,7 @@
  {
   "input": "Instead we started with these two different premises for how we wanted a distribution in two dimensions to behave, and we were drawn to the conclusion that the shape of the expression describing that distribution as a function of the radius away from the origin has to be e to the power of some constant times that radius squared.",
   "model": "nmt",
-  "translatedText": "Stattdessen begannen wir mit diesen beiden unterschiedlichen Prämissen für das Verhalten einer Verteilung in zwei Dimensionen und kamen zu dem Schluss, dass die Form des Ausdrucks, der diese Verteilung als Funktion des Radius vom Ursprung weg beschreibt, e sein muss hoch mit einer konstanten Zeit dieses Radius im Quadrat.",
+  "translatedText": "Stattdessen begannen wir mit diesen beiden unterschiedlichen Prämissen für das Verhalten einer Verteilung in zwei Dimensionen und kamen zu dem Schluss, dass die Form des Ausdrucks, der diese Verteilung als Funktion des Radius vom Ursprung weg beschreibt, e hoch einer Konstanten mal Radius Quadrat sein muss.",
   "time_range": [
    1238.76,
    1255.16
@@ -1550,7 +1550,7 @@
  {
   "input": "You'll remember I said earlier this answer will be off by a factor of a constant.",
   "model": "nmt",
-  "translatedText": "Sie werden sich erinnern, dass ich vorhin gesagt habe, dass diese Antwort um einen Faktor einer Konstante abweichen wird.",
+  "translatedText": "Sie werden sich erinnern, dass ich vorhin gesagt habe, dass diese Antwort um einen konstanten Faktor abweichen wird.",
   "time_range": [
    1256.32,
    1259.68
@@ -1559,7 +1559,7 @@
  {
   "input": "We need to rescale it to make it a valid probability distribution, and geometrically you might think of that as scaling it so that the volume under the surface is equal to one.",
   "model": "nmt",
-  "translatedText": "Wir müssen es neu skalieren, um daraus eine gültige Wahrscheinlichkeitsverteilung zu machen, und geometrisch könnte man sich das so vorstellen, dass man es so skaliert, dass das Volumen unter der Oberfläche gleich eins ist.",
+  "translatedText": "Wir müssen sie neu skalieren, um daraus eine gültige Wahrscheinlichkeitsverteilung zu machen, und geometrisch könnte man sich das so vorstellen, dass so zu skalieren, dass das Volumen unter der Oberfläche gleich eins ist.",
   "time_range": [
    1260.1,
    1267.86
@@ -1568,7 +1568,7 @@
  {
   "input": "Now you might notice that for positive values of this constant in the exponent c, our function blows up to infinity in all directions, so the volume under that surface would be infinite, meaning it's not possible to renormalize.",
   "model": "nmt",
-  "translatedText": "Nun fällt Ihnen vielleicht auf, dass unsere Funktion bei positiven Werten dieser Konstante im Exponenten c in alle Richtungen bis ins Unendliche expandiert, sodass das Volumen unter dieser Oberfläche unendlich wäre, was bedeutet, dass eine Renormierung nicht möglich ist.",
+  "translatedText": "Nun fällt Ihnen vielleicht auf, dass unsere Funktion bei positiven Werten dieser Konstante c im Exponenten in alle Richtungen bis ins Unendliche steigt, sodass das Volumen unter dieser Oberfläche unendlich wäre, was bedeutet, dass eine Renormierung nicht möglich ist.",
   "time_range": [
    1268.94,
    1280.72
@@ -1577,7 +1577,7 @@
  {
   "input": "You can't turn it into a probability distribution, and that leaves us with the last constraint, which is that this constant in the exponent has to be a negative number, and the specific value of that number determines the spread of the distribution.",
   "model": "nmt",
-  "translatedText": "Man kann es nicht in eine Wahrscheinlichkeitsverteilung umwandeln, und damit bleibt die letzte Einschränkung, die darin besteht, dass diese Konstante im Exponenten eine negative Zahl sein muss und der spezifische Wert dieser Zahl die Streuung der Verteilung bestimmt.",
+  "translatedText": "Man könnte die Funktion nicht in eine Wahrscheinlichkeitsverteilung umwandeln, und damit bleibt die letzte Einschränkung, die darin besteht, dass diese Konstante im Exponenten eine negative Zahl sein muss, Der spezifische Wert dieser Zahl bestimmt die Streuung der Verteilung.",
   "time_range": [
    1280.92,
    1292.56
@@ -1631,7 +1631,7 @@
  {
   "input": "More than that, it makes the clever proof that we saw earlier feel a little bit less out of the blue.",
   "model": "nmt",
-  "translatedText": "Darüber hinaus wirkt der clevere Beweis, den wir zuvor gesehen haben, etwas weniger aus heiterem Himmel.",
+  "translatedText": "Darüber hinaus wirkt der clevere Beweis, den wir zuvor gesehen haben, etwas weniger wie aus heiterem Himmel.",
   "time_range": [
    1328.2,
    1332.74
@@ -1649,7 +1649,7 @@
  {
   "input": "And if you had been primed by this Herschel-Maxwell derivation, where the defining property for a Gaussian is this coincidence of having a distribution that's both radially symmetric and also independent along each axis, then the very first step of our proof, which seemed so strange bumping the problem up one dimension, was really just a way of opening the door to let that defining property make itself visible.",
   "model": "nmt",
-  "translatedText": "Und wenn Sie diese Herschel-Maxwell-Ableitung kennengelernt hätte, bei der die definierende Eigenschaft für eine Gaußsche Funktion das Zusammentreffen einer Verteilung ist, die sowohl radialsymmetrisch als auch entlang jeder Achse unabhängig ist, dann wäre das der allererste Schritt unseres Beweises, der so schien Es ist seltsam, das Problem um eine Dimension nach oben zu schieben. Es war eigentlich nur eine Möglichkeit, die Tür zu öffnen, damit diese definierende Eigenschaft sichtbar wird.",
+  "translatedText": "Und wenn Sie schon zuvor diese Herschel-Maxwell-Ableitung gekannt hätten, bei der die definierende Eigenschaft für eine Gaußsche Funktion scheinbar zufällig eine Verteilung ist, die sowohl radialsymmetrisch als auch entlang jeder Achse unabhängig ist, dann wäre der allererste Schritt unseres Beweises, diese überraschende Erhöhung um eine Dimension, nur eine Möglichkeit, diese definierende Eigenschaft sichtbar zu machen.",
   "time_range": [
    1338.52,
    1361.18
@@ -1658,7 +1658,7 @@
  {
   "input": "And if you think back, the essence of the proof came down to using that radial symmetry on the one hand, and then also using the ability to factor the function on the other.",
   "model": "nmt",
-  "translatedText": "Und wenn Sie zurückdenken, bestand der Kern des Beweises darin, einerseits diese Radialsymmetrie zu nutzen und andererseits auch die Fähigkeit zur Faktorisierung der Funktion zu nutzen.",
+  "translatedText": "Und wenn Sie zurückdenken, bestand der Kern des Beweises darin, einerseits diese Radialsymmetrie zu nutzen und andererseits auch die Möglichkeit, die Funktion in Faktoren zu zerlegen.",
   "time_range": [
    1362.04,
    1370.64
@@ -1685,7 +1685,7 @@
  {
   "input": "Using the Herschel-Maxwell derivation, saying this property of a multi-dimensional distribution is what defines a Gaussian, well that presumes that we're already in some kind of multi-dimensional situation in the first place.",
   "model": "nmt",
-  "translatedText": "Wenn man die Herschel-Maxwell-Ableitung verwendet und sagt, dass diese Eigenschaft einer mehrdimensionalen Verteilung eine Gaußsche Verteilung definiert, setzt das voraus, dass wir uns überhaupt bereits in einer mehrdimensionalen Situation befinden.",
+  "translatedText": "Wenn man die Herschel-Maxwell-Ableitung verwendet und sagt, dass diese Eigenschaft einer mehrdimensionalen Verteilung eine Gaußsche Verteilung definiert, setzt das voraus, dass wir uns bereits in einer mehrdimensionalen Situation befinden.",
   "time_range": [
    1385.32,
    1397.64
@@ -1703,7 +1703,7 @@
  {
   "input": "It stems from the central limit theorem, which is all about adding together many different independent variables.",
   "model": "nmt",
-  "translatedText": "Es geht auf den zentralen Grenzwertsatz zurück, bei dem es um die Addition vieler verschiedener unabhängiger Variablen geht.",
+  "translatedText": "Sie geht auf den zentralen Grenzwertsatz zurück, bei dem es um die Addition vieler verschiedener unabhängiger Zufallsvariablen geht.",
   "time_range": [
    1404.88,
    1410.3
@@ -1712,7 +1712,7 @@
  {
   "input": "So to bring it all home here, what we need to do is explain why the function that's characterized by this Herschel-Maxwell derivation should be the same thing as the function that sits at the heart of the central limit theorem.",
   "model": "nmt",
-  "translatedText": "Um es hier auf den Punkt zu bringen, müssen wir erklären, warum die Funktion, die durch diese Herschel-Maxwell-Ableitung charakterisiert wird, dieselbe sein sollte wie die Funktion, die im Mittelpunkt des zentralen Grenzwertsatzes steht.",
+  "translatedText": "Um das Bild zu vervollständigen, müssen wir erklären, warum die Funktion, die durch diese Herschel-Maxwell-Ableitung charakterisiert wird, dieselbe sein sollte wie die Funktion, die im Mittelpunkt des zentralen Grenzwertsatzes steht.",
   "time_range": [
    1410.82,
    1421.78
@@ -1721,7 +1721,7 @@
  {
   "input": "And at this point, those of you following along are probably going to make fun of me, I think it makes sense to pull this last step out as its own video.",
   "model": "nmt",
-  "translatedText": "Und an diesem Punkt werden sich diejenigen von Ihnen, die mitmachen, wahrscheinlich über mich lustig machen. Ich denke, es macht Sinn, diesen letzten Schritt als eigenes Video herauszubringen.",
+  "translatedText": "Diejenigen von Ihnen, die dieser Mini-Videoserie folgen, werden sich vielleicht etwas amüsieren, aber an diesem Punkt denke ich, es macht Sinn, diesen letzten Schritt als eigenes Video herauszubringen.",
   "time_range": [
    1422.52,
    1429.68
@@ -1730,7 +1730,7 @@
  {
   "input": "Oh, and one final footnote here.",
   "model": "nmt",
-  "translatedText": "Oh, und noch eine letzte Fußnote.",
+  "translatedText": "Oh, und noch eine letzte Bemerkung.",
   "time_range": [
    1430.26,
    1432.18
@@ -1739,7 +1739,7 @@
  {
   "input": "After making a Patreon post about this particular project, one patron, who's a mathematician named Kevin Ega, shared something completely delightful that I had never seen before, which is that if you apply this integration trick in higher dimensions, it lets you derive the formulas for volumes of higher dimensional spheres.",
   "model": "nmt",
-  "translatedText": "Nachdem ich einen Patreon-Beitrag über dieses spezielle Projekt verfasst hatte, teilte ein Gönner, ein Mathematiker namens Kevin Ega, etwas völlig Erfreuliches mit, das ich noch nie zuvor gesehen hatte, nämlich dass man Formeln ableiten kann, wenn man diesen Integrationstrick in höheren Dimensionen anwendet für Volumina höherdimensionaler Kugeln.",
+  "translatedText": "Nachdem ich einen Patreon-Beitrag über dieses spezielle Projekt verfasst hatte, zeigte mir einer meiner Patrons, ein Mathematiker namens Kevin Ega, etwas Faszinierendes, das ich noch nie zuvor gesehen hatte, nämlich dass man mit dem Integrationstrick aus diesem Video in höheren Dimensionen Formeln für Volumina höherdimensionaler Kugeln bestimmen kann.",
   "time_range": [
    1432.38,
    1449.32
@@ -1748,7 +1748,7 @@
  {
   "input": "A very fun exercise, I'm leaving the details up on the screen for any viewers who are comfortable with integration by parts.",
   "model": "nmt",
-  "translatedText": "Eine sehr unterhaltsame Übung. Ich lasse die Details auf dem Bildschirm für alle Betrachter, die mit der Integration nach Teilen vertraut sind.",
+  "translatedText": "Eine sehr unterhaltsame Übung. Ich lasse die Details auf dem Bildschirm für alle Betrachter, die mit der partiellen Integration vertraut sind.",
   "time_range": [
    1449.32,
    1454.78
@@ -1757,7 +1757,7 @@
  {
   "input": "Thank you very much to Kevin for sharing that one, and thanks to all patrons, by the way, both for the support of the channel and also for all the feedback you offer on the early drafts of videos.",
   "model": "nmt",
-  "translatedText": "Vielen Dank an Kevin, dass er das geteilt hat, und vielen Dank übrigens an alle Gönner, sowohl für die Unterstützung des Kanals als auch für all das Feedback, das Sie zu den ersten Videoentwürfen geben.",
+  "translatedText": "Vielen Dank an Kevin hierfür, und vielen Dank übrigens an alle Patrons, sowohl für die Unterstützung des Kanals als auch für all das Feedback, das Sie zu den ersten Videoentwürfen geben.",
   "time_range": [
    1455.26,
    1485.1


### PR DESCRIPTION
Following the initial translation by translating  any "they" which stands for a single person into the male form. Sadly, German language has no gender-neutral counterpart. Maybe this should be changed into all-female just for fun. I don't know.

Not sure about the correct translation of the word "reprint" in Wigners's story. Is it supposed to be a reprint of one of the statistician's own works, or some standard text book (or sth else entirely?)

One remark why a different interface might be helpful after all (but I don't use the GitHub interface for editing normally, so I'm not sure...): If I edit on the web interface, it doesn't store intermediate editing steps, right? Because this here took me several hours, and usually I just cannot do that in one run, however commits of partial work are also really unsatisfactory.