### PR TITLE
CLT Hebrew subtitles update#2

### DIFF
--- a/2023/clt/hebrew/sentence_translations.json
+++ b/2023/clt/hebrew/sentence_translations.json
@@ -10,7 +10,7 @@
  },
  {
   "input": "Maybe you've seen one before, it's a popular demonstration of how, even when a single event is chaotic and random, with an effectively unknowable outcome, it's still possible to make precise statements about a large number of events, namely how the relative proportions for many different outcomes are distributed. ",
-  "translatedText": "אולי ראיתם אחד בעבר, זו הדגמה פופולרית של איך, אפילו כאשר אירוע בודד הוא כאוטי ואקראי, עם תוצאה בלתי ידועה למעשה, עדיין אפשר להצהיר הצהרות מדויקות על מספר רב של אירועים, כלומר איך הפרופורציות היחסיות עבור תוצאות רבות ושונות מופצות. ",
+  "translatedText": "אולי ראיתם אחד בעבר, זו הדגמה פופולרית של איך, אפילו כאשר אירוע בודד הוא כאוטי ואקראי, עם תוצאה בלתי ידועה למעשה, עדיין אפשר להצהיר הצהרות מדויקות על מספר רב של אירועים, כלומר איך הפרופורציות היחסיות עבור תוצאות רבות ושונות מתפלגות. ",
   "model": "nmt",
   "time_range": [
    2.52,
@@ -19,7 +19,7 @@
  },
  {
   "input": "More specifically, the Galton board illustrates one of the most prominent distributions in all of probability, known as the normal distribution, more colloquially known as a bell curve, and also called a Gaussian distribution. ",
-  "translatedText": "ליתר דיוק, לוח גלטון ממחיש את אחת ההתפלגויות הבולטות בכל ההסתברות, המכונה התפלגות נורמלית, הידועה יותר כעקומת פעמון, ונקראת גם התפלגות גאוסית. ",
+  "translatedText": "ליתר דיוק, לוח גלטון ממחיש את אחת ההתפלגויות הבולטות בכל תורת ההסתברות, המכונה התפלגות נורמלית, הידועה יותר כעקומת פעמון, ונקראת גם התפלגות גאוסית. ",
   "model": "nmt",
   "time_range": [
    20.38,
@@ -154,7 +154,7 @@
  },
  {
   "input": "If we let many different balls fall, making yet another unrealistic assumption that they don't influence each other as if they're all ghosts, then the number of balls that fall into each different bucket gives us some loose sense for how likely each one of those buckets is. ",
-  "translatedText": "אם אנו נותנים לכדורים רבים ליפול, תוך הנחה לא מציאותית נוספת שהם לא משפיעים זה על זה כאילו כולם רוחות רפאים, אז מספר הכדורים שנופלים לכל מיכל אחר נותן לנו תחושה כלשהי לגבי הסבירות של מהו כל אחד מהמיכלים האלה. ",
+  "translatedText": "אם אנו נותנים לכדורים רבים ליפול, תוך הנחה לא מציאותית נוספת שהם לא משפיעים זה על זה כאילו כולם רוחות רפאים, אז מספר הכדורים שנופלים לכל מיכל נותן לנו תחושה כלשהי לגבי הסבירות של מהו כל אחד מהמיכלים האלה. ",
   "model": "nmt",
   "time_range": [
    190.57,
@@ -208,7 +208,7 @@
  },
  {
   "input": "The basic idea of the central limit theorem is that if you increase the size of that sum, for example here that would mean increasing the number of rows of pegs for each ball to bounce off, then the distribution that describes where that sum is going to fall looks more and more like a bell curve. ",
-  "translatedText": "הרעיון הבסיסי של משפט הגבול המרכזי הוא שאם תגדילו את גודל הסכום הזה, למשל כאן זה אומר הגדלת מספר שורות היתדות עבור כל כדור שיקפוץ, אז ההתפלגות המתארת לאן הסכום הזה הולך נראה יותר ויותר כמו עקומת פעמון. ",
+  "translatedText": "הרעיון הבסיסי של משפט הגבול המרכזי הוא שאם תגדילו את גודל הסכום, למשל כאן זה אומר הגדלת מספר שורות היתדות עבור כל כדור שיקפוץ, אז ההתפלגות המתארת לאן הסכום הולך נראה יותר ויותר כמו עקומת פעמון. ",
   "model": "nmt",
   "time_range": [
    236.81,
@@ -217,7 +217,7 @@
  },
  {
   "input": "Here, it's actually worth taking a moment to write down that general idea. ",
-  "translatedText": "כאן, בעצם שווה להקדיש רגע כדי לרשום את הרעיון הכללי הזה. ",
+  "translatedText": "כאן, בעצם שווה להקדיש רגע כדי לרשום את הרעיון הכללי. ",
   "model": "nmt",
   "time_range": [
    255.47,
@@ -253,7 +253,7 @@
  },
  {
   "input": "Those outcomes are associated with the numbers negative one and positive one. ",
-  "translatedText": "תוצאות אלו קשורות למספרים אחד שלילי אחד וחיובי. ",
+  "translatedText": "תוצאות אלו קשורות למספרים מונוס 1 ופלוס 1. ",
   "model": "nmt",
   "time_range": [
    274.85,
@@ -262,7 +262,7 @@
  },
  {
   "input": "Another example of a random variable would be rolling a die, where you have six different outcomes, each one associated with a number. ",
-  "translatedText": "דוגמה נוספת למשתנה אקראי תהיה הטלת קובייה, שבה יש לכם שש תוצאות שונות, שכל אחת מהן קשורה למספר. ",
+  "translatedText": "דוגמה נוספת למשתנה אקראי תהיה הטלת קובייה, שבה יש שש תוצאות שונות, שכל אחת מהן קשורה למספר. ",
   "model": "nmt",
   "time_range": [
    278.53,
@@ -289,7 +289,7 @@
  },
  {
   "input": "The claim of the central limit theorem is that as you let the size of that sum get bigger and bigger, then the distribution of that sum, how likely it is to fall into different possible values, will look more and more like a bell curve. ",
-  "translatedText": "הטענה של משפט הגבול המרכזי היא שככל שאתה נותן לגודל הסכום הזה להיות גדול יותר ויותר, אז ההתפלגות של הסכום הזה, מה הסיכוי שהוא ייפול לערכים אפשריים שונים, תיראה יותר ויותר כמו עקומת פעמון. ",
+  "translatedText": "הטענה של משפט הגבול המרכזי היא שככל שאתם נותנים לגודל הסכום להיות גדול יותר ויותר, אז ההתפלגות של הסכום, מה הסיכוי שהוא ייפול לערכים אפשריים שונים, תיראה יותר ויותר כמו עקומת פעמון. ",
   "model": "nmt",
   "time_range": [
    301.43,
@@ -316,7 +316,7 @@
  },
  {
   "input": "We're going to put some numbers to it, put some formulas to it, show how you can use it to make predictions. ",
-  "translatedText": "אנחנו הולכים לשים לזה כמה מספרים, לשים לזה כמה נוסחאות, להראות איך אתם יכולים להשתמש בזה כדי ליצור תחזיות. ",
+  "translatedText": "אנחנו הולכים לשים בה כמה מספרים, לשים בה כמה נוסחאות, להראות איך אתם יכולים להשתמש בזה כדי ליצור תחזיות. ",
   "model": "nmt",
   "time_range": [
    322.07,
@@ -370,7 +370,7 @@
  },
  {
   "input": "Now let me say at the top that this theorem has three different assumptions that go into it, three things that have to be true before the theorem follows. ",
-  "translatedText": "עכשיו הרשו לי להתחיל בכך שלמשפט הזה יש שלוש הנחות שונות שמובלעות בתוכו, שלושה דברים שצריכים להיות נכונים לפני שהמשפט יבוא אחריהם. ",
+  "translatedText": "עכשיו הרשו לי להתחיל בכך שלמשפט הזה יש שלוש הנחות שונות שמובלעות בתוכו, שלושה דברים שצריכים להיות נכונים כדי שהמשפט יהיה נכון. ",
   "model": "nmt",
   "time_range": [
    353.45,
@@ -415,7 +415,7 @@
  },
  {
   "input": "We could start with a weighted die, something with a non-trivial distribution across the outcomes, and the core idea still holds. ",
-  "translatedText": "אנחנו יכולים להתחיל עם קוביה משוקללת, משהו עם התפלגות לא טריוויאלית על פני התוצאות, והרעיון המרכזי עדיין מתקיים. ",
+  "translatedText": "אנחנו יכולים להתחיל עם קובייה משוקללת, משהו עם התפלגות לא טריוויאלית על פני התוצאות, והרעיון המרכזי עדיין מתקיים. ",
   "model": "nmt",
   "time_range": [
    387.83,
@@ -469,7 +469,7 @@
  },
  {
   "input": "Maybe if you squint your eyes you can see it skews a tiny bit to the left, but it's neat that something so symmetric emerged from a starting point that was so asymmetric. ",
-  "translatedText": "אולי אם תמצמצמו את עיניכם תוכלו לראות הטיה קטנטנה שמאלה, אבל זה יפה שמשהו כל כך סימטרי צץ מנקודת התחלה שהייתה כל כך אסימטרית. ",
+  "translatedText": "אולי אם תצמצמו את עיניכם תוכלו לראות הטיה קטנטנה שמאלה, אבל זה יפה שמשהו כל כך סימטרי צץ מנקודת התחלה שהייתה כל כך אסימטרית. ",
   "model": "nmt",
   "time_range": [
    432.87,
@@ -478,7 +478,7 @@
  },
  {
   "input": "To better illustrate what the central limit theorem is all about, let me run four of these simulations in parallel, where on the upper left I'm doing it where we're only adding two dice at a time, on the upper right we're doing it where we're adding five dice at a time, the lower left is the one that we just saw adding 10 dice at a time, and then we'll do another one with a bigger sum, 15 at a time. ",
-  "translatedText": "כדי להמחיש טוב יותר על מה עוסק משפט הגבול המרכזי, הרשו לי להריץ ארבע מהסימולציות הללו במקביל, כאשר בפינה השמאלית העליונה אני עושה זאת כאשר אנו מוסיפים רק שתי קוביות בכל פעם, בצד ימין למעלה אנו אנחנו עושים את זה כאשר אנחנו מוסיפים חמש קוביות בכל פעם, השמאלית התחתונה היא זו שראינו עכשיו ושבה מוסיפים 10 קוביות בכל פעם, ואז נעשה עוד אחת עם סכום גדול יותר, 15 בכל פעם. ",
+  "translatedText": "כדי להמחיש טוב יותר במה עוסק משפט הגבול המרכזי, הרשו לי להריץ ארבע מהסימולציות הללו במקביל, כאשר בפינה השמאלית העליונה אני עושה זאת כאשר אנו מוסיפים רק שתי קוביות בכל פעם, בצד ימין למעלה אנו אנחנו עושים את זה כאשר אנחנו מוסיפים חמש קוביות בכל פעם, השמאלית התחתונה היא זו שראינו עכשיו ושבה מוסיפים 10 קוביות בכל פעם, ואז נעשה עוד אחת עם סכום גדול יותר, 15 בכל פעם. ",
   "model": "nmt",
   "time_range": [
    441.47,
@@ -505,7 +505,7 @@
  },
  {
   "input": "It has the lump in the middle and fade towards the tail's shape of a bell curve. ",
-  "translatedText": "יש לו את התפיחה באמצע והוא יורד לקראת צורת הזנב של עקומת פעמון. ",
+  "translatedText": "יש לה את התפיחה באמצע והיא יורדת לקראת צורת הזנב של עקומת פעמון. ",
   "model": "nmt",
   "time_range": [
    479.95,
@@ -739,7 +739,7 @@
  },
  {
   "input": "The mean of a distribution, often denoted with the Greek letter mu, is a way of capturing the center of mass for that distribution. ",
-  "translatedText": "הממוצע של התפלגות, מסומן לעתים קרובות באות היוונית mu, הוא דרך ללכוד את מרכז המסה של התפלגות זו. ",
+  "translatedText": "הממוצע של התפלגות, המסומן לעתים קרובות באות היוונית mu, הוא דרך למצוא את מרכז המסה של התפלגות זו. ",
   "model": "nmt",
   "time_range": [
    703.41,
@@ -748,7 +748,7 @@
  },
  {
   "input": "It's calculated as the expected value of our random variable, which is a way of saying you go through all of the different possible outcomes, and you multiply the probability of that outcome times the value of the variable. ",
-  "translatedText": "זה מחושב כערך הצפוי של המשתנה האקראי שלנו, שזו דרך לומר שאתם עוברים על כל התוצאות האפשריות השונות, ואתם מכפילים את ההסתברות של התוצאה הזו כפול ערכו של המשתנה. ",
+  "translatedText": "הוא מחושב כערך הצפוי של המשתנה האקראי שלנו, שזו דרך לומר שאתם עוברים על כל התוצאות האפשריות השונות, ואתם מכפילים את ההסתברות של התוצאה הזו כפול ערכו של המשתנה. ",
   "model": "nmt",
   "time_range": [
    711.19,
@@ -793,7 +793,7 @@
  },
  {
   "input": "The idea there is to look at the difference between each possible value and the mean, square that difference, and ask for its expected value. ",
-  "translatedText": "הרעיון הוא להסתכל על ההבדל בין כל ערך אפשרי לבין הממוצע, לרבע את ההבדל ולבקש את הערך הצפוי שלו. ",
+  "translatedText": "הרעיון הוא להסתכל על ההבדל בין כל ערך אפשרי לבין הממוצע, להעלות בריבוע את ההפרש ולמצוא את הערך הצפוי שלו. ",
   "model": "nmt",
   "time_range": [
    740.83,
@@ -811,7 +811,7 @@
  },
  {
   "input": "Squaring it like this turns out to make the math much much nicer than if we did something like an absolute value, but the downside is that it's hard to think about this as a distance in our diagram because the units are off. ",
-  "translatedText": "ריבוע זה הופך את המתמטיקה להרבה הרבה יותר יפה מאשר אם היינו משתמשים במשהו כמו ערך מוחלט, אבל החיסרון הוא שקשה לחשוב על זה כעל מרחק בתרשים שלנו כי היחידות לא מתואמות. ",
+  "translatedText": "העלאה זו בריבוע הופכת את המתמטיקה להרבה הרבה יותר יפה מאשר אם היינו משתמשים במשהו כמו ערך מוחלט, אבל החיסרון הוא שקשה לחשוב על זה כעל מרחק בתרשים שלנו כי היחידות לא מתואמות. ",
   "model": "nmt",
   "time_range": [
    757.3699999999999,
@@ -820,7 +820,7 @@
  },
  {
   "input": "Kind of like the units here are square units, whereas a distance in our diagram would be a kind of linear unit. ",
-  "translatedText": "בערך כמו שהיחידות כאן הן יחידות מרובעות, בעוד שמרחק בתרשים שלנו יהיה סוג של יחידה לינארית. ",
+  "translatedText": "בערך כמו שהיחידות כאן הן יחידות בריבוע, בעוד שמרחק בתרשים שלנו יהיה סוג של יחידה לינארית. ",
   "model": "nmt",
   "time_range": [
    768.33,
@@ -838,7 +838,7 @@
  },
  {
   "input": "That can be interpreted much more reasonably as a distance on our diagram, and it's commonly denoted with the Greek letter sigma, so you know m for mean as for standard deviation, but both in Greek. ",
-  "translatedText": "זה יכול להתפרש בצורה הרבה יותר סבירה כמרחק בתרשים שלנו, והוא מסומן בדרך כלל באות היוונית סיגמה, אז אתה מכיר m עבור ממוצע וגם עבור סטיית תקן, אבל שניהם ביוונית. ",
+  "translatedText": "היא יכול להתפרש בצורה הרבה יותר סבירה כמרחק בתרשים שלנו, והוא מסומן בדרך כלל באות היוונית סיגמה, אז אתם מכירים m עבור ממוצע ו-s  עבור סטיית תקן, אבל שניהם ביוונית. ",
   "model": "nmt",
   "time_range": [
    778.69,
@@ -847,7 +847,7 @@
  },
  {
   "input": "Looking back at our sequence of distributions, let's talk about the mean and standard deviation. ",
-  "translatedText": "במבט לאחור על רצף ההתפלגויות שלנו, בואו נדבר על הממוצע ועל סטיית התקן. ",
+  "translatedText": "במבט נוסף על רצף ההתפלגויות שלנו, בואו נדבר על הממוצע ועל סטיית התקן. ",
   "model": "nmt",
   "time_range": [
    791.87,
@@ -856,7 +856,7 @@
  },
  {
   "input": "If we call the mean of the initial distribution mu, which for the one illustrated happens to be 2.24, hopefully it won't be too surprising if I tell you that the mean of the next one is 2 times mu. ",
-  "translatedText": "אם נקרא לממוצע של ההתפלגות הראשונית mu, אשר עבור זו המוצגת הוא במקרה 2.24, אני מקווה שזה לא יהיה מפתיע מדי אם אני אגיד לכם שהממוצע של הבא הוא פי 2 mu. ",
+  "translatedText": "אם נקרא לממוצע של ההתפלגות הראשונית mu, אשר עבור זו המוצגת הוא במקרה 2.24, אני מקווה שזה לא יהיה מפתיע מדי אם אני אגיד לכם שהממוצע של הבא הוא פי 2. ",
   "model": "nmt",
   "time_range": [
    796.63,
@@ -901,7 +901,7 @@
  },
  {
   "input": "The key fact here is that if you have two different random variables, then the variance for the sum of those variables is the same as just adding together the original two variances. ",
-  "translatedText": "עובדת המפתח כאן היא שאם יש לכם שני משתנים אקראיים שונים, השונות עבור סכום המשתנים האלה זהה לחיבור של שתי השונות המקוריות. ",
+  "translatedText": "עובדת המפתח כאן היא שאם יש לכם שני משתנים אקראיים שונים, השונות עבור סכום המשתנים האלה זהה לחיבור של שתי השונויות המקוריות. ",
   "model": "nmt",
   "time_range": [
    830.49,
@@ -937,7 +937,7 @@
  },
  {
   "input": "But right now, the main thing I want you to highlight is how it's the variance that adds, it's not the standard deviation that adds. ",
-  "translatedText": "אבל כרגע, הדבר העיקרי שאני רוצה שתדגיש הוא איך השונות היא שמוסיפה, זו לא סטיית התקן שמוסיפה. ",
+  "translatedText": "אבל כרגע, הדבר העיקרי שאני רוצה שתדגישו הוא איך השונות היא שמצטברת, זו לא סטיית התקן שמצטברת. ",
   "model": "nmt",
   "time_range": [
    854.01,
@@ -946,7 +946,7 @@
  },
  {
   "input": "So, critically, if you were to take n different realizations of the same random variable and ask what the sum looks like, the variance of that sum is n times the variance of your original variable, meaning the standard deviation, the square root of all this, is the square root of n times the original standard deviation. ",
-  "translatedText": "אז, באופן קריטי, אם הייתם לוקחים n מימושים שונים של אותו משתנה אקראי ושואלים איך נראה הסכום, השונות של הסכום הזה היא פי n מהשונות של המשתנה המקורי שלכם, כלומר סטיית התקן, השורש הריבועי של כולם. זהו השורש הריבועי של n כפול סטיית התקן המקורית. ",
+  "translatedText": "אז אם הייתם לוקחים n מימושים שונים של אותו משתנה אקראי ושואלים איך נראה הסכום, השונות של הסכום הזה היא פי n מהשונות של המשתנה המקורי שלכם, כלומר סטיית התקן, השורש הריבועי של כולם. זהו השורש הריבועי של n כפול סטיית התקן המקורית. ",
   "model": "nmt",
   "time_range": [
    859.73,
@@ -973,7 +973,7 @@
  },
  {
   "input": "It means that even though our distributions are getting spread out, they're not spreading out all that quickly, they only do so in proportion to the square root of the size of the sum. ",
-  "translatedText": "זה אומר שלמרות שההתפלגות שלנו מתפזרות, הן לא מתפשטות כל כך מהר, הן עושות זאת רק ביחס לשורש הריבועי של גודל הסכום. ",
+  "translatedText": "זה אומר שלמרות שההתפלגויות שלנו מתפזרות, הן לא מתפשטות כל כך מהר, הן עושות זאת רק ביחס לשורש הריבועי של גודל הסכום. ",
   "model": "nmt",
   "time_range": [
    896.07,
@@ -982,7 +982,7 @@
  },
  {
   "input": "As we prepare to make a more quantitative description of the central limit theorem, the core intuition I want you to keep in your head is that we'll basically realign all of these distributions so that their means line up together, and then rescale them so that all of the standard deviations are just going to be equal to 1. ",
-  "translatedText": "כשאנחנו מתכוננים לתיאור כמותי יותר של משפט הגבול המרכזי, האינטואיציה המרכזית שאני רוצה שתשמרו בראשכם היא שאנחנו בעצם נערוך מחדש את כל ההתפלגויות האלה כך שהאמצעים שלהן יסתדרו יחד, ואז נשנה את קנה המידה כך שכל סטיות התקן פשוט יהיו שוות ל-1. ",
+  "translatedText": "כשאנחנו מתכוננים לתיאור כמותי יותר של משפט הגבול המרכזי, האינטואיציה המרכזית שאני רוצה שתשמרו בראשכם היא שאנחנו בעצם נערוך מחדש את כל ההתפלגויות האלה כך שהמרכזים שלהן יסתדרו יחד, ואז נשנה את קנה המידה כך שכל סטיות התקן פשוט יהיו שוות ל-1. ",
   "model": "nmt",
   "time_range": [
    904.71,
@@ -1000,7 +1000,7 @@
  },
  {
   "input": "And let me say one more time, the real magic here is how we could have started with any distribution, describing a single roll of the die, and if we play the same game, considering what the distributions for the many different sums look like, and we realign them so that the means line up, and we rescale them so that the standard deviations are all 1, we still approach that same universal shape, which is kind of mind-boggling. ",
-  "translatedText": "ותנו לי לומר עוד פעם, הקסם האמיתי כאן הוא איך היינו יכולים להתחיל עם כל חלוקה, לתאר זריקת קובייה בודדת, ואם נשחק באותו משחק, בהתחשב איך נראות ההתפלגויות עבור הסכומים הרבים השונים, ואנחנו מארגנים אותם מחדש כך שהאמצעים יסתדרו, ואנחנו משנים את קנה המידה שלהם כך שסטיות התקן יהיו כולן 1, אנחנו עדיין מתקרבים לאותה צורה אוניברסלית, שהיא סוג של תוצאה מפתיעה. ",
+  "translatedText": "ותנו לי לומר עוד פעם, הקסם האמיתי כאן הוא איך היינו יכולים להתחיל עם כל התפלגות שמתארת זריקת קובייה בודדת, ואם נשחק באותו משחק, בהתחשב באיך נראות ההתפלגויות עבור הסכומים הרבים השונים, ואנחנו מארגנים אותם מחדש כך שהמרכזים יסתדרו, ואנחנו משנים את קנה המידה שלהם כך שסטיות התקן יהיו כולן 1, אנחנו עדיין מתקרבים לאותה צורה אוניברסלית, שהיא סוג של תוצאה מפתיעה. ",
   "model": "nmt",
   "time_range": [
    930.47,
@@ -1009,7 +1009,7 @@
  },
  {
   "input": "And now, my friends, is probably as good a time as any to finally get into the formula for a normal distribution. ",
-  "translatedText": "ועכשיו ידידי, זה כנראה זמן טוב להיכנס סוף סוף לנוסחה של התפלגות נורמלית. ",
+  "translatedText": "ועכשיו ידידי, זה כנראה זמן טוב להיכנס סוף סוף לנוסחה של ההתפלגות הנורמלית. ",
   "model": "nmt",
   "time_range": [
    954.81,
@@ -1018,7 +1018,7 @@
  },
  {
   "input": "And the way I'd like to do this is to basically peel back all the layers and build it up one piece at a time. ",
-  "translatedText": "והדרך שבה הייתי רוצה לעשות את זה היא בעצם לקלף את כל השכבות ולבנות אותה חתיכה אחת בכל פעם. ",
+  "translatedText": "והדרך שבה הייתי רוצה לעשות זאת היא בעצם לקלף את כל השכבות ולבנות אותה שיכבה אחת בכל פעם. ",
   "model": "nmt",
   "time_range": [
    961.49,
@@ -1045,7 +1045,7 @@
  },
  {
   "input": "That would give us this kind of awkward sharp point in the middle, but if instead you make that exponent the negative square of x, you get a smoother version of the same thing, which decays in both directions. ",
-  "translatedText": "זה ייתן לנו סוג כזה של נקודה חדה מוזרה באמצע, אבל אם במקום זאת תהפכו את המעריך הזה לריבוע השלילי של x, תקבלו גרסה חלקה יותר של אותו דבר, שדועך בשני הכיוונים. ",
+  "translatedText": "זה ייתן לנו סוג כזה של נקודה חדה מוזרה באמצע, אבל אם במקום זאת תהפכו את האקספוננט הזה לריבוע השלילי של x, תקבלו גרסה חלקה יותר של אותו דבר, שדועך בשני הכיוונים. ",
   "model": "nmt",
   "time_range": [
    985.93,
@@ -1063,7 +1063,7 @@
  },
  {
   "input": "Now if you throw a constant in front of that x, and you scale that constant up and down, it lets you stretch and squish the graph horizontally, allowing you to describe narrow and wider bell curves. ",
-  "translatedText": "עכשיו, אם אתם שמים קבוע לפני ה-X הזה, ומשנים את קנה המידה של הקבוע הזה למעלה ולמטה, זה מאפשר לכם למתוח ולמעוך את הגרף אופקית, דבר שמאפשר לכם לתאר עקומות פעמון צרות ורחבות יותר. ",
+  "translatedText": "עכשיו, אם אתם שמים קבוע לפני ה-X, ומשנים את קנה המידה של הקבוע הזה למעלה ולמטה, זה מאפשר לכם למתוח ולמעוך את הגרף אופקית, דבר שמאפשר לכם לתאר עקומות פעמון צרות ורחבות יותר. ",
   "model": "nmt",
   "time_range": [
    998.65,
@@ -1072,7 +1072,7 @@
  },
  {
   "input": "And a quick thing I'd like to point out here is that based on the rules of exponentiation, as we tweak around that constant c, you could also think about it as simply changing the base of the exponentiation. ",
-  "translatedText": "ודבר מהיר שהייתי רוצה לציין כאן הוא שבהתבסס על כללי החזקה, כשאנחנו משנים אותו קבוע c, אתם יכולים גם לחשוב על זה פשוט כשינוי בסיס החקה. ",
+  "translatedText": "ודבר מהיר שהייתי רוצה לציין כאן הוא שבהתבסס על כללי החזקה, כשאנחנו משנים אותו קבוע c, אתם יכולים גם לחשוב על זה פשוט כשינוי בסיס החזקה. ",
   "model": "nmt",
   "time_range": [
    1009.01,
@@ -1126,7 +1126,7 @@
  },
  {
   "input": "Or rather, if we reconfigure things a little bit so that the exponent looks like negative one half times x divided by a certain constant, which we'll suggestively call sigma squared, then once we turn this into a probability distribution, that constant sigma will be the standard deviation of that distribution. ",
-  "translatedText": "או ליתר דיוק, אם נגדיר את הדברים קצת מחדש כך שהמעריך ייראה כמו שלילי חצי כפול x חלקי קבוע מסוים, שנקרא לו סיגמא בריבוע, אז ברגע שנהפוך את זה להתפלגות הסתברותית, הקבוע סיגמה יהיה סטיית התקן של התפלגות זו. ",
+  "translatedText": "או ליתר דיוק, אם נגדיר את הדברים קצת מחדש כך שהמעריך ייראה כמו מינוס חצי כפול x חלקי קבוע מסוים, שנקרא לו סיגמא בריבוע, אז ברגע שנהפוך את זה להתפלגות הסתברותית, הקבוע סיגמא יהיה סטיית התקן של התפלגות זו. ",
   "model": "nmt",
   "time_range": [
    1040.11,
@@ -1144,7 +1144,7 @@
  },
  {
   "input": "But before we can interpret this as a probability distribution, we need the area under the curve to be 1. ",
-  "translatedText": "אבל לפני שנוכל לפרש זאת כהתפלגות הסתברות, אנו צריכים שהשטח מתחת לעקומה יהיה 1. ",
+  "translatedText": "אבל לפני שנוכל לפרש זאת כהתפלגות הסתברותית, אנו צריכים שהשטח מתחת לעקומה יהיה 1. ",
   "model": "nmt",
   "time_range": [
    1058.91,
@@ -1189,7 +1189,7 @@
  },
  {
   "input": "There's a whole other video about this, they're called probability density functions. ",
-  "translatedText": "יש סרטון אחר לגמרי על זה, הם נקראים פונקציות צפיפות הסתברותיות. ",
+  "translatedText": "יש סרטון אחר לגמרי על זה, הן נקראות פונקציות צפיפות הסתברותיות. ",
   "model": "nmt",
   "time_range": [
    1086.03,
@@ -1216,7 +1216,7 @@
  },
  {
   "input": "As it stands with the basic bell curve shape of e to the negative x squared, the area is not 1, it's actually the square root of pi. ",
-  "translatedText": "כפי שהוא עומד עם צורת עקומת הפעמון הבסיסית של e בחזקת-x השלילי בריבוע, השטח אינו 1, זה למעשה השורש הריבועי של pi. ",
+  "translatedText": "כפי שהוא, עם צורת עקומת הפעמון הבסיסית של e בחזקה השלילית של-x בריבוע, השטח אינו 1, הוא למעשה השורש הריבועי של pi. ",
   "model": "nmt",
   "time_range": [
    1101.05,
@@ -1396,7 +1396,7 @@
  },
  {
   "input": "Instead of focusing on the sum of all of these random variables, let's modify this expression a little bit, where what we'll do is we'll look at the mean that we expect that sum to take, and we subtract it off so that our new expression has a mean of 0, and then we're going to look at the standard deviation we expect of our sum, and divide out by that, which basically just rescales the units so that the standard deviation of our expression will equal 1. ",
-  "translatedText": "במקום להתמקד בסכום של כל המשתנים האקראיים האלה, הבה נשנה מעט את הביטוי הזה, ומה שנעשה הוא להסתכל על הממוצע שאנו מצפים שהסכום הזה יקבל, ונחסר אותו כך לביטוי החדש שלנו יש ממוצע של 0, ואז נסתכל על סטיית התקן שאנו מצפים מהסכום שלנו, ונחלק בזה, חלוקה שבעצם רק משנה את קנה המידה של היחידות כך שסטיית התקן של הביטוי שלנו תהיה שווה ל-1 . ",
+  "translatedText": "במקום להתמקד בסכום של כל המשתנים האקראיים האלה, הבה נשנה מעט את הביטוי הזה, ומה שנעשה הוא להסתכל על הממוצע שאנו מצפים שהסכום הזה יקבל, ונחסר אותו כך שלביטוי החדש שלנו יש ממוצע של 0, ואז נסתכל על סטיית התקן שאנו מצפים מהסכום שלנו, ונחלק בזה, חלוקה שבעצם רק משנה את קנה המידה של היחידות כך שסטיית התקן של הביטוי שלנו תהיה שווה ל-1 . ",
   "model": "nmt",
   "time_range": [
    1255.27,
@@ -1432,7 +1432,7 @@
  },
  {
   "input": "Also, by the way, in anticipation for the animation I'm trying to build to here, the way I'm representing things on that lower plot is that the area of each one of these bars is telling us the probability of the corresponding value rather than the height. ",
-  "translatedText": "כמו כן, אגב, בציפייה לאנימציה שאני מנסה לבנות לה כאן, הדרך שבה אני מייצג דברים על התרשים התחתון הזה הוא שהשטח של כל אחת מהעמודות האלה אומר לנו את ההסתברות של הערך המתאים ולא הגובה. ",
+  "translatedText": "כמו כן, אגב, בציפייה לאנימציה שאני מנסה לבנות לה כאן, הדרך שבה אני מייצג דברים על התרשים התחתון הזה הוא שהשטח של כל אחת מהעמודות האלה מציין את ההסתברות של הערך המתאים ולא את ההגובה. ",
   "model": "nmt",
   "time_range": [
    1305.13,
@@ -1450,7 +1450,7 @@
  },
  {
   "input": "The reason for this is to set the stage so that it aligns with the way we interpret continuous distributions, where the probability of falling between a range of values is equal to an area under a curve between those values. ",
-  "translatedText": "הסיבה לכך היא להגדיר את השלב כך שיתיישר עם הדרך בה אנו מפרשים התפלגויות רציפות, כאשר ההסתברות ליפול בטווח ערכים שווה לשטח מתחת לעקומה בין הערכים האלו. ",
+  "translatedText": "הסיבה לכך היא להגדיר את השלב כך שיתאים לדרך בה אנו מפרשים התפלגויות רציפות, כאשר ההסתברות ליפול בטווח ערכים שווה לשטח מתחת לעקומה בין הערכים האלו. ",
   "model": "nmt",
   "time_range": [
    1322.27,
@@ -1513,7 +1513,7 @@
  },
  {
   "input": "If we let the size of our sum get a little bit bigger, say going up to 10, and as I change the distribution for x, it largely stays looking like a bell curve, but I can find some distributions that get it to change shape. ",
-  "translatedText": "אם נניח לגודל הסכום שלנו לגדול קצת יותר, נניח עולה ל-10, וכשאני משנה את ההתפלגות עבור x, הוא נשאר ברובו כמו עקומת פעמון, אבל אני יכול למצוא כמה התפלגויות שגורמות לו לשנות צורה . ",
+  "translatedText": "אם נניח לגודל הסכום שלנו לגדול קצת יותר, נניח ל-10, וכשאני משנה את ההתפלגות עבור x, הוא נשאר ברובו כמו עקומת פעמון, אבל אני יכול למצוא כמה התפלגויות שגורמות לו לשנות צורה . ",
   "model": "nmt",
   "time_range": [
    1360.35,
@@ -1558,7 +1558,7 @@
  },
  {
   "input": "No matter where we start, all of the information and nuance for the distribution of x gets washed away, and we tend towards this single universal shape described by a very elegant function for the standard normal distribution, 1 over square root of 2 pi times e to the negative x squared over 2. ",
-  "translatedText": "לא משנה מאיפה נתחיל, כל המידע והניואנסים להתפלגות x נעלמים, ואנו נוטים לצורה אוניברסלית יחידה זו המתוארת על ידי פונקציה אלגנטית מאוד עבור ההתפלגות הנורמלית הסטנדרטית, 1 מעל שורש ריבועי של 2 pi כפול e בחזקת-X השלילי בריבוע על פני 2. ",
+  "translatedText": "לא משנה מאיפה נתחיל, כל המידע והניואנסים להתפלגות x נעלמים, ואנו נוטים לצורה אוניברסלית יחידה זו המתוארת על ידי פונקציה אלגנטית מאוד עבור ההתפלגות הנורמלית הסטנדרטית, 1 חלקי שורש ריבועי של 2 pi כפול e בחזקת מינוס-X בריבוע חלקי 2. ",
   "model": "nmt",
   "time_range": [
    1411.17,
@@ -1594,7 +1594,7 @@
  },
  {
   "input": "Like, what's the mathematical statement that could be proved or disproved that we're claiming here? ",
-  "translatedText": "זא, מהי האמירה המתמטית שניתן להוכיח או להפריך שאנו טוענים כאן? ",
+  "translatedText": "ז"א, מהי האמירה המתמטית שניתן להוכיח או להפריך שאנו טוענים כאן? ",
   "model": "nmt",
   "time_range": [
    1444.81,
@@ -1621,7 +1621,7 @@
  },
  {
   "input": "Again, meaning you can read it as asking how many standard deviations away from the mean is the sum. ",
-  "translatedText": "שוב, כלומר אתם יכולים לקרוא את זה כשאלה בכמה סטיות תקן רחוקות הסכום רחוק מהממוצע. ",
+  "translatedText": "שוב, כלומר אתם יכולים לקרוא את זה כשאלה בכמה סטיות תקן הסכום רחוק מהממוצע. ",
   "model": "nmt",
   "time_range": [
    1460.23,
@@ -1630,7 +1630,7 @@
  },
  {
   "input": "Then the actual rigorous no-jokes-this-time statement of the central limit theorem is that if you consider the probability that this value falls between two given real numbers, a and b, and you consider the limit of that probability as the size of your sum goes to infinity, then that limit is equal to a certain integral, which basically describes the area under a standard normal distribution between those two values. ",
-  "translatedText": "אז ההצהרה המחמירה האמיתית ללא בדיחות-הפעם של משפט הגבול המרכזי היא שאם אתם מחשיבים את ההסתברות שהערך הזה נופל בין שני מספרים ממשיים נתונים, a ו-b, ואתה מחשיב את הגבול של ההסתברות הזו כגודל של הסכום שלכם באינסוף, ואז הגבול הזה שווה לאינטגרל מסוים, שמתאר בעצם את השטח תחת התפלגות נורמלית סטנדרטית בין שני הערכים הללו. ",
+  "translatedText": "אז ההצהרה הקפדנית האמיתית ללא בדיחות-הפעם של משפט הגבול המרכזי היא שאם אתם מחשיבים את ההסתברות שהערך הזה נופל בין שני מספרים ממשיים נתונים, a ו-b, ואתה מחשיב את הגבול של ההסתברות הזו כגודל של הסכום שלכם באינסוף, ואז הגבול הזה שווה לאינטגרל מסוים, שמתאר בעצם את השטח תחת התפלגות נורמלית סטנדרטית בין שני הערכים הללו. ",
   "model": "nmt",
   "time_range": [
    1465.77,
@@ -1639,7 +1639,7 @@
  },
  {
   "input": "Again, there are three underlying assumptions that I have yet to tell you, but other than those, in all of its gory detail, this right here is the central limit theorem. ",
-  "translatedText": "שוב, ישנן שלוש הנחות יסוד שעדיין לא סיפרתי לכם, אבל חוץ מאלה, על כל הפרטים המרשימים שלה, ממש כאן זהו משפט הגבול המרכזי. ",
+  "translatedText": "שוב, ישנן שלוש הנחות יסוד שעדיין לא סיפרתי לכם עליהן, אבל חוץ מאלה, על כל הפרטים המרשימים שלו, ממש כאן זהו משפט הגבול המרכזי. ",
   "model": "nmt",
   "time_range": [
    1491.25,
@@ -1666,7 +1666,7 @@
  },
  {
   "input": "For questions like this, there's a handy rule of thumb about normal distributions, which is that about 68% of your values are going to fall within one standard deviation of the mean, 95% of your values, the thing we care about, fall within two standard deviations of the mean, and a whopping 99.7% of your values will fall within three standard deviations of the mean. ",
-  "translatedText": "לשאלות כאלה, יש כלל אצבע שימושי לגבי התפלגויות נורמליות, שהוא שכ-68% מהערכים עומדים ליפול בתוך סטיית תקן אחת מהממוצע, 95% מהערכים, הדבר שאכפת לנו ממנו, נופלים בתוך שתי סטיות תקן של הממוצע, ו-99. 7% מהערכים שלך יפלו בתוך שלוש סטיות תקן מהממוצע. ",
+  "translatedText": "לשאלות כאלה, יש כלל אצבע שימושי לגבי התפלגויות נורמליות, שהוא שכ-68% מהערכים עומדים ליפול בתוך סטיית תקן אחת מהממוצע, 95% מהערכים, הדבר שאכפת לנו ממנו, נופלים בתוך שתי סטיות תקן של הממוצע, ו-99.7%  מהערכים שלך יפלו בתוך שלוש סטיות תקן מהממוצע. ",
   "model": "nmt",
   "time_range": [
    1527.13,
@@ -1702,7 +1702,7 @@
  },
  {
   "input": "We also need the standard deviation, which requires calculating the variance, which as you know involves adding all the squares of the differences between the values and the means, and it works out to be 2.92, square root of that comes out to be 1.71. ",
-  "translatedText": "5. צריך גם את סטיית התקן שדורשת את חישוב השונות, שכידוע כרוכה בהוספת כל הריבועים של ההפרשים בין הערכים והאמצעים, ומסתבר שזה 2.92, השורש הריבועי של זה יוצא כ-1.71. ",
+  "translatedText": "5. צריך גם את סטיית התקן שדורשת את חישוב השונות, שכידוע כרוכה בהוספת כל הריבועים של ההפרשים בין הערכים והאמצעים, ומסתבר שהיא 2.92, השורש הריבועי של זה יוצא כ-1.71. ",
   "model": "nmt",
   "time_range": [
    1581.53,
@@ -1774,7 +1774,7 @@
  },
  {
   "input": "The expression essentially tells you the empirical average for 100 different die rolls, and that interval we found is now telling you what range you are expecting to see for that empirical average. ",
-  "translatedText": "הביטוי בעצם נותן את הממוצע האמפירי עבור 100 סיבובי קוביות שונים, והמרווח הזה שמצאנו אומר לכם איזה טווח אתם מצפים לראות עבור הממוצע האמפירי הזה. ",
+  "translatedText": "הביטוי בעצם נותן את הממוצע האמפירי עבור 100 הטלות שונות של קוביות, והמרווח הזה שמצאנו אומר לכם איזה טווח אתם מצפים לראות עבור הממוצע האמפירי הזה. ",
   "model": "nmt",
   "time_range": [
    1652.07,
@@ -1792,7 +1792,7 @@
  },
  {
   "input": "In particular, it's worth your time to take a moment mulling over what the standard deviation for this empirical average is, and what happens to it as you look at a bigger and bigger sample of die rolls. ",
-  "translatedText": "בפרט, שווה את הזמן שלך להרהר רגע מה סטיית התקן של הממוצע האמפירי הזה, ומה קורה לו כשאתה מסתכל על מדגם גדול יותר ויותר של הטלות של קוביות. ",
+  "translatedText": "בפרט, שווה את הזמן שלכם להרהר רגע מה סטיית התקן של הממוצע האמפירי הזה, ומה קורה לו כשאתם מסתכלים על מדגם גדול יותר ויותר של הטלות של קוביות. ",
   "model": "nmt",
   "time_range": [
    1677.59,
@@ -1855,7 +1855,7 @@
  },
  {
   "input": "Sometimes in the literature you'll see these two assumptions lumped together under the initials IID for independent and identically distributed. ",
-  "translatedText": "לפעמים בספרות תראו את שתי ההנחות הללו מחוברות יחדי תחת ראשי התיבות IID (independent and identically distributed). ",
+  "translatedText": "לפעמים בספרות תראו את שתי ההנחות הללו מחוברות יחד תחת ראשי התיבות IID (independent and identically distributed). ",
   "model": "nmt",
   "time_range": [
    1722.85,
@@ -1873,7 +1873,7 @@
  },
  {
   "input": "I mean, think about it. ",
-  "translatedText": "כלומר, תחשובו על זה. ",
+  "translatedText": "כלומר, תחשבו על זה. ",
   "model": "nmt",
   "time_range": [
    1735.71,
@@ -1882,7 +1882,7 @@
  },
  {
   "input": "Is it the case that the way a ball bounces off of one of the pegs is independent from how it's going to bounce off the next peg? ",
-  "translatedText": "האם זה המקרה שהאופן שבו כדור קופץ מאחת מהיתדות אינה תלויה באיך הוא עומד לקפוץ מהיתד הבא? ",
+  "translatedText": "האם זה המקרה שהאופן שבו כדור קופץ מאחת מהיתדות אינו תלוי באיך הוא עומד לקפוץ מהיתד הבא? ",
   "model": "nmt",
   "time_range": [
    1736.97,
@@ -1927,7 +1927,7 @@
  },
  {
   "input": "Maybe it hits one peg glancing to the left, meaning the outcomes are hugely skewed in that direction, and then hits the next one glancing to the right. ",
-  "translatedText": "אולי זה פוגע ביתד אחד ונזרק שמאלה, כלומר התוצאות מוטות מאוד בכיוון הזה, ואז פוגע ביתד הבא ומועף ימינה. ",
+  "translatedText": "אולי הוא פוגע ביתד אחד ונזרק שמאלה, כלומר התוצאות מוטות מאוד בכיוון הזה, ואז פוגע ביתד הבא ומועף ימינה. ",
   "model": "nmt",
   "time_range": [
    1756.71,
@@ -1945,7 +1945,7 @@
  },
  {
   "input": "It's also that those assumptions were necessary for this to actually be an example of the central limit theorem. ",
-  "translatedText": "זה גם כדי שההנחות הללו היו הכרחיות כדי שזה יהיה למעשה דוגמה למשפט הגבול המרכזי. ",
+  "translatedText": "זה היה גם כי ההנחות הללו היו הכרחיות כדי שזו תהיה למעשה דוגמה למשפט הגבול המרכזי. ",
   "model": "nmt",
   "time_range": [
    1771.97,
@@ -2026,7 +2026,7 @@
  },
  {
   "input": "But in those situations, as you consider adding many different instantiations of that variable and letting that sum approach infinity, even if the first two assumptions hold, it is very much a possibility that the thing you tend towards is not actually a normal distribution. ",
-  "translatedText": "אבל במצבים האלה, כאשר אתם שוקלים להוסיף מופעים רבים ושונים של אותו משתנה ולתת לסכום הזה להתקרב לאינסוף, גם אם שתי ההנחות הראשונות מתקיימות, קיימת אפשרות מאוד מעשית שהדבר שאתה נוטה לכיוונו אינו למעשה התפלגות נורמלית. ",
+  "translatedText": "אבל במצבים האלה, כאשר אתם שוקלים להוסיף מופעים רבים ושונים של אותו משתנה ולתת לסכום הזה להתקרב לאינסוף, גם אם שתי ההנחות הראשונות מתקיימות, קיימת אפשרות מאוד מעשית שהדבר שאתם נוטים לכיוונו אינו למעשה התפלגות נורמלית. ",
   "model": "nmt",
   "time_range": [
    1827.55,
@@ -2035,7 +2035,7 @@
  },
  {
   "input": "If you've understood everything up to this point, you now have a very strong foundation in what the central limit theorem is all about. ",
-  "translatedText": "אם הבנת הכל עד לנקודה זו, כעת יש לך בסיס חזק מאוד במה עוסק משפט הגבול המרכזי. ",
+  "translatedText": "אם הבנתם הכל עד לנקודה זו, כעת יש לכם בסיס חזק מאוד במה עוסק משפט הגבול המרכזי. ",
   "model": "nmt",
   "time_range": [
    1842.15,
@@ -2044,7 +2044,7 @@
  },
  {
   "input": "And next up, I'd like to explain why it is that this particular function is the thing that we tend towards, and why it has a pi in it, what it has to do with circles. ",
-  "translatedText": "ובהמשך, אני רוצה להסביר מדוע הפונקציה הספציפית הזו היא הדבר שאליו אנו נוטים לכיוונו, למה יש בה פאי, ומה זה קשור לעיגולים. ",
+  "translatedText": "ובהמשך, אני רוצה להסביר מדוע הפונקציה הספציפית הזו היא הדבר שאליו אנו נוטים לכיוונו, למה יש בה פאי, ומה זה קשור למעגלים. ",
   "model": "nmt",
   "time_range": [
    1848.29,


### PR DESCRIPTION
Enhancing the previous enhancement to the CTL Hebrew subtitles, after viewing the video with the updated subtitles.  It would really help if there will be **a way to view the updated subtitles with the video before committing the PR**.

Also, I noticed in one case that the English text used for the Hebrew translation was not the same as the English subtitles for the video.  If it is possible to **translate the text only after the English text is final**, it would help for both the auto translation and the updates to the translation.