### PR TITLE
[French] Updating 2023/refractive-index-questions

### DIFF
--- a/2023/refractive-index-questions/french/description.json
+++ b/2023/refractive-index-questions/french/description.json
@@ -1,14 +1,14 @@
 [
  {
-  "translatedText": "Répondre aux questions des téléspectateurs sur l'indice de réfraction",
+  "translatedText": "Réponse aux questions des spectateurs sur l'indice de réfraction",
   "input": "Answering viewer questions about the index of refraction"
  },
  {
-  "translatedText": "Les cours sont principalement financés directement par les téléspectateurs, qui bénéficient d'un accès anticipé aux nouvelles vidéos : https://3b1b.co/support",
+  "translatedText": "Les lessons sont principalement financées directement par les spectateurs, qui bénéficient d'un accès anticipé aux nouvelles vidéos : https://3b1b.co/support",
   "input": "Lessons are primarily funded directly by viewers, who get early access to new videos: https://3b1b.co/support"
  },
  {
-  "translatedText": "Une forme de soutien tout aussi précieuse consiste à simplement partager les vidéos.",
+  "translatedText": "Une manière toute aussi précieuse de soutenir la chaîne consiste à simplement partager les vidéos.",
   "input": "An equally valuable form of support is to simply share the videos."
  },
  {
@@ -16,7 +16,7 @@
   "input": ""
  },
  {
-  "translatedText": "Une grande partie de la dernière vidéo, ainsi que celle-ci, est basée sur la conférence Feynman suivante :",
+  "translatedText": "Une grande partie de la dernière vidéo, et de celle-ci, est basée sur la conférence Feynman suivante :",
   "input": "Much of the last video, as well as this one, is based on the following Feynman Lecture:"
  },
  {
@@ -48,19 +48,19 @@
   "input": ""
  },
  {
-  "translatedText": "0:00 – Pourquoi ralentir implique de se pencher",
+  "translatedText": "0:00 – Pourquoi un ralentissement implique une déviation",
   "input": "0:00 - Why slowing implies bending"
  },
  {
-  "translatedText": "3:36 – Récapitulatif de la façon dont le ralentissement se produit",
+  "translatedText": "3:36 – Récapitulatif sur la manière dont le ralentissement se produit",
   "input": "3:36 - Recap for how slowing happens"
  },
  {
-  "translatedText": "5:08 - Biréfringence",
+  "translatedText": "5:08 - La biréfringence",
   "input": "5:08 - Birefringence"
  },
  {
-  "translatedText": "6:19 – Le pôle barbier",
+  "translatedText": "6:19 – L'enseigne de barbier",
   "input": "6:19 - The barber pole"
  },
  {

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -227,7 +227,7 @@
  {
   "input": "If you do this, what you write down is effectively the same thing as Snell's Law, you just have a tiny bit of added work to relate the relevant angles here, and then to note how the speed and the wavelength all depend on each other.",
   "model": "nmt",
-  "translatedText": "Si vous faites cela, ce que vous obtiendrez est effectivement la même chose que la loi de Snell, vous avez juste un tout petit peu de travail supplémentaire pour relier les angles pertinents ici, puis pour noter comment la vitesse et la longueur d'onde dépendent l'une de l'autre.",
+  "translatedText": "Si vous faites cela, ce que vous obtiendrez est effectivement la même chose que la loi de Snell, vous avez juste un tout petit peu de travail supplémentaire pour relier les angles pertinents ici, puis pour trouver comment la vitesse et la longueur d'onde dépendent l'une de l'autre.",
   "time_range": [
    205.48,
    215.54
@@ -236,7 +236,7 @@
  {
   "input": "To answer the other questions I want to get to, we're going to lean pretty heavily on the explanation from the main video.",
   "model": "nmt",
-  "translatedText": "Pour répondre aux autres questions que je souhaite aborder, nous allons nous appuyer beaucoup sur l'explication de la vidéo principale.",
+  "translatedText": "Pour répondre aux autres questions que je souhaite aborder, nous allons beaucoup nous appuyer sur les explications de la vidéo principale.",
   "time_range": [
    216.96,
    222.22
@@ -245,7 +245,7 @@
  {
   "input": "I'm mostly assuming that people here will have watched that, but here's a quick recap of the key points.",
   "model": "nmt",
-  "translatedText": "Je suppose surtout que les gens ici auront regardé cela, mais voici un bref récapitulatif des points clés.",
+  "translatedText": "Je vais supposer que la majorité des gens ici l'auront regardé, mais voici un bref récapitulatif des points clés.",
   "time_range": [
    222.62,
    227.84
@@ -263,7 +263,7 @@
  {
   "input": "Now a continuous sequence of infinitesimal phase kicks like this produces something that's mathematically identical to a wave that's just traveling slower.",
   "model": "nmt",
-  "translatedText": "Maintenant, une séquence continue de phases infinitésimales comme celle-ci produit quelque chose qui est mathématiquement identique à une onde qui se déplace simplement plus lentement.",
+  "translatedText": "Une séquence continue de perturbations infinitésimales de phase comme celle-ci produit quelque chose qui est mathématiquement identique à une onde qui se déplace simplement plus lentement.",
   "time_range": [
    239.0,
    247.8
@@ -272,7 +272,7 @@
  {
   "input": "The actual mechanism for that phase kick is that the incoming light wave causes the charges in the material to oscillate a little bit.",
   "model": "nmt",
-  "translatedText": "Le mécanisme réel de ce coup de phase est que l’onde lumineuse entrante fait osciller un peu les charges présentes dans le matériau.",
+  "translatedText": "Le mécanisme réel de cette variation de phase est que l’onde lumineuse entrante fait faiblement osciller les charges présentes dans le matériau.",
   "time_range": [
    248.52,
    255.72
@@ -281,7 +281,7 @@
  {
   "input": "Those oscillations produce their own propagation in the electromagnetic field, and when you add together this newly induced wave with the original one, then in the region of space past that layer, the sum looks just like a copy of that original wave, but shifted back a little.",
   "model": "nmt",
-  "translatedText": "Ces oscillations produisent leur propre propagation dans le champ électromagnétique, et lorsque vous additionnez cette onde nouvellement induite avec celle d'origine, alors dans la région de l'espace au-delà de cette couche, la somme ressemble à une copie de cette onde originale, mais décalée vers l'arrière. un peu.",
+  "translatedText": "Ces oscillations produisent leur propre rayonnement dans le champ électromagnétique, et lorsque vous additionnez l'onde nouvellement induite avec celle d'origine, alors dans la région de l'espace au-delà de cette couche, la somme ressemble à une copie de l'onde originale, mais légèrement décalée vers l'arrière.",
   "time_range": [
    255.72,
    271.42
@@ -299,7 +299,7 @@
  {
   "input": "What we found is that the amplitude of oscillation, when you shine a light on a charge like this, will depend on how close the frequency of that light is to the resonant frequency associated with this spring-like restoring force.",
   "model": "nmt",
-  "translatedText": "Ce que nous avons découvert, c'est que l'amplitude de l'oscillation, lorsque vous éclairez une charge comme celle-ci, dépendra de la proximité de la fréquence de cette lumière avec la fréquence de résonance associée à cette force de rappel semblable à un ressort.",
+  "translatedText": "Ce que nous avons découvert, c'est que l'amplitude de l'oscillation, lorsque vous éclairez une charge comme celle-ci, dépendra de la proximité de la fréquence de cette lumière avec la fréquence de résonance associée à cette force de rappel semblable à celle d'un ressort.",
   "time_range": [
    287.32,
    300.78
@@ -308,7 +308,7 @@
  {
   "input": "Or, to put it shortly, the index of refraction depends on how much the light resonates with charges in the material.",
   "model": "nmt",
-  "translatedText": "Ou, pour le dire brièvement, l'indice de réfraction dépend de la façon dont la lumière résonne avec les charges présentes dans le matériau.",
+  "translatedText": "Ou, pour le dire brièvement, l'indice de réfraction dépend de la résonnance de la lumière avec les charges présentes dans le matériau.",
   "time_range": [
    301.16,
    307.8

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -317,7 +317,7 @@
  {
   "input": "As an example of one phenomenon that this explanation helps us to understand, let's take a question asked by Dan Stock, which is what causes birefringence?",
   "model": "nmt",
-  "translatedText": "Comme exemple d'un phénomène que cette explication nous aide à comprendre, prenons une question posée par Dan Stock : quelle est la cause de la biréfringence?",
+  "translatedText": "Comme exemple d'un phénomène que cette explication nous aide à comprendre, prenons cette question posée par Dan Stock : quelle est la cause de la biréfringence?",
   "time_range": [
    308.59,
    317.4
@@ -326,7 +326,7 @@
  {
   "input": "So, this is a phenomenon where a material has two distinct indices of refraction, which has the effect of making you see double when you look through it.",
   "model": "nmt",
-  "translatedText": "Il s’agit donc d’un phénomène où un matériau possède deux indices de réfraction distincts, ce qui a pour effet de faire voir double lorsqu’on regarde à travers.",
+  "translatedText": "Il s’agit d’un phénomène où un matériau possède deux indices de réfraction distincts, ce qui a pour effet de faire voir double lorsqu’on regarde à travers.",
   "time_range": [
    318.06,
    326.68
@@ -335,7 +335,7 @@
  {
   "input": "Imagine you have some kind of crystal structure, such that the ions in that structure will have some restoring force when you pull them in one direction, which is distinct from the restoring force when you pull them in another direction.",
   "model": "nmt",
-  "translatedText": "Imaginez que vous ayez une sorte de structure cristalline, telle que les ions de cette structure auront une certaine force de restauration lorsque vous les tirez dans une direction, qui est distincte de la force de restauration lorsque vous les tirez dans une autre direction.",
+  "translatedText": "Imaginez que vous ayez une certaine structure cristalline, telle que les ions de cette structure ont une certaine force de rappel lorsque vous les tirez dans une direction, qui est distincte de la force de rappel lorsque vous les tirez dans une autre direction.",
   "time_range": [
    327.46,
    340.4
@@ -353,7 +353,7 @@
  {
   "input": "What that means is if you shine some light through this material, then because the index of refraction depends on resonance, the value of that index of refraction will be different for light that's oscillating up and down than it will for light that's oscillating side to side.",
   "model": "nmt",
-  "translatedText": "Cela signifie que si vous projetez un peu de lumière à travers ce matériau, alors, comme l'indice de réfraction dépend de la résonance, la valeur de cet indice de réfraction sera différente pour la lumière qui oscille de haut en bas que pour la lumière qui oscille d'un côté à l'autre.",
+  "translatedText": "Cela signifie que si vous projetez de la lumière à travers ce matériau, alors, puisque l'indice de réfraction dépend de la résonance, la valeur de cet indice de réfraction sera différente pour la lumière qui oscille verticalement que pour la lumière qui oscille horizontalement.",
   "time_range": [
    348.92,
    363.84
@@ -371,7 +371,7 @@
  {
   "input": "And this really happens.",
   "model": "nmt",
-  "translatedText": "Et cela arrive réellement.",
+  "translatedText": "Et c'est vraiment le cas.",
   "time_range": [
    367.72,
    368.52
@@ -380,7 +380,7 @@
  {
   "input": "The example you're looking at right now is calcite, and when you're seeing double, it's because light with one polarization is getting bent at a different rate than light with the other polarization.",
   "model": "nmt",
-  "translatedText": "L'exemple que vous regardez en ce moment est la calcite, et lorsque vous voyez double, c'est parce que la lumière avec une polarisation se courbe à une vitesse différente de celle de la lumière avec l'autre polarisation.",
+  "translatedText": "L'exemple que vous regardez en ce moment est la calcite. Lorsque vous voyez double, c'est parce que la lumière avec une polarisation se courbe à une vitesse différente de celle de la lumière avec l'autre polarisation.",
   "time_range": [
    368.76,
    378.42

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -1,4 +1,4 @@
-[
+r[
  {
   "input": "The last video I put out was about the index of refraction.",
   "model": "nmt",
@@ -110,7 +110,7 @@
  {
   "input": "You can still clearly see the wavelength as the distance between these crests.",
   "model": "nmt",
-  "translatedText": "Vous pouvez toujours clairement visualiser la longueur d'onde comme la distance deux crêtes.",
+  "translatedText": "Vous pouvez toujours clairement visualiser la longueur d'onde comme la distance entre deux crêtes.",
   "time_range": [
    109.02,
    112.58
@@ -470,7 +470,7 @@
  {
   "input": "And finally, to wrap things up, let's hit what might be the most intriguing question of them all, which is how the index of refraction can be lower than one, since what that seems to imply is that the speed of light through a medium would be faster than the speed of light.",
   "model": "nmt",
-  "translatedText": "Et enfin, pour conclure, abordons ce qui pourrait être la question la plus intrigante de toutes, à savoir comment l'indice de réfraction peut être inférieur à un, puisque cela semble impliquer que la vitesse de la lumière à travers un milieu serait être plus rapide que la vitesse de la lumière.",
+  "translatedText": "Pour conclure, abordons ce qui pourrait être la question la plus intrigante de toutes, à savoir comment l'indice de réfraction d'un milieu peut être inférieur à un, puisque cela semblerait impliquer que la vitesse de la lumière à travers un milieu pourrait être plus rapide que la vitesse de la lumière.",
   "time_range": [
    500.96,
    515.18
@@ -479,7 +479,7 @@
  {
   "input": "So this really does happen, and it's not as wild as you might think.",
   "model": "nmt",
-  "translatedText": "Donc cela arrive vraiment, et ce n’est pas aussi sauvage qu’on pourrait le penser.",
+  "translatedText": "Cela se produit réellement, et ce n’est pas aussi surprenant qu’on pourrait le penser.",
   "time_range": [
    515.62,
    518.66
@@ -488,7 +488,7 @@
  {
   "input": "If you think back to how everything in our discussion arose from how a layer of material can kick back the phase of a wave, there is no reason that the layer of the material can't also kick forward the phase of that wave, and when you have many successive layers all kicking forward the phase like this, it gives the illusion of a wave that's traveling faster than the speed of light, in the sense that those crests genuinely are moving faster than c.",
   "model": "nmt",
-  "translatedText": "Si vous repensez à la façon dont tout dans notre discussion est né de la façon dont une couche de matériau peut faire reculer la phase d'une onde, il n'y a aucune raison pour que la couche de matériau ne puisse pas également faire avancer la phase de cette onde, et quand vous avez de nombreuses couches successives qui font toutes avancer la phase comme celle-ci, cela donne l'illusion d'une onde qui se déplace plus vite que la vitesse de la lumière, dans le sens où ces crêtes se déplacent véritablement plus vite que c.",
+  "translatedText": "Si vous repensez à la façon dont toute discussion est fondée sur la façon dont une couche de matériau peut faire reculer la phase d'une onde, il n'y a aucune raison pour que la couche de matériau ne puisse pas également faire avancer la phase de cette onde, et si vous avez de nombreuses couches successives qui font toutes avancer la phase de cette manière, cela donne l'illusion d'une onde qui se déplace plus vite que la vitesse de la lumière, au sens où les crêtes de l'onde se déplacent véritablement plus vite que c.",
   "time_range": [
    519.0,
    541.78
@@ -497,7 +497,7 @@
  {
   "input": "In fact, when you unpack the math underlying all of this, whenever the key amplitude expression that we wrote down is smaller than zero, that corresponds to an index of refraction smaller than one.",
   "model": "nmt",
-  "translatedText": "En fait, lorsque vous analysez les calculs qui sous-tendent tout cela, chaque fois que l’expression d’amplitude clé que nous avons notée est inférieure à zéro, cela correspond à un indice de réfraction inférieur à un.",
+  "translatedText": "En fait, lorsque vous examinez les calculs qui sous-tendent tout cela, chaque fois que l'amplitude de l'expression que nous avons écrite est inférieure à zéro, cela correspond à un indice de réfraction inférieur à un.",
   "time_range": [
    542.36,
    552.3
@@ -506,7 +506,7 @@
  {
   "input": "So in particular, if the frequency of the light, omega sub l, is bigger than the resonant frequency for our oscillator, you have this effect.",
   "model": "nmt",
-  "translatedText": "Ainsi, en particulier, si la fréquence de la lumière, oméga sub l, est supérieure à la fréquence de résonance de notre oscillateur, vous obtenez cet effet.",
+  "translatedText": "Ainsi, en particulier, si la fréquence de la lumière, oméga_l, est supérieure à la fréquence de résonance de notre oscillateur, vous obtenez cet effet.",
   "time_range": [
    552.68,
    561.48
@@ -515,7 +515,7 @@
  {
   "input": "For example, when you shine an x-ray through glass, the index of refraction really is smaller than one.",
   "model": "nmt",
-  "translatedText": "Par exemple, lorsque vous faites passer un rayon X à travers du verre, l’indice de réfraction est en réalité inférieur à un.",
+  "translatedText": "Par exemple, lorsque vous faites passer un rayon X à travers du verre, l’indice de réfraction est en effet inférieur à un.",
   "time_range": [
    562.02,
    566.62
@@ -524,7 +524,7 @@
  {
   "input": "There is no contradiction with causality here, and it's worth taking a moment to reflect on the role played by the speed c in all of this explanation.",
   "model": "nmt",
-  "translatedText": "Il n’y a ici aucune contradiction avec la causalité, et cela vaut la peine de prendre un moment pour réfléchir au rôle joué par la vitesse c dans toute cette explication.",
+  "translatedText": "Il n’y a ici aucune contradiction avec le principe de causalité, et cela vaut la peine de prendre un moment pour réfléchir au rôle joué par la vitesse c dans toute cette explication.",
   "time_range": [
    567.56,
    575.96
@@ -533,7 +533,7 @@
  {
   "input": "C is the speed determining how long it takes for an accelerating charge to induce a force on any other charge.",
   "model": "nmt",
-  "translatedText": "C est la vitesse qui détermine le temps nécessaire à une charge accélératrice pour induire une force sur toute autre charge.",
+  "translatedText": "c est la vitesse qui détermine le temps nécessaire à une charge en accélération pour induire une force sur toute autre charge.",
   "time_range": [
    576.58,
    583.5
@@ -542,7 +542,7 @@
  {
   "input": "Even if there's material in the way, whether that material has an index of refraction bigger than one or less than one, that amount of time that it takes for the influence of one charge to reach another is always the distance between them divided by c.",
   "model": "nmt",
-  "translatedText": "Même s'il y a du matériel sur le chemin, que ce matériau ait un indice de réfraction supérieur à un ou inférieur à un, le temps qu'il faut pour que l'influence d'une charge en atteigne une autre est toujours la distance qui les sépare divisée par c.",
+  "translatedText": "Même s'il y a un matériau sur le chemin, que ce matériau ait un indice de réfraction supérieur ou inférieur à un, le temps qu'il faut pour que l'influence d'une charge en atteigne une autre est toujours la distance qui les sépare divisée par c.",
   "time_range": [
    584.0,
    597.04
@@ -551,7 +551,7 @@
  {
   "input": "By contrast, the speed that's relevant to an index of refraction is how fast the crest of one of those waves is moving.",
   "model": "nmt",
-  "translatedText": "En revanche, la vitesse pertinente pour un indice de réfraction est la vitesse à laquelle la crête de l'une de ces vagues se déplace.",
+  "translatedText": "En revanche, la vitesse pertinente pour un indice de réfraction est celle à laquelle la crête de l'une de ces ondes se déplace.",
   "time_range": [
    597.88,
    604.9
@@ -569,7 +569,7 @@
  {
   "input": "That phase velocity is what determines how much the wave gets scrunched up, which in turn determines how much it refracts or bends, which is part of the reason I think it's very good terminology to call this the index of refraction rather than say the index of slowing.",
   "model": "nmt",
-  "translatedText": "Cette vitesse de phase est ce qui détermine à quel point l'onde est froissée, ce qui à son tour détermine à quel point elle se réfracte ou se plie, ce qui explique en partie pourquoi je pense que c'est une très bonne terminologie d'appeler cela l'indice de réfraction plutôt que de dire l'indice de ralentir.",
+  "translatedText": "Cette vitesse de phase est ce qui détermine à quel point l'onde est comprimée, ce qui à son tour détermine à quel point elle se réfracte ou se courbe, ce qui explique en partie pourquoi je pense que c'est une très bonne terminologie d'appeler cela l'indice de réfraction plutôt que l'indice de ralentissement.",
   "time_range": [
    607.62,
    621.4
@@ -578,7 +578,7 @@
  {
   "input": "In general, the electric field inside a medium like glass is this incredibly complicated sum of a whole bunch of propagating influences from every one of the wiggling charges in that material, all together with the incoming light wave.",
   "model": "nmt",
-  "translatedText": "En général, le champ électrique à l’intérieur d’un milieu comme le verre est cette somme incroyablement compliquée de tout un tas d’influences se propageant de chacune des charges ondulantes de ce matériau, le tout ainsi que l’onde lumineuse entrante.",
+  "translatedText": "En général, le champ électrique à l’intérieur d’un milieu comme le verre est cette somme incroyablement compliquée de tout un tas d’influences se propageant à partir de chacune des charges oscillantes de ce matériau, simultanément avec l’onde lumineuse entrante.",
   "time_range": [
    622.12,
    635.56
@@ -587,7 +587,7 @@
  {
   "input": "But importantly, all of those individual propagations are traveling at c, never slower, never faster.",
   "model": "nmt",
-  "translatedText": "Mais surtout, toutes ces propagations individuelles se déplacent en c, jamais plus lentement, jamais plus vite.",
+  "translatedText": "Mais surtout, toutes ces propagations individuelles se déplacent à la vitesse c, jamais plus lentement, jamais plus vite.",
   "time_range": [
    635.94,
    641.9
@@ -596,7 +596,7 @@
  {
   "input": "It is miraculous that the way that these combine can be described simply at all, and that it's not some monstrously intractable mess.",
   "model": "nmt",
-  "translatedText": "Il est miraculeux que la façon dont ces éléments se combinent puisse être décrite simplement, et qu'il ne s'agisse pas d'un désordre monstrueusement insoluble.",
+  "translatedText": "C'est un miracle que la façon dont ces éléments se combinent puisse être décrite simplement, et qu'il ne s'agisse pas d'un désordre monstrueux et insoluble.",
   "time_range": [
    641.9,
    649.28
@@ -605,7 +605,7 @@
  {
   "input": "But we are fortunate, and when you add them all up, the net effect can be described cleanly, and it looks just like a sine wave, one whose phase velocity happens to be different from c.",
   "model": "nmt",
-  "translatedText": "Mais nous avons de la chance, et lorsque vous les additionnez tous, l’effet net peut être décrit clairement, et il ressemble à une onde sinusoïdale, dont la vitesse de phase se trouve être différente de c.",
+  "translatedText": "Mais nous avons de la chance, et lorsque vous les additionnez tous, l’effet global peut être décrit clairement, et il ressemble à une onde sinusoïdale, dont la vitesse de phase se trouve être différente de c.",
   "time_range": [
    649.78,
    659.82
@@ -614,7 +614,7 @@
  {
   "input": "Another thing to keep in mind if it seems very weird for these wave crests to move faster than c is that everything in this explanation depends very heavily on things being in a steady state.",
   "model": "nmt",
-  "translatedText": "Une autre chose à garder à l’esprit s’il semble très étrange que ces crêtes de vagues se déplacent plus vite que c est que tout dans cette explication dépend très fortement du fait que les choses soient dans un état stable.",
+  "translatedText": "Une autre chose à garder à l’esprit s’il vous semble très étrange que ces crêtes d'ondes se déplacent plus vite que c, est que tout dans cette explication dépend très fortement du fait que les choses soient dans un état stable.",
   "time_range": [
    660.4,
    670.72
@@ -623,7 +623,7 @@
  {
   "input": "That's very different from say trying to send information through the medium with a little pulse of light.",
   "model": "nmt",
-  "translatedText": "C'est très différent d'essayer, par exemple, d'envoyer des informations via un support avec une petite impulsion de lumière.",
+  "translatedText": "C'est très différent d'essayer, par exemple, d'essayer de transmettre des informations à travers un milieu avec une petite impulsion de lumière.",
   "time_range": [
    671.0,
    676.38
@@ -632,7 +632,7 @@
  {
   "input": "This is what Mithina explores in her videos on the index of refraction over on Looking Glass Universe, which you should definitely look at.",
   "model": "nmt",
-  "translatedText": "C'est ce que Mithina explore dans ses vidéos sur l'indice de réfraction sur Looking Glass Universe, qu'il faut absolument regarder.",
+  "translatedText": "C'est ce que Mithina explore dans ses vidéos sur l'indice de réfraction sur la chaîne 'Looking Glass Universe', que vous devriez absolument aller regarder.",
   "time_range": [
    677.24,
    683.62
@@ -641,7 +641,7 @@
  {
   "input": "Over there she talks about how when you express a pulse of light as a sum of many pure sine waves, even if the phase velocities of those constituent components go faster than c, that doesn't necessarily imply that the center of mass of this pulse will itself go faster than c.",
   "model": "nmt",
-  "translatedText": "Là-bas, elle explique que lorsque vous exprimez une impulsion lumineuse comme une somme de nombreuses ondes sinusoïdales pures, même si les vitesses de phase de ces composants vont plus vite que c, cela n'implique pas nécessairement que le centre de masse de cette impulsion ira lui-même plus vite que c.",
+  "translatedText": "Elle y explique que lorsque vous exprimez une impulsion lumineuse comme une somme de nombreuses ondes sinusoïdales pures, même si les vitesses de phase de ces composants vont plus vite que c, cela n'implique pas nécessairement que le centre de masse de cette impulsion ira lui-même plus vite que c.",
   "time_range": [
    683.98,
    699.22
@@ -650,7 +650,7 @@
  {
   "input": "And in fact, when you simulate the effect of passing through a medium, when the index of refraction is less than one, what you find is a pulse that goes slower than c, even when the crests within it are going faster.",
   "model": "nmt",
-  "translatedText": "Et en fait, lorsque vous simulez l’effet du passage à travers un milieu, lorsque l’indice de réfraction est inférieur à un, vous trouvez une impulsion qui va plus lentement que c, même lorsque les crêtes qui la composent vont plus vite.",
+  "translatedText": "Et en fait, lorsque vous simulez l’effet du passage à travers un milieu, lorsque l’indice de réfraction est inférieur à un, vous obtenez une impulsion qui va plus lentement que c, même si les crêtes des ondes qui la composent vont plus vite.",
   "time_range": [
    699.64,
    710.12
@@ -659,7 +659,7 @@
  {
   "input": "And if that still seems a bit weird, here's an analogy to help see why phase velocity can be way higher than the speed of anything real.",
   "model": "nmt",
-  "translatedText": "Et si cela semble encore un peu bizarre, voici une analogie pour vous aider à comprendre pourquoi la vitesse de phase peut être bien supérieure à la vitesse de quelque chose de réel.",
+  "translatedText": "Et si cela semble encore un peu bizarre, voici une analogie pour vous aider à comprendre pourquoi la vitesse de phase peut être bien supérieure à la vitesse de toute chose réelle.",
   "time_range": [
    710.92,
    718.02
@@ -668,7 +668,7 @@
  {
   "input": "Imagine a little machine that has a bunch of rotating arms all extending from a shared shaft.",
   "model": "nmt",
-  "translatedText": "Imaginez une petite machine dotée d'un ensemble de bras rotatifs s'étendant tous à partir d'un arbre commun.",
+  "translatedText": "Imaginez une petite machine dotée d'un ensemble de bras rotatifs s'étendant tous autour d'un arbre commun.",
   "time_range": [
    718.5,
    723.56
@@ -677,7 +677,7 @@
  {
   "input": "If you view this machine from the side, the tips of all of those arms form what looks like a wave, with crests traveling from right to left.",
   "model": "nmt",
-  "translatedText": "Si vous regardez cette machine de côté, les extrémités de tous ces bras forment ce qui ressemble à une vague, avec des crêtes se déplaçant de droite à gauche.",
+  "translatedText": "Si vous regardez cette machine de côté, les extrémités de tous ces bras forment ce qui ressemble à une onde, avec des crêtes se déplaçant de droite à gauche.",
   "time_range": [
    724.04,
    731.72
@@ -686,7 +686,7 @@
  {
   "input": "But if I go and reposition the arms to be angled quite close to each other, then you can make it so that the phase velocity of this emergent wave is arbitrarily high, potentially faster than the speed of light or anything else, even when the shaft is rotating at a gentle constant rate, and even when every component of the machine is moving at a reasonably slow pace.",
   "model": "nmt",
-  "translatedText": "Mais si je repositionne les bras pour qu'ils soient assez proches l'un de l'autre, alors vous pouvez faire en sorte que la vitesse de phase de cette onde émergente soit arbitrairement élevée, potentiellement plus rapide que la vitesse de la lumière ou toute autre chose, même lorsque l'arbre tourne à un rythme doux et constant, et même lorsque chaque composant de la machine se déplace à un rythme raisonnablement lent.",
+  "translatedText": "Mais si je repositionne les bras pour qu'ils soient assez proches les uns des autres, alors vous pouvez faire en sorte que la vitesse de phase de cette onde émergente soit arbitrairement élevée, potentiellement plus rapide que la vitesse de la lumière ou de n'importe quoi, cela même lorsque l'arbre tourne à un rythme doux et constant, et même lorsque chaque composant de la machine se déplace à un rythme raisonnablement lent.",
   "time_range": [
    732.68,
    752.24
@@ -695,7 +695,7 @@
  {
   "input": "Here it's pretty obvious that such a machine doesn't violate the rules of physics, and that it doesn't let you send messages faster than light, because the wave crest is not a real object.",
   "model": "nmt",
-  "translatedText": "Ici, il est assez évident qu'une telle machine ne viole pas les règles de la physique et qu'elle ne permet pas d'envoyer des messages plus rapidement que la lumière, car la crête de la vague n'est pas un objet réel.",
+  "translatedText": "Ici, il est assez évident qu'une telle machine ne viole pas les règles de la physique et qu'elle ne permet pas d'envoyer des messages plus rapidement que la lumière, car la crête de l'onde n'est pas un objet réel.",
   "time_range": [
    752.72,
    761.76
@@ -722,7 +722,7 @@
  {
   "input": "Sure, if you shine an x-ray through glass, it is true that the wave crests go faster than the speed of light, but the underlying influences between electric charges that determine the field values in the first place are themselves all bound by the speed c.",
   "model": "nmt",
-  "translatedText": "Bien sûr, si vous faites passer un rayon X à travers du verre, il est vrai que les crêtes des vagues vont plus vite que la vitesse de la lumière, mais les influences sous-jacentes entre les charges électriques qui déterminent les valeurs du champ en premier lieu sont elles-mêmes toutes liées par la vitesse. c.",
+  "translatedText": "Bien sûr, si vous faites passer un rayon X à travers du verre, il est vrai que les crêtes des ondes vont plus vite que la vitesse de la lumière, mais les influences sous-jacentes entre les charges électriques qui déterminent les valeurs du champ en premier lieu sont elles-mêmes toutes limitées par la vitesse c.",
   "time_range": [
    768.16,
    781.7

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -371,7 +371,7 @@
  {
   "input": "And this really happens.",
   "model": "nmt",
-  "translatedText": "Et c'est vraiment le cas.",
+  "translatedText": "Et vous pouvez l'observer en vrai.",
   "time_range": [
    367.72,
    368.52

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -389,7 +389,7 @@
  {
   "input": "For those of you who watched the videos about the barber pole effect, a very similar phenomenon answers the final question that we left there.",
   "model": "nmt",
-  "translatedText": "Pour ceux d’entre vous qui ont regardé les vidéos sur l’effet barbier, un phénomène très similaire répond à la dernière question que nous avons laissée là.",
+  "translatedText": "Pour ceux d’entre vous qui ont regardé les vidéos sur l’effet de l'enseigne de barbier, un phénomène très similaire répond à la dernière question que nous nous étions posés à ce moment.",
   "time_range": [
    379.78,
    386.84
@@ -398,7 +398,7 @@
  {
   "input": "If you didn't watch those, feel free to jump ahead, but if you did, you might recall that where we left off was with a claim that sugar causes right-handed circularly polarized light to travel at a slightly different speed from left-handed circularly polarized light.",
   "model": "nmt",
-  "translatedText": "Si vous ne les avez pas regardés, n'hésitez pas à avancer, mais si vous l'avez fait, vous vous souviendrez peut-être que là où nous nous sommes arrêtés, c'était avec une affirmation selon laquelle le sucre fait voyager la lumière polarisée circulairement vers la droite à une vitesse légèrement différente de celle vers la gauche. lumière polarisée circulairement.",
+  "translatedText": "Si vous ne les avez pas regardés, n'hésitez pas à passer à la suite, mais si vous l'avez regardée, vous vous souviendrez peut-être que nous nous étions arrêtés avec une affirmation selon laquelle le sucre fait voyager la lumière polarisée circulairement vers la droite à une vitesse légèrement différente de celle de la lumière polarisée circulairement vers la gauche.",
   "time_range": [
    387.36,
    402.62
@@ -407,7 +407,7 @@
  {
   "input": "The reason that mattered is that it meant linearly polarized light, which can be expressed as a sum of those two, will slowly rotate over time as one of those two components lags behind the other.",
   "model": "nmt",
-  "translatedText": "La raison qui importait est que cela signifiait que la lumière polarisée linéairement, qui peut être exprimée comme la somme de ces deux composants, tournerait lentement au fil du temps, l'un de ces deux composants étant en retard sur l'autre.",
+  "translatedText": "C'était un fait important car cela signifiait que la lumière polarisée linéairement, qui peut être exprimée comme la somme de ces deux composants, tourne lentement au fil du temps, car l'un de ces deux composants prend du retard sur l'autre.",
   "time_range": [
    403.32,
    415.3
@@ -416,7 +416,7 @@
  {
   "input": "Once you understand that an index of refraction depends on resonance, you can start to see why something like this might happen.",
   "model": "nmt",
-  "translatedText": "Une fois que vous comprenez qu’un indice de réfraction dépend de la résonance, vous pouvez commencer à comprendre pourquoi une telle chose peut se produire.",
+  "translatedText": "Une fois que vous avez compris que l'indice de réfraction dépend de la résonance, vous pouvez commencer à comprendre pourquoi un tel phénomène peut se produire.",
   "time_range": [
    415.9,
    422.58
@@ -425,7 +425,7 @@
  {
   "input": "If the molecular structure of sucrose was one such that electrons might get pushed along a path with a clockwise component more freely than they get pushed along paths with counterclockwise components, well, that would mean that the resonance with right-handed circularly polarized light would be a little different from what it is for left-handed circularly polarized light, and hence the indices of refraction would be slightly different for each one.",
   "model": "nmt",
-  "translatedText": "Si la structure moléculaire du saccharose était telle que les électrons pourraient être poussés plus librement le long d'un chemin avec une composante dans le sens des aiguilles d'une montre qu'ils ne le sont le long de chemins avec des composantes dans le sens inverse des aiguilles d'une montre, eh bien, cela signifierait que la résonance avec une lumière polarisée circulairement vers la droite serait un peu différent de ce qu'il est pour la lumière polarisée circulairement vers la gauche, et donc les indices de réfraction seraient légèrement différents pour chacun.",
+  "translatedText": "Si la structure moléculaire du saccharose faisait que les électrons pourraient être poussés plus librement le long d'un chemin avec une composante dans le sens des aiguilles d'une montre qu'ils ne le sont le long de chemins avec des composantes dans le sens inverse des aiguilles d'une montre, eh bien, cela signifierait que la résonance avec une lumière polarisée circulairement vers la droite serait un peu différent de ce qu'elle est pour une lumière polarisée circulairement vers la gauche, et donc les indices de réfraction seraient légèrement différents pour chacune.",
   "time_range": [
    423.3,
    447.58
@@ -434,7 +434,7 @@
  {
   "input": "When you combine this together with the fact that the resonance depends on the frequency of the light, which is to say it depends on the color, this ultimately explains why the optical rotation in that barber pole effect separated out the colors the way that it did.",
   "model": "nmt",
-  "translatedText": "Lorsque vous combinez cela avec le fait que la résonance dépend de la fréquence de la lumière, c'est-à-dire qu'elle dépend de la couleur, cela explique finalement pourquoi la rotation optique dans cet effet de pôle de barbier a séparé les couleurs comme elle l'a fait.",
+  "translatedText": "Lorsque vous combinez cela avec le fait que la résonance dépend de la fréquence de la lumière, c'est-à-dire qu'elle dépend de la couleur, cela explique finalement pourquoi la rotation optique dans cet effet d'enseigne de barbier a séparé les couleurs de cette manière.",
   "time_range": [
    447.58,
    462.24
@@ -443,7 +443,7 @@
  {
   "input": "Now, one example of a shape that would resonate differently with left-handed and right-handed circularly polarized light would be a helix, and in fact people will use a helical antenna when they want to pick up on radio waves with just one-handedness.",
   "model": "nmt",
-  "translatedText": "Maintenant, un exemple de forme qui résonnerait différemment avec une lumière polarisée circulairement vers la gauche et vers la droite serait une hélice, et en fait les gens utiliseront une antenne hélicoïdale lorsqu'ils voudront capter les ondes radio avec une seule main.",
+  "translatedText": "Maintenant, un exemple de forme qui résonnerait différemment avec une lumière polarisée circulairement vers la gauche ou vers la droite serait une hélice, et de fait les gens utilisent une antenne hélicoïdale lorsqu'ils veulent capter des ondes radio avec une seule polarisation.",
   "time_range": [
    462.94,
    476.02
@@ -452,7 +452,7 @@
  {
   "input": "Although sucrose is not so clean and pure an example as a helix, the key property is that it is chiral, meaning it's fundamentally different from its mirror image, in that there's no way to reorient it in 3D space to make it look like its mirror image.",
   "model": "nmt",
-  "translatedText": "Bien que le saccharose ne soit pas un exemple aussi propre et pur qu'une hélice, la propriété clé est qu'il est chiral, ce qui signifie qu'il est fondamentalement différent de son image miroir, en ce sens qu'il n'y a aucun moyen de le réorienter dans l'espace 3D pour le faire ressembler à son miroir. image.",
+  "translatedText": "Bien que le saccharose ne soit pas un exemple aussi propre et pur qu'une hélice, la propriété clé est qu'il est chiral, ce qui signifie qu'il est fondamentalement différent de son image miroir, en ce sens qu'il n'y a aucun moyen de le réorienter dans l'espace 3D pour le faire ressembler à son image miroir.",
   "time_range": [
    476.02,
    489.76
@@ -461,7 +461,7 @@
  {
   "input": "I will not pretend to know why this particular structure resonates with one-handedness more than another, but at least in principle it makes sense that chirality would lend itself to this phenomenon.",
   "model": "nmt",
-  "translatedText": "Je ne prétendrai pas savoir pourquoi cette structure particulière résonne plus avec une seule main qu'une autre, mais au moins en principe, il est logique que la chiralité se prête à ce phénomène.",
+  "translatedText": "Je ne prétendrai pas savoir pourquoi cette structure particulière résonne plus avec une polarisation plutôt qu'une autre, mais au moins en principe, il semble logique que la chiralité se prête à ce phénomène.",
   "time_range": [
    490.24,
    499.46

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -1,4 +1,4 @@
-r[
+[
  {
   "input": "The last video I put out was about the index of refraction.",
   "model": "nmt",

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -146,7 +146,7 @@
  {
   "input": "It reminds me a little of the rolling shutter effect, and overall the wave crest ends up at a different angle.",
   "model": "nmt",
-  "translatedText": "Cela me rappelle un peu l'effet du volet roulant, et au final, la crête de l'onde termine avec un angle différent.",
+  "translatedText": "Cela me rappelle un peu l'effet 'Rolling Shutter', et au final, la crête de l'onde termine avec un angle différent.",
   "time_range": [
    132.28,
    137.78

--- a/2023/refractive-index-questions/french/sentence_translations.json
+++ b/2023/refractive-index-questions/french/sentence_translations.json
@@ -11,7 +11,7 @@
  {
   "input": "It talked about why light slows down when it passes through a medium, and in particular, why the rate of slowdown would depend on color.",
   "model": "nmt",
-  "translatedText": "Il explique pourquoi la lumière ralentit lorsqu'elle traverse un milieu et, en particulier, pourquoi le taux de ralentissement dépend de la couleur.",
+  "translatedText": "Elle expliquait pourquoi la lumière ralentit lorsqu'elle traverse un milieu et, en particulier, pourquoi le taux de ralentissement dépend de la couleur.",
   "time_range": [
    3.42,
    10.22
@@ -20,7 +20,7 @@
  {
   "input": "It turns out people have a lot of questions about the index of refraction, and in this supplemental video I wanted to take a chance to answer a couple of them.",
   "model": "nmt",
-  "translatedText": "Il s’avère que les gens se posent beaucoup de questions sur l’indice de réfraction, et dans cette vidéo supplémentaire, je voulais tenter ma chance pour répondre à quelques-unes d’entre elles.",
+  "translatedText": "Il s’avère que les gens se posent beaucoup de questions sur l’indice de réfraction, et dans cette vidéo supplémentaire, je vais tenter de répondre à certaines d’entre elles.",
   "time_range": [
    10.88,
    17.96
@@ -38,7 +38,7 @@
  {
   "input": "To kick things off though, I want to take a question that does not require too much background, asked by Kevin O'Toole, which is why exactly light slowing down would imply that it bends as it enters a medium.",
   "model": "nmt",
-  "translatedText": "Pour commencer, je voudrais répondre à une question qui ne nécessite pas trop de contexte, posée par Kevin O'Toole, c'est pourquoi le ralentissement exact de la lumière impliquerait qu'elle se plie lorsqu'elle entre dans un milieu.",
+  "translatedText": "Pour commencer, je voudrais répondre à une question qui ne nécessite pas trop de contexte, posée par Kevin O'Toole, c'est pourquoi le ralentissement de la lumière implique qu'elle dévie lorsqu'elle entre dans un milieu.",
   "time_range": [
    31.98,
    43.48
@@ -47,7 +47,7 @@
  {
   "input": "There's a common analogy, which is to think of something like a car or a tank, where it turns a little bit while one side of it slows down before the other, and although it's a very visceral and memorable analogy, it's not like light has wheels, and it also tells you nothing about how to be more quantitative.",
   "model": "nmt",
-  "translatedText": "Il existe une analogie courante, qui consiste à penser à quelque chose comme une voiture ou un char, où il tourne un peu tandis qu'un côté ralentit avant l'autre, et bien que ce soit une analogie très viscérale et mémorable, ce n'est pas comme si la lumière avait roues, et cela ne vous dit rien non plus sur la façon d'être plus quantitatif.",
+  "translatedText": "Il existe une analogie courante, qui consiste à penser à quelque chose comme une voiture ou un char, qui tourne un peu lorsqu'un côté ralentit avant l'autre, mais bien que ce soit une analogie très visuelle et mémorable, ce n'est pas comme si la lumière avait des roues, et cela ne vous dit rien sur la façon d'être plus quantitatif.",
   "time_range": [
    44.36,
    59.68
@@ -56,7 +56,7 @@
  {
   "input": "And derive the formula describing exactly how much light bends.",
   "model": "nmt",
-  "translatedText": "Et dérivez la formule décrivant exactement la quantité de lumière qui se courbe.",
+  "translatedText": "Et comment trouver la formule décrivant avec précision l'angle de la déviation.",
   "time_range": [
    60.06,
    63.86
@@ -74,7 +74,7 @@
  {
   "input": "If you have some light wave shining into a material like glass, if it slows down, notice how that means that it gets kind of scrunched up.",
   "model": "nmt",
-  "translatedText": "Si une onde lumineuse brille dans un matériau comme le verre, si elle ralentit, remarquez comment cela signifie qu'elle est en quelque sorte froissée.",
+  "translatedText": "Une onde lumineuse pénètre dans un matériau comme le verre, si elle ralentit, remarquez comment cela se traduit par une sorte de compression.",
   "time_range": [
    65.94,
    73.24
@@ -83,7 +83,7 @@
  {
   "input": "If its wavelength in a vacuum was some number lambda, then the wavelength inside this material, where it's gotten slowed down, is something smaller than that.",
   "model": "nmt",
-  "translatedText": "Si sa longueur d'onde dans le vide était d'un certain nombre lambda, alors la longueur d'onde à l'intérieur de ce matériau, là où il a été ralenti, est quelque chose de plus petit que cela.",
+  "translatedText": "Si sa longueur d'onde dans le vide vaut un certain nombre lambda, alors sa longueur d'onde à l'intérieur de ce matériau, là où l'onde a été ralenti, à une valeur plus faible.",
   "time_range": [
    73.44,
    81.24
@@ -92,7 +92,7 @@
  {
   "input": "Here I am drawing the wave only on a one-dimensional line, but we need to understand it in at least two dimensions, where every point on this plane, for example, is associated with a little vector in the electric field oscillating up and down.",
   "model": "nmt",
-  "translatedText": "Ici, je dessine l'onde uniquement sur une ligne unidimensionnelle, mais nous devons la comprendre dans au moins deux dimensions, où chaque point de ce plan, par exemple, est associé à un petit vecteur dans le champ électrique oscillant de haut en bas.",
+  "translatedText": "Ici, je dessine l'onde uniquement sur une ligne unidimensionnelle, mais nous devons au moins le comprendre en deux dimensions, où chaque point de ce plan, par exemple, est associé à un petit vecteur dans le champ électrique oscillant de haut en bas.",
   "time_range": [
    81.8,
    95.18
@@ -101,7 +101,7 @@
  {
   "input": "This particular animation is a little bit messy and hard to follow, so it might be clearer if instead we simply color every point of the plane, such that those points are white near the crests of the wave, and then black away from the crests.",
   "model": "nmt",
-  "translatedText": "Cette animation particulière est un peu brouillonne et difficile à suivre, elle pourrait donc être plus claire si nous colorions simplement chaque point du plan, de telle sorte que ces points soient blancs près des crêtes de la vague, puis noirs à l'écart des crêtes.",
+  "translatedText": "Cette animation est un peu brouillonne et difficile à suivre, donc pour gagner en clarté nous colorons simplement chaque point du plan, de telle sorte qu'un point soit blanc près des crêtes de l'onde, et noir à l'écart des crêtes.",
   "time_range": [
    95.74,
    108.52
@@ -110,7 +110,7 @@
  {
   "input": "You can still clearly see the wavelength as the distance between these crests.",
   "model": "nmt",
-  "translatedText": "Vous pouvez toujours voir clairement la longueur d'onde comme la distance entre ces crêtes.",
+  "translatedText": "Vous pouvez toujours clairement visualiser la longueur d'onde comme la distance deux crêtes.",
   "time_range": [
    109.02,
    112.58
@@ -119,7 +119,7 @@
  {
   "input": "It's exactly what we were looking at before, just drawn in a different way, and in particular notice how they're scrunched up inside the glass.",
   "model": "nmt",
-  "translatedText": "C'est exactement ce que nous regardions auparavant, juste dessiné d'une manière différente, et en particulier remarquez comment ils sont froissés à l'intérieur du verre.",
+  "translatedText": "C'est exactement ce que nous regardions auparavant, juste dessiné d'une manière différente, en particulier remarquez comment les crêtes sont comprimés à l'intérieur du verre.",
   "time_range": [
    112.82,
    119.28
@@ -128,7 +128,7 @@
  {
   "input": "If that glass were positioned at an angle, think about what happens to each one of those wave crests.",
   "model": "nmt",
-  "translatedText": "Si ce verre était positionné de biais, pensez à ce qui arrive à chacune de ces crêtes de vagues.",
+  "translatedText": "Si ce verre était positionné de biais, pensez à ce qui arriverait à chacune de ces crêtes.",
   "time_range": [
    119.92,
    125.02
@@ -137,7 +137,7 @@
  {
   "input": "As it hits the glass, the lower parts slow down before the top parts, causing it to get sort of smeared out.",
   "model": "nmt",
-  "translatedText": "Lorsqu'il touche le verre, les parties inférieures ralentissent avant les parties supérieures, ce qui le tache en quelque sorte.",
+  "translatedText": "Lorsque l'onde atteint le verre, les parties inférieures ralentissent avant les parties supérieures, ce qui l'étire en quelque sorte.",
   "time_range": [
    125.46,
    131.94
@@ -146,7 +146,7 @@
  {
   "input": "It reminds me a little of the rolling shutter effect, and overall the wave crest ends up at a different angle.",
   "model": "nmt",
-  "translatedText": "Cela me rappelle un peu l'effet de volet roulant, et globalement, la crête de la vague se termine sous un angle différent.",
+  "translatedText": "Cela me rappelle un peu l'effet du volet roulant, et au final, la crête de l'onde termine avec un angle différent.",
   "time_range": [
    132.28,
    137.78
@@ -155,7 +155,7 @@
  {
   "input": "When you take into account the fact that for a beam of light, the beam is always perpendicular to those wave crests, this means your light has to turn, and moreover you can calculate exactly how much it needs to turn.",
   "model": "nmt",
-  "translatedText": "Lorsque vous prenez en compte le fait que pour un faisceau de lumière, le faisceau est toujours perpendiculaire à ces crêtes d'onde, cela signifie que votre lumière doit tourner, et de plus, vous pouvez calculer exactement de combien elle doit tourner.",
+  "translatedText": "Lorsque vous prenez en compte le fait que pour un faisceau de lumière, le faisceau est toujours perpendiculaire à ces crêtes d'onde, cela signifie que votre lumière doit changer de direction, et de plus, vous pouvez calculer exactement de combien elle doit dévier.",
   "time_range": [
    138.5,
    149.48
@@ -164,7 +164,7 @@
  {
   "input": "Think about all those waves in the vacuum, with some kind of wavelength lambda-1 sitting between them, and focus on all the points where those crests intersect with the boundary between the vacuum and the glass.",
   "model": "nmt",
-  "translatedText": "Pensez à toutes ces ondes dans le vide, avec une sorte de longueur d'onde lambda-1 entre elles, et concentrez-vous sur tous les points où ces crêtes croisent la frontière entre le vide et le verre.",
+  "translatedText": "Pensez à toutes ces ondes dans le vide, avec une certaine longueur d'onde lambda-1 entre elles, et concentrez-vous sur tous les points où ces crêtes sont à la frontière entre le vide et le verre.",
   "time_range": [
    150.22,
    160.98
@@ -173,7 +173,7 @@
  {
   "input": "But then consider those wave crests inside the glass.",
   "model": "nmt",
-  "translatedText": "Mais considérons ensuite ces crêtes de vagues à l’intérieur du verre.",
+  "translatedText": "Considérons ensuite ces crêtes d'ondes à l’intérieur du verre.",
   "time_range": [
    161.38,
    164.04
@@ -182,7 +182,7 @@
  {
   "input": "If it was the case that no bending happened, then because the wavelength is smaller in there, when you look at all those intersection points, they would have to be closer together.",
   "model": "nmt",
-  "translatedText": "Si aucune courbure ne se produisait, alors, comme la longueur d'onde est plus petite à cet endroit, lorsque vous regardez tous ces points d'intersection, ils devraient être plus proches les uns des autres.",
+  "translatedText": "Si aucune courbure ne se produisait, alors, comme la longueur d'onde est plus petite dans cet endroit, lorsque vous regardez tous ces points d'intersection, ils seraient plus proches les uns des autres.",
   "time_range": [
    164.22,
    172.76
@@ -191,7 +191,7 @@
  {
   "input": "But of course that can't happen, whether you're looking at it from one side, or looking at it from the other, those intersection points are all the same.",
   "model": "nmt",
-  "translatedText": "Mais bien sûr, cela ne peut pas arriver, que vous regardiez les choses d’un côté ou de l’autre, ces points d’intersection sont tous les mêmes.",
+  "translatedText": "Mais bien sûr, cela ne peut pas arriver, que vous regardiez les choses d’un côté ou de l’autre, ces points d’intersection sont les mêmes.",
   "time_range": [
    172.76,
    179.7
@@ -200,7 +200,7 @@
  {
   "input": "So the only way this can work is if those wave crests inside the glass were oriented at a different angle.",
   "model": "nmt",
-  "translatedText": "La seule façon pour que cela puisse fonctionner est que les crêtes de vagues à l’intérieur du verre soient orientées selon un angle différent.",
+  "translatedText": "Donc la seule façon pour que cela fonctionne est que les crêtes d'ondes à l’intérieur du verre soient orientées selon un angle différent.",
   "time_range": [
    180.22,
    185.62
@@ -209,7 +209,7 @@
  {
   "input": "You might mentally imagine turning them with a little knob to find the sweet spot angle where all those intersection points line up.",
   "model": "nmt",
-  "translatedText": "Vous pourriez imaginer mentalement les tourner avec un petit bouton pour trouver l’angle idéal où tous ces points d’intersection s’alignent.",
+  "translatedText": "Vous pourriez imaginer mentalement les tourner avec un petit bouton pour trouver l’angle idéal où tous ces points d’intersection correspondent.",
   "time_range": [
    186.3,
    192.34
@@ -218,7 +218,7 @@
  {
   "input": "And for those of you into exercises, you could take a moment to try to write down the specific equation telling you how to relate the wavelengths inside and outside the glass with the angles between those wave crests and the boundary itself.",
   "model": "nmt",
-  "translatedText": "Et pour ceux d'entre vous qui aiment les exercices, vous pouvez prendre un moment pour essayer d'écrire l'équation spécifique vous indiquant comment relier les longueurs d'onde à l'intérieur et à l'extérieur du verre avec les angles entre ces crêtes d'ondes et la limite elle-même.",
+  "translatedText": "Et pour ceux d'entre vous qui aiment les exercices, vous pouvez prendre un moment pour essayer d'écrire l'équation précisant la relation entre les longueurs d'onde à l'intérieur et à l'extérieur du verre et les angles entre les crêtes d'ondes et la frontière.",
   "time_range": [
    192.78,
    204.7
@@ -227,7 +227,7 @@
  {
   "input": "If you do this, what you write down is effectively the same thing as Snell's Law, you just have a tiny bit of added work to relate the relevant angles here, and then to note how the speed and the wavelength all depend on each other.",
   "model": "nmt",
-  "translatedText": "Si vous faites cela, ce que vous écrivez est effectivement la même chose que la loi de Snell, vous avez juste un tout petit peu de travail supplémentaire pour relier les angles pertinents ici, puis pour noter comment la vitesse et la longueur d'onde dépendent toutes les unes des autres.",
+  "translatedText": "Si vous faites cela, ce que vous obtiendrez est effectivement la même chose que la loi de Snell, vous avez juste un tout petit peu de travail supplémentaire pour relier les angles pertinents ici, puis pour noter comment la vitesse et la longueur d'onde dépendent l'une de l'autre.",
   "time_range": [
    205.48,
    215.54

--- a/2023/refractive-index-questions/french/title.json
+++ b/2023/refractive-index-questions/french/title.json
@@ -1,4 +1,4 @@
 {
- "translatedText": "Comment la lumière peut apparaître plus vite que c, pourquoi elle se plie et autres questions | Puzzles d'optique 4",
+ "translatedText": "Comment la lumière peut sembler plus rapide que c, pourquoi elle se courbe, et autres questions | Énigmes optique 4",
  "input": "How light can appear faster than c, why it bends, and other questions | Optics puzzles 4"
 }


### PR DESCRIPTION
I updated the automatic translations for the title/description/video of the refractive index questions video. The automatic translation does a good job overall, and someone who watches the video with it would grasp the essentials of it. However, it often sounds unnatural, with structures that wouldn't be used in French (or that don't transfer well from English to French). Also, some specific physics terms were not well translated (for instance "vague" instead of "onde" for "wave", "pliage" instead of "courbure"/"déviation" for "bending, "ondulantes" instead of "oscillantes" for "wiggling" etc.). Also, the "Rolling Shutter" effect doesn't have an equivalent name in French so I just left it in English.