### PR TITLE
[French] Updating 2023/moser-reboot

### DIFF
--- a/2023/moser-reboot/french/sentence_translations.json
+++ b/2023/moser-reboot/french/sentence_translations.json
@@ -461,7 +461,7 @@
  {
   "input": "In graph theory lingo, you typically call those nodes vertices and the lines connecting them edges, and the wonderful fact that we can leverage is that if you count up the number of vertices, and then you subtract the total number of edges, and then you consider the number of regions that this graph has cut the plane into, including that infinite outer region, then always, no matter what planar graph you started with, you get two.",
   "model": "nmt",
-  "translatedText": "Dans le jargon de la théorie des graphes, vous appelez généralement ces nœuds sommets et les lignes qui les relient arêtes, et le fait merveilleux que nous pouvons exploiter est que si vous comptez le nombre de sommets, puis vous soustrayez le nombre total d'arêtes, et qu'ensuite vous considérez le nombre de régions en lesquelles ce graphe a découpé le plan, y compris cette région extérieur, alors toujours, quel que soit le graphe planaire avec lequel vous avez commencé, vous obtenez deux.",
+  "translatedText": "Dans le jargon de la théorie des graphes, vous appelez généralement ces nœuds sommets et les lignes qui les relient arêtes, et le fait merveilleux que nous pouvons utiliser est que si vous comptez le nombre de sommets, puis vous soustrayez le nombre total d'arêtes, et qu'ensuite vous considérez le nombre de régions en lesquelles ce graphe a découpé le plan, y compris cette région extérieur, alors toujours, quel que soit le graphe planaire avec lequel vous avez commencé, vous obtenez deux.",
   "time_range": [
    402.28,
    425.3
@@ -488,7 +488,7 @@
  {
   "input": "Draw any graph, make sure the lines don't intersect, and then count the number of vertices, subtract the number of edges, and count the number of regions that it's cut the plane into, and no matter what diagram you chose, the answer always works out to be two.",
   "model": "nmt",
-  "translatedText": "Dessinez n'importe quel graphe, assurez-vous que les lignes ne se coupent pas, puis comptez le nombre de sommets, soustrayez le nombre d'arêtes et comptez le nombre de régions dans lesquelles le plan est coupé, et quel que soit le diagramme que vous avez choisi, la réponse est toujours deux.",
+  "translatedText": "Dessinez n'importe quel graphe, assurez-vous que les lignes ne se croisent pas, puis comptez le nombre de sommets, soustrayez le nombre d'arêtes et comptez le nombre de régions en lesquelles le plan est coupé, et quel que soit le diagramme que vous avez choisi, vous trouverez toujours deux.",
   "time_range": [
    428.12,
    442.16
@@ -497,7 +497,7 @@
  {
   "input": "More commonly you would see this written as v minus e plus f is equal to two, since originally the equation described the vertices, edges, and faces of three-dimensional polyhedra, and if you want to know why this magical fact is true, you can think about building up your graph from a trivial case where you have a single node and no edges.",
   "model": "nmt",
-  "translatedText": "Plus communément, vous verriez cela écrit sous la forme v moins e plus f est égal à deux, puisqu'à l'origine l'équation décrivait les sommets, les arêtes et les faces des polyèdres tridimensionnels, et si vous voulez savoir pourquoi ce fait magique est vrai, vous pouvez penser à construire votre graphique à partir d'un cas trivial où vous avez un seul nœud et aucune arête.",
+  "translatedText": "Plus communément, vous verriez cela écrit sous la forme v moins e plus f est égal à deux, puisqu'à l'origine l'équation décrivait les sommets (v), les arêtes (e) et les faces des polyèdres tridimensionnels, et si vous voulez savoir pourquoi cette astuce est vraie, vous pouvez essayer de construire votre graphique à partir d'un cas trivial où vous avez un seul nœud et aucune arête.",
   "time_range": [
    443.18,
    462.82
@@ -506,7 +506,7 @@
  {
   "input": "So v would be equal to one, f would also be equal to one because of that infinite outer region, and e is zero, so the equation is obviously true.",
   "model": "nmt",
-  "translatedText": "Donc v serait égal à un, f serait également égal à un à cause de cette région externe infinie, et e est nul, donc l'équation est évidemment vraie.",
+  "translatedText": "Ici v serait égal à un, f serait également égal à un à cause de cette région externe infinie, et e est nul, donc l'équation est trivialement vraie.",
   "time_range": [
    463.46,
    471.96
@@ -524,7 +524,7 @@
  {
   "input": "But if a new edge doesn't correspond to a new vertex, meaning it's connecting to a pre-existing vertex, that means that it's enclosed a new region of space, so e goes up by one, but f also goes up by one, which again leaves the equation balanced.",
   "model": "nmt",
-  "translatedText": "Mais si une nouvelle arête ne correspond pas à un nouveau sommet, c'est-à-dire qu'elle se connecte à un sommet préexistant, cela signifie qu'elle est entourée d'une nouvelle région de l'espace, donc e monte de un, mais f monte aussi de un, ce qui laisse encore une fois l’équation équilibrée.",
+  "translatedText": "Mais si une nouvelle arête ne correspond pas à un nouveau sommet, c'est-à-dire qu'elle se connecte à un sommet préexistant, cela signifie qu'elle délimite une nouvelle région de l'espace, donc e monte de un, mais f monte aussi de un, ce qui laisse encore une fois l’équation équilibrée.",
   "time_range": [
    485.5,
    499.8
@@ -533,7 +533,7 @@
  {
   "input": "So as you build up some potentially complicated graph, v minus e plus f always stays fixed at two.",
   "model": "nmt",
-  "translatedText": "Ainsi, lorsque vous construisez un graphique potentiellement compliqué, v moins e plus f reste toujours fixé à deux.",
+  "translatedText": "Ainsi, lorsque vous construisez un graphique potentiellement compliqué, v moins e plus f reste toujours égal à deux.",
   "time_range": [
    500.92,
    507.14
@@ -542,7 +542,7 @@
  {
   "input": "This equation has a name, it's called Euler's characteristic formula, and I remember when I made a video about this a while ago I had some dumb joke in there about Euler's being German for beautiful, and there were a decent number of comments that were like, you know, Euler is actually a person, I speak German, and it doesn't mean beautiful.",
   "model": "nmt",
-  "translatedText": "Cette équation a un nom, elle s'appelle la formule caractéristique d'Euler, et je me souviens que lorsque j'ai fait une vidéo à ce sujet il y a quelque temps, j'y avais fait une blague stupide sur le fait qu'Euler signifiait beau en allemand, et il y avait un bon nombre de commentaires qui étaient comme , tu sais, Euler est en fait une personne, je parle allemand, et ça ne veut pas dire beau.",
+  "translatedText": "Cette équation a un nom, elle s'appelle la formule caractéristique d'Euler, et je me souviens que lorsque j'ai fait une vidéo à ce sujet il y a quelque temps, j'avais fait une blague stupide sur le fait qu'Euler signifiait beau en allemand, et il y avait un bon nombre de commentaires qui disaient, tu sais, Euler est en fait une personne, je parle allemand, et ça ne veut pas dire beau.",
   "time_range": [
    507.6,
    523.84
@@ -551,7 +551,7 @@
  {
   "input": "Anyway, for our purposes it gives us a tool for counting the number of regions that a planar graph has cut space into.",
   "model": "nmt",
-  "translatedText": "Quoi qu'il en soit, pour nos besoins, cela nous donne un outil pour compter le nombre de régions dans lesquelles un graphe planaire a découpé l'espace.",
+  "translatedText": "Quoi qu'il en soit, pour ce qu'on veut en faire, cela nous donne un outil pour compter le nombre de régions dans lesquelles un graphe planaire a découpé l'espace.",
   "time_range": [
    524.58,
    531.24
@@ -578,7 +578,7 @@
  {
   "input": "And at first you might complain, but we can't use Euler's formula in this case, because it only applies to planar graphs, and in our case the lines absolutely intersect with each other.",
   "model": "nmt",
-  "translatedText": "Et au début, vous pourriez vous plaindre, mais nous ne pouvons pas utiliser la formule d'Euler dans ce cas, car elle ne s'applique qu'aux graphes planaires, et dans notre cas, les lignes se coupent absolument.",
+  "translatedText": "Et au début, vous pourriez vous plaindre et dire que nous ne pouvons pas utiliser la formule d'Euler dans ce cas, car elle ne s'applique qu'aux graphes planaires, et dans notre cas, les lignes se coupent certainement.",
   "time_range": [
    547.82,
    557.02
@@ -587,7 +587,7 @@
  {
   "input": "We even counted how many times they intersect with each other.",
   "model": "nmt",
-  "translatedText": "Nous avons même compté combien de fois ils se croisent.",
+  "translatedText": "Nous avons même compté combien de fois elles se coupent.",
   "time_range": [
    557.2,
    559.72
@@ -596,7 +596,7 @@
  {
   "input": "But the key is to treat this as a new graph where those intersection points are themselves vertices, so the total number of vertices here would not be n, but n plus the n choose 4 total intersection points.",
   "model": "nmt",
-  "translatedText": "Mais la clé est de traiter cela comme un nouveau graphique où ces points d'intersection sont eux-mêmes des sommets, donc le nombre total de sommets ici ne serait pas n, mais n plus n, choisissez 4 points d'intersection au total.",
+  "translatedText": "Mais la clé est de traiter cela comme un nouveau graphe où ces points d'intersection sont eux-mêmes des sommets, donc le nombre total de sommets ici ne serait pas n, mais n plus les 4 parmi n points d'intersection au total.",
   "time_range": [
    560.24,
    571.78
@@ -605,7 +605,7 @@
  {
   "input": "That in turn chops up all of our chords into a larger number of edges, it's much more than just n choose 2, and initially it might seem really annoying and tricky to think about exactly how much it's chopped them up, but one way you can think about it is that every intersection point takes what started as two separate lines and then turns it into four lines.",
   "model": "nmt",
-  "translatedText": "Cela coupe à son tour tous nos accords en un plus grand nombre d'arêtes, c'est bien plus que simplement n choisir 2, et au début, cela peut sembler vraiment ennuyeux et délicat de penser exactement à quel point cela les a coupés, mais une façon de le faire Pensez-y, c'est que chaque point d'intersection prend ce qui a commencé comme deux lignes distinctes et le transforme ensuite en quatre lignes.",
+  "translatedText": "Cela coupe à son tour tous nos cordes en un plus grand nombre d'arêtes, c'est bien plus que juste 2 parmi n, et au début, cela peut sembler vraiment désagréable et délicat d'imaginer exactement à quel point cela les a divisé, mais une façon d'y penser est que chaque point d'intersection prend ce qui était au début deux lignes distinctes et les transforme ensuite en quatre lignes.",
   "time_range": [
    572.06,
    591.1
@@ -632,7 +632,7 @@
  {
   "input": "The total number of edges after the chopping would look like three plus two times two, or seven.",
   "model": "nmt",
-  "translatedText": "Le nombre total d’arêtes après le découpage ressemblerait à trois plus deux fois deux, ou sept.",
+  "translatedText": "Le nombre total d’arêtes après le découpage serait à trois plus deux fois deux, ou sept.",
   "time_range": [
    600.92,
    607.58
@@ -650,7 +650,7 @@
  {
   "input": "And for the diagram we care about where we started off with n choose two separate lines and they're getting chopped up at n choose four points in the middle, you would end up with n choose two plus two times n choose four edges.",
   "model": "nmt",
-  "translatedText": "Et pour le diagramme, nous nous soucions de l'endroit où nous avons commencé avec n, choisissez deux lignes distinctes et elles sont découpées en n, choisissez quatre points au milieu, vous vous retrouveriez avec n, choisissez deux plus deux fois n, choisissez quatre bords.",
+  "translatedText": "Et pour le diagramme, nous avons commencé avec avec 2 parmi n lignes distinctes, et elles sont découpées en 4 parmi n points au milieu, vous vous retrouveriez avec deux parmi n plus deux fois 4 parmi n bords.",
   "time_range": [
    616.08,
    630.14
@@ -659,7 +659,7 @@
  {
   "input": "And actually there are a few more than that, because we're including the circle we also need to count the n different arcs that sit on the outside of this diagram.",
   "model": "nmt",
-  "translatedText": "Et en fait, il y en a un peu plus, parce que nous incluons le cercle, nous devons également compter les n arcs différents qui se trouvent à l'extérieur de ce diagramme.",
+  "translatedText": "Et en fait, il y en a un peu plus, parce que nous incluons le cercle, nous devons également compter les n arcs qui se trouvent à l'extérieur de ce diagramme.",
   "time_range": [
    630.68,
    638.56
@@ -677,7 +677,7 @@
  {
   "input": "Pulling up our variant of Euler's formula that counts the number of regions we'll plug in the expression for the number of vertices which is n plus the n choose four intersection points, and you also plug in the slightly larger expression for the new number of edges n choose two plus two times n choose four plus n, and the expression has a lot of nice cancellation, for example you are adding an n but also subtracting an n and you're adding two copies of n choose four but subtracting another copy of n choose four and when all the dust settles the answer to the question is one plus n choose two plus n choose four.",
   "model": "nmt",
-  "translatedText": "En tirant notre variante de la formule d'Euler qui compte le nombre de régions, nous insérons l'expression pour le nombre de sommets qui est n plus n, choisissons quatre points d'intersection, et nous insérons également l'expression légèrement plus grande pour le nouveau nombre de bords n choisissez deux plus deux fois n choisissez quatre plus n, et l'expression a beaucoup d'annulations intéressantes, par exemple vous ajoutez un n mais soustrayez également un n et vous ajoutez deux copies de n choisissez quatre mais soustrayez une autre copie sur n, choisissez-en quatre et lorsque toute la poussière retombe, la réponse à la question est un plus n, choisissez deux, plus n, choisissez quatre.",
+  "translatedText": "En tirant notre variante de la formule d'Euler qui compte le nombre de régions, nous insérons l'expression pour le nombre de sommets qui est n plus 4 parmi n points d'intersection, et nous insérons également l'expression légèrement plus grande du nouveau nombre de bords deux parmi n plus deux fois quatre parmi n plus n, et l'expression a beaucoup d'annulations intéressantes, par exemple vous ajoutez un n mais soustrayez également un n et vous ajoutez deux copies de quatre parmi n mais soustrayez une autre copie de quatre parmi n, et lorsque la poussière retombe, la réponse à la question est un plus deux parmi n, plus quatre parmi n.",
   "time_range": [
    643.08,
    675.72
@@ -695,7 +695,7 @@
  {
   "input": "I give you one of these circle diagrams with n points on the boundary and using this formula you can figure out how many regions the circle has been cut into.",
   "model": "nmt",
-  "translatedText": "Je vous donne un de ces diagrammes circulaires avec n points sur la frontière et en utilisant cette formule, vous pouvez déterminer le nombre de régions dans lesquelles le cercle a été découpé.",
+  "translatedText": "Je vous donne un de ces diagrammes circulaires avec n points sur le contour et en utilisant cette formule, vous pouvez déterminer le nombre de régions dans lesquelles le cercle a été découpé.",
   "time_range": [
    679.94,
    687.82
@@ -704,7 +704,7 @@
  {
   "input": "But of course we're not really done because that doesn't scratch the itch.",
   "model": "nmt",
-  "translatedText": "Mais bien sûr, nous n’avons pas vraiment terminé car cela ne soulage pas les démangeaisons.",
+  "translatedText": "Mais bien sûr, nous n’avons pas vraiment terminé car cela ne soulage pas nos démangeaisons.",
   "time_range": [
    688.58,
    691.2
@@ -713,7 +713,7 @@
  {
   "input": "Why is it the case that this looks like powers of two and then falls short by just one?",
   "model": "nmt",
-  "translatedText": "Pourquoi cela ressemble-t-il à des puissances de deux et échoue-t-il ensuite à un seul?",
+  "translatedText": "Pourquoi cela ressemble-t-il à des puissances de deux et s'en éloigne de seulement un?",
   "time_range": [
    691.62,
    696.18
@@ -731,7 +731,7 @@
  {
   "input": "You know this triangle, it's the one where each term looks like a sum of the two different terms above it and there are basically two facts we need to bring in about this triangle.",
   "model": "nmt",
-  "translatedText": "Vous connaissez ce triangle, c'est celui où chaque terme ressemble à la somme des deux termes différents au-dessus et il y a essentiellement deux faits que nous devons prendre en compte à propos de ce triangle.",
+  "translatedText": "Vous connaissez ce triangle, c'est celui où chaque terme ressemble à la somme des deux termes différents au-dessus, et il y a essentiellement deux faits que nous devons considérer à propos de ce triangle.",
   "time_range": [
    701.7,
    709.92
@@ -740,7 +740,7 @@
  {
   "input": "The first is that every term inside this triangle looks like n choose k for some value of n and k.",
   "model": "nmt",
-  "translatedText": "La première est que chaque terme à l’intérieur de ce triangle ressemble à n, choisissez k pour une valeur de n et k.",
+  "translatedText": "La première est que chaque terme à l’intérieur de ce triangle ressemble à k parmi n pour une valeur de n et k.",
   "time_range": [
    710.52,
    717.02
@@ -758,7 +758,7 @@
  {
   "input": "The way to think about it is by indexing the rows and columns starting from zero.",
   "model": "nmt",
-  "translatedText": "La façon d’y penser est d’indexer les lignes et les colonnes en partant de zéro.",
+  "translatedText": "On peut y penser en indexant les lignes et les colonnes en partant de zéro.",
   "time_range": [
    726.62,
    730.1
@@ -767,7 +767,7 @@
  {
   "input": "For example if you count up to the 0 1 2 3 4 5th row and you count in to the 0 1 2 3rd element you see 10 and indeed 5 choose 3 is equal to 10.",
   "model": "nmt",
-  "translatedText": "Par exemple, si vous comptez jusqu'au 0 1 2 3 4 5ème ligne et que vous comptez jusqu'au 0 1 2 3ème élément, vous voyez 10 et effectivement 5 choisissez 3 est égal à 10.",
+  "translatedText": "Par exemple, si vous comptez jusqu'au 0 1 2 3 4 5ème ligne et que vous comptez jusqu'au 0 1 2 3ème élément, vous voyez 10 et effectivement 3 parmi 5 est égal à 10.",
   "time_range": [
    730.54,
    742.04
@@ -776,7 +776,7 @@
  {
   "input": "If you've never seen this before and you want to know why it's true there's a really lovely argument.",
   "model": "nmt",
-  "translatedText": "Si vous n'avez jamais vu cela auparavant et que vous voulez savoir pourquoi c'est vrai, il y a une très belle dispute.",
+  "translatedText": "Si vous n'avez jamais vu cela auparavant et que vous voulez savoir pourquoi c'est vrai, il y a un très joli argument.",
   "time_range": [
    742.86,
    747.1
@@ -785,7 +785,7 @@
  {
   "input": "I'll leave it up as an exercise but moving on to the second thing that we need to know.",
   "model": "nmt",
-  "translatedText": "Je vais laisser cela comme un exercice, mais je passe à la deuxième chose que nous devons savoir.",
+  "translatedText": "Je vais le laisser cela comme exercice, et je passe à la deuxième chose que nous devons savoir.",
   "time_range": [
    747.22,
    751.7
@@ -812,7 +812,7 @@
  {
   "input": "Maybe at this point you're a little gun shy about jumping to conclusions about powers of 2 too quickly but in this case it's a genuine pattern.",
   "model": "nmt",
-  "translatedText": "Peut-être qu'à ce stade, vous hésitez un peu à tirer des conclusions trop rapides sur les puissances de 2, mais dans ce cas, il s'agit d'un véritable modèle.",
+  "translatedText": "Peut-être qu'à ce stade, vous hésitez un peu à tirer des conclusions trop rapides sur les puissances de 2, mais dans ce cas, il s'agit d'un véritable patterne.",
   "time_range": [
    766.18,
    772.64
@@ -821,7 +821,7 @@
  {
   "input": "There's no trickery being pulled and there are a few ways that you can think about why there should be powers of 2 here.",
   "model": "nmt",
-  "translatedText": "Il n’y a aucune supercherie et il existe plusieurs façons de réfléchir aux raisons pour lesquelles il devrait y avoir des puissances de 2 ici.",
+  "translatedText": "Il n’y a aucune supercherie et il existe plusieurs façons d'imaginer les raisons pour lesquelles il devrait y avoir des puissances de 2 ici.",
   "time_range": [
    772.74,
    778.5
@@ -830,7 +830,7 @@
  {
   "input": "The one that I like is to think about how as you go from that first row to the next one it's like the number 1 is sort of donating two copies of itself into the next row.",
   "model": "nmt",
-  "translatedText": "Celui que j'aime, c'est penser à la façon dont, lorsque vous passez de cette première rangée à la suivante, c'est comme si le chiffre 1 faisait en quelque sorte don de deux copies de lui-même dans la rangée suivante.",
+  "translatedText": "Celles que j'aime, c'est penser à la façon dont, lorsque vous passez de cette première rangée à la suivante, c'est comme si le chiffre 1 faisait en quelque sorte don de deux copies de lui-même dans la rangée suivante.",
   "time_range": [
    779.08,
    787.78
@@ -839,7 +839,7 @@
  {
   "input": "Likewise as you go from the second row to the third each of those ones is donating two copies of itself to the next row and in general as you go from one row to the next each number donates two copies of itself to the one below.",
   "model": "nmt",
-  "translatedText": "De même, lorsque vous passez de la deuxième rangée à la troisième, chacun de ces numéros fait don de deux copies de lui-même à la rangée suivante et en général, lorsque vous passez d'une rangée à la suivante, chaque numéro fait don de deux copies de lui-même à celle du dessous.",
+  "translatedText": "De même, lorsque vous passez de la deuxième rangée à la troisième, chacun de ces numéros fait don de deux copies de lui-même à la rangée suivante et de manière générale, lorsque vous passez d'une rangée à la suivante, chaque numéro fait don de deux copies de lui-même à celle du dessous.",
   "time_range": [
    788.58,
    801.3
@@ -866,7 +866,7 @@
  {
   "input": "The answer to our question looked like 1 plus n choose 2 plus n choose 4.",
   "model": "nmt",
-  "translatedText": "La réponse à notre question ressemblait à 1 plus n choisissez 2 plus n choisissez 4.",
+  "translatedText": "La réponse à notre question ressemblait à 1 plus 2 parmoi n plus 4 parmi n.",
   "time_range": [
    812.7,
    817.32
@@ -911,7 +911,7 @@
  {
   "input": "When you situate this formula inside Pascal's triangle and you relate it to the previous row what you're doing is adding up the entirety of that previous row.",
   "model": "nmt",
-  "translatedText": "Lorsque vous situez cette formule à l'intérieur du triangle de Pascal et que vous la reliez à la ligne précédente, vous additionnez l'intégralité de cette ligne précédente.",
+  "translatedText": "Lorsque vous placez cette formule à l'intérieur du triangle de Pascal et que vous la reliez à la ligne précédente, vous additionnez l'intégralité de cette ligne précédente.",
   "time_range": [
    848.16,
    856.42
@@ -920,7 +920,7 @@
  {
   "input": "The point at which this breaks is for n equals 6 because in that case when you relate this to the previous row adding up the first five elements of that row it doesn't cover the whole thing.",
   "model": "nmt",
-  "translatedText": "Le point auquel cela se brise est pour n est égal à 6 car dans ce cas, lorsque vous reliez cela à la ligne précédente en additionnant les cinq premiers éléments de cette ligne, cela ne couvre pas la totalité.",
+  "translatedText": "L'endroit auquel ça se brise est pour n est égal à 6 car dans ce cas, lorsque vous reliez cela à la ligne précédente en additionnant les cinq premiers éléments de cette ligne, cela n'en couvre pas la totalité.",
   "time_range": [
    857.32,
    867.26
@@ -929,7 +929,7 @@
  {
   "input": "It falls short specifically by just one which is why we miss the power of 2 and why it falls short specifically by just one.",
   "model": "nmt",
-  "translatedText": "Il manque spécifiquement d'un seul, c'est pourquoi nous manquons la puissance de 2 et pourquoi il manque spécifiquement d'un seul.",
+  "translatedText": "Il manque exactement un, c'est pourquoi nous manquons la puissance de 2 et pourquoi nous manquons spécifiquement d'un.",
   "time_range": [
    867.52,
    874.96
@@ -938,7 +938,7 @@
  {
   "input": "Also notice what happens when we plug in n equals 10.",
   "model": "nmt",
-  "translatedText": "Notez également ce qui se passe lorsque nous connectons n est égal à 10.",
+  "translatedText": "Notez également ce qui se passe lorsque nous insérons n est égal à 10.",
   "time_range": [
    875.68,
    878.36
@@ -974,7 +974,7 @@
  {
   "input": "Stepping back to summarize we started by counting the total number of chords and the total number of intersection points which by thinking about the right associations is the same as computing n choose 2 and n choose 4.",
   "model": "nmt",
-  "translatedText": "En prenant du recul pour résumer, nous avons commencé par compter le nombre total d'accords et le nombre total de points d'intersection, ce qui, en réfléchissant aux bonnes associations, équivaut à calculer n choisir 2 et n choisir 4.",
+  "translatedText": "En prenant du recul pour résumer, nous avons commencé par compter le nombre total de cordes et le nombre total de points d'intersection, ce qui, en réfléchissant aux bonnes associations, équivaut à calculer deux parmi n et 4 parmi n.",
   "time_range": [
    909.34,
    921.14
@@ -983,7 +983,7 @@
  {
   "input": "Bringing in Euler's formula this let us get an exact closed form expression for the number of regions inside the circle.",
   "model": "nmt",
-  "translatedText": "En introduisant la formule d'Euler, nous obtenons une expression exacte sous forme fermée pour le nombre de régions à l'intérieur du cercle.",
+  "translatedText": "En introduisant la formule d'Euler, nous obtenons une expression exacte sous forme close qui donne le nombre de régions à l'intérieur du cercle.",
   "time_range": [
    921.52,
    927.84
@@ -1001,7 +1001,7 @@
  {
   "input": "So yes, Moser's circle problem is a cautionary tale about being wary of patterns without proof but at a deeper level it also tells us that what's sometimes chalked up to be coincidence still leaves room for satisfying understandings.",
   "model": "nmt",
-  "translatedText": "Alors oui, le problème du cercle de Moser est une mise en garde contre la méfiance à l'égard des modèles sans preuve, mais à un niveau plus profond, il nous dit également que ce qui est parfois considéré comme une coïncidence laisse encore place à des compréhensions satisfaisantes.",
+  "translatedText": "Alors oui, le problème du cercle de Moser est une mise en garde à l'égard des modèles sans preuve, mais à un niveau plus profond, il nous dit également que ce qui est parfois considéré comme une coïncidence laisse encore place à des explications satisfaisantes.",
   "time_range": [
    937.28,
    949.86

--- a/2023/moser-reboot/french/sentence_translations.json
+++ b/2023/moser-reboot/french/sentence_translations.json
@@ -2,7 +2,7 @@
  {
   "input": "This is a very famous cautionary tale in math, known as Moser's circle problem.",
   "model": "nmt",
-  "translatedText": "Il s'agit d'une mise en garde très célèbre en mathématiques, connue sous le nom de problème du cercle de Moser.",
+  "translatedText": "Voici une mise en garde très célèbre en mathématiques, connue sous le nom de problème du cercle de Moser.",
   "time_range": [
    0.0,
    4.26
@@ -11,7 +11,7 @@
  {
   "input": "Some of you may have seen this before, but what I want to do here is really explain what's going on.",
   "model": "nmt",
-  "translatedText": "Certains d'entre vous ont peut-être déjà vu cela, mais ce que je veux faire ici, c'est vraiment expliquer ce qui se passe.",
+  "translatedText": "Certains d'entre vous ont peut-être déjà vu ça, mais ce que je veux faire ici, c'est vraiment expliquer ce qui se passe.",
   "time_range": [
    4.78,
    9.08
@@ -20,7 +20,7 @@
  {
   "input": "The way this starts is we take a circle and put two points on that circle and connect them with a line, that is a chord of the circle, and note that it divides the circle into two different regions.",
   "model": "nmt",
-  "translatedText": "La façon dont cela commence est que nous prenons un cercle et mettons deux points sur ce cercle et les connectons avec une ligne, qui est une corde du cercle, et notons qu'elle divise le cercle en deux régions différentes.",
+  "translatedText": "Pour commencer nous prenons un cercle et mettons deux points sur ce cercle et les connectons avec une ligne, c'est une corde du cercle, et notons qu'elle divise le cercle en deux régions différentes.",
   "time_range": [
    9.74,
    20.06
@@ -29,7 +29,7 @@
  {
   "input": "If I add a third point and then connect that to the previous two points with two more chords, then these lines all divide the circle into four separate regions.",
   "model": "nmt",
-  "translatedText": "Si j'ajoute un troisième point et que je le connecte ensuite aux deux points précédents avec deux accords supplémentaires, alors ces lignes divisent toutes le cercle en quatre régions distinctes.",
+  "translatedText": "Si j'ajoute un troisième point et que je le connecte ensuite aux deux points précédents avec deux cordes supplémentaires, alors ces lignes divisent toutes le cercle en quatre régions distinctes.",
   "time_range": [
    20.66,
    29.26
@@ -38,7 +38,7 @@
  {
   "input": "Then if you add a fourth point and connect that to the previous three, and you play the same game, you count up how many regions has this cut the circle into, you end up with eight.",
   "model": "nmt",
-  "translatedText": "Ensuite, si vous ajoutez un quatrième point et que vous le connectez aux trois précédents, et que vous jouez au même jeu, vous comptez le nombre de régions dans lesquelles cela a coupé le cercle, vous vous retrouvez avec huit.",
+  "translatedText": "Ensuite, si vous ajoutez un quatrième point et que vous le connectez aux trois précédents, et que vous faites la même chose, vous comptez en combien de régions le cercle a été coupé, vous tombez sur huit.",
   "time_range": [
    29.26,
    38.94
@@ -47,7 +47,7 @@
  {
   "input": "Add a fifth point to the circle, connect it to the previous four, count up the total number of regions, and if you're careful with your counting, you'll get a total of sixteen.",
   "model": "nmt",
-  "translatedText": "Ajoutez un cinquième point au cercle, reliez-le aux quatre précédents, comptez le nombre total de régions, et si vous faites attention à votre comptage, vous obtiendrez un total de seize.",
+  "translatedText": "Ajoutez un cinquième point au cercle, reliez-le aux quatre précédents, comptez le nombre total de régions, et si vous comptez avec attention, vous obtiendrez un total de seize.",
   "time_range": [
    39.54,
    48.14
@@ -56,7 +56,7 @@
  {
   "input": "Naturally, you can guess what might come next, but would you bet your life on it?",
   "model": "nmt",
-  "translatedText": "Naturellement, vous pouvez deviner ce qui pourrait arriver ensuite, mais parieriez-vous votre vie là-dessus?",
+  "translatedText": "Naturellement, vous pouvez deviner ce qui risque d'arriver ensuite, mais y metteriez vous votre main à couper?",
   "time_range": [
    48.96,
    52.28
@@ -65,7 +65,7 @@
  {
   "input": "Add a sixth point, connect it to all the previous ones, and if you carefully count up all the different regions, you end up not with the power of two you might have expected, but just one shy of it.",
   "model": "nmt",
-  "translatedText": "Ajoutez un sixième point, connectez-le à tous les précédents, et si vous comptez soigneusement toutes les différentes régions, vous n'obtenez pas la puissance de deux à laquelle vous auriez pu vous attendre, mais juste une de moins.",
+  "translatedText": "Ajoutez un sixième point, connectez-le à tous les précédents, et si vous comptez soigneusement toutes les différentes régions, vous n'obtenez pas la puissance de deux à laquelle vous auriez pu vous attendre, mais juste un de moins.",
   "time_range": [
    52.54,
    62.66
@@ -74,7 +74,7 @@
  {
   "input": "Some of you might be raising your hand saying, doesn't it depend on where we put the points?",
   "model": "nmt",
-  "translatedText": "Certains d'entre vous lèveront peut-être la main et demanderont : cela ne dépend-il pas de la manière dont nous plaçons les points?",
+  "translatedText": "Certains d'entre vous vont peut être se demander si cela ne dépend pas de la manière dont on place les points.",
   "time_range": [
    64.04,
    67.96
@@ -83,7 +83,7 @@
  {
   "input": "For example, watch how this middle region disappears if I place everything nice and symmetrically around the circle.",
   "model": "nmt",
-  "translatedText": "Par exemple, observez comment cette région médiane disparaît si je place tout de manière agréable et symétrique autour du cercle.",
+  "translatedText": "Par exemple, observez comment la région du milieu disparaît si je place tout proprement et symétriquement autour du cercle.",
   "time_range": [
    68.86,
    74.1
@@ -92,7 +92,7 @@
  {
   "input": "So yes, it does depend, but we're going to consider the cases where you never have any three lines intersecting with each other.",
   "model": "nmt",
-  "translatedText": "Alors oui, cela dépend, mais nous allons considérer les cas où trois lignes ne se croisent jamais.",
+  "translatedText": "Alors oui, ça dépend, mais nous allons considérer les cas où trois lignes ne se croisent jamais.",
   "time_range": [
    74.32,
    80.3
@@ -101,7 +101,7 @@
  {
   "input": "This would be the generic case if you just choose n random points, almost certainly you'll never have three lines coincide, but setting aside the technical nuances, the problem is such a tease, it looks so convincingly like powers of two until it just barely breaks.",
   "model": "nmt",
-  "translatedText": "Ce serait le cas générique si vous choisissez simplement n points aléatoires, presque certainement vous n'aurez jamais trois lignes qui coïncident, mais en mettant de côté les nuances techniques, le problème est tellement taquin, il ressemble de manière si convaincante à des puissances de deux jusqu'à ce qu'il se brise à peine.",
+  "translatedText": "Ce serait le cas générique si vous choisissez simplement n points au hasard, vous n'aurez presque jamais trois lignes qui coïncident, mais en mettant de côté les nuances techniques, le problème est tellement taquin, il ressemble de manière si convaincante à des puissances de deux jusqu'à ce qu'il se brise de presque rien.",
   "time_range": [
    80.54,
    93.54
@@ -110,7 +110,7 @@
  {
   "input": "And I have such a strange soft spot for this particular question, when I was younger I wrote a poem about it and also a song, and on the one hand it's kind of silly because this is just one example of what the mathematician Richard Guy called the strong law of small numbers, summed up in the phrase, there aren't enough small numbers to meet the many demands made of them.",
   "model": "nmt",
-  "translatedText": "Et j'ai un faible pour cette question particulière, quand j'étais plus jeune, j'ai écrit un poème à ce sujet et aussi une chanson, et d'un côté c'est un peu idiot parce que ce n'est qu'un exemple de ce que le mathématicien Richard Guy a appelé la loi forte des petits nombres, résumée dans la phrase : il n'y a pas assez de petits nombres pour répondre aux nombreuses demandes qui leur sont faites.",
+  "translatedText": "Et j'ai un étrange faible pour cette question en particulier, quand j'étais plus jeune, j'ai écrit un poème à ce sujet et aussi une chanson, et d'un côté c'est un peu idiot parce que ce n'est qu'un exemple de ce que le mathématicien Richard Guy a appelé la loi forte des petits nombres, résumée dans la phrase : il n'y a pas assez de petits nombres pour satisfaire les nombreuses exigences qu'on porte sur eux.",
   "time_range": [
    93.92,
    112.0
@@ -119,7 +119,7 @@
  {
   "input": "But I think what I really like about this problem is that if you sit down to try to work out what is the real pattern, what's actually going on here, one, it's just a really good exercise in problem solving, so it makes for a nice lesson right here, but also it's not just a coincidence that it starts off being powers of two, there's a very good reason this happens, and it's also not a coincidence that you seemingly randomly hit another power of two a little bit later on the tenth iteration.",
   "model": "nmt",
-  "translatedText": "Mais je pense que ce que j'aime vraiment dans ce problème, c'est que si vous vous asseyez pour essayer de déterminer quel est le véritable modèle, ce qui se passe réellement ici, premièrement, c'est juste un très bon exercice de résolution de problèmes, donc cela en fait un belle leçon ici, mais ce n'est pas non plus une simple coïncidence si cela commence par des puissances de deux, il y a une très bonne raison pour laquelle cela se produit, et ce n'est pas non plus une coïncidence si vous frappez apparemment au hasard une autre puissance de deux un peu plus tard. dixième itération.",
+  "translatedText": "Mais je pense que ce que j'aime vraiment dans ce problème, c'est que si vous vous asseyez pour essayer de déterminer quel est le véritable modèle, ce qui se passe réellement ici, premièrement, c'est juste un très bon exercice de résolution de problèmes, donc cela en fait un belle leçon ici, mais ce n'est pas non plus une simple coïncidence si cela commence par des puissances de deux, il y a une très bonne raison pour laquelle cela se produit, et ce n'est pas non plus une coïncidence si vous frappez apparemment au hasard une autre puissance de deux un peu plus tard lors de la dixième itération.",
   "time_range": [
    112.8,
    136.92
@@ -137,7 +137,7 @@
  {
   "input": "If you put n points on the boundary of a circle, and you connect them with all the possible chords, and you count how many regions the circle has been cut into, if the answer isn't a power of two, what is it?",
   "model": "nmt",
-  "translatedText": "Si vous placez n points sur la limite d'un cercle, que vous les connectez avec tous les accords possibles et que vous comptez le nombre de régions dans lesquelles le cercle a été coupé, si la réponse n'est pas une puissance de deux, qu'est-ce que c'est?",
+  "translatedText": "Si vous placez n points sur le contour d'un cercle, que vous les connectez avec toutes les cordes possibles et que vous comptez le nombre de régions dans lesquelles le cercle a été coupé, si la réponse n'est pas une puissance de deux, qu'est-ce que c'est?",
   "time_range": [
    146.54,
    156.78
@@ -146,7 +146,7 @@
  {
   "input": "What function of n should we plug in?",
   "model": "nmt",
-  "translatedText": "Quelle fonction de n devons-nous brancher?",
+  "translatedText": "Quelle fonction de n devons-nous insérer?",
   "time_range": [
    156.98,
    158.66
@@ -173,7 +173,7 @@
  {
   "input": "In this case, two warm-up questions that come to mind are, how many total chords are there in this diagram, and at how many points within the circle do those chords intersect each other?",
   "model": "nmt",
-  "translatedText": "Dans ce cas, deux questions d'échauffement qui me viennent à l'esprit sont les suivantes : combien y a-t-il d'accords au total dans ce diagramme et en combien de points du cercle ces accords se croisent-ils?",
+  "translatedText": "Dans ce cas, il me vient deux questions préliminaires : combien y a-t-il de cordes au total dans ce diagramme et en combien de points du cercle ces cordes se croisent-elles?",
   "time_range": [
    170.6,
    181.5
@@ -182,7 +182,7 @@
  {
   "input": "The first question is relatively friendly, every one of those chords corresponds uniquely with a pair of points on the circle.",
   "model": "nmt",
-  "translatedText": "La première question est relativement conviviale, chacun de ces accords correspond uniquement à une paire de points du cercle.",
+  "translatedText": "La première question est relativement simple, chacune de ces cordes correspond à une unique paire de points du cercle.",
   "time_range": [
    182.2,
    188.84
@@ -191,7 +191,7 @@
  {
   "input": "So effectively what you want to do is count how many distinct pairs of points are there.",
   "model": "nmt",
-  "translatedText": "Donc, effectivement, ce que vous voulez faire, c'est compter le nombre de paires de points distinctes.",
+  "translatedText": "Donc, en pratique, ce que vous voulez faire, c'est compter le nombre de paires de points distinctes.",
   "time_range": [
    189.64,
    193.8
@@ -200,7 +200,7 @@
  {
   "input": "There's a function that does this, it's called n choose two.",
   "model": "nmt",
-  "translatedText": "Il existe une fonction qui fait cela, elle s'appelle n choisissez deux.",
+  "translatedText": "Il existe une fonction qui fait cela, elle s'appelle deux parmi n.",
   "time_range": [
    194.3,
    196.98
@@ -209,7 +209,7 @@
  {
   "input": "By definition, this counts the number of distinct pairs that you can choose from a set of n items, where order doesn't matter.",
   "model": "nmt",
-  "translatedText": "Par définition, cela compte le nombre de paires distinctes que vous pouvez choisir parmi un ensemble de n éléments, où l'ordre n'a pas d'importance.",
+  "translatedText": "Par définition, elle compte le nombre de paires distinctes que vous pouvez choisir parmi un ensemble de n éléments, où l'ordre n'a pas d'importance.",
   "time_range": [
    197.42,
    204.34
@@ -218,7 +218,7 @@
  {
   "input": "To calculate it, the way you often think about it is that you have n choices for what your first item should be, and then you have n minus one options for what that second item should be, but simply multiplying those would over count, since for a given pair you would have two distinct ways to arrive at that pair.",
   "model": "nmt",
-  "translatedText": "Pour le calculer, la façon dont vous y pensez souvent est que vous avez n choix pour ce que devrait être votre premier élément, puis vous avez n moins une options pour ce que devrait être ce deuxième élément, mais simplement les multiplier serait surcompte, puisque pour une paire donnée, vous auriez deux manières distinctes d’arriver à cette paire.",
+  "translatedText": "Pour le calculer, la façon dont on y pense souvent est qu'on a n choix pour choisir le premier élément, puis on a n moins une options pour trouver le deuxième élément, mais en faisant juste une multiplication on surcompterait, puisque pour une paire donnée, vous auriez deux manières distinctes d’arriver à cette paire.",
   "time_range": [
    205.0,
    222.14
@@ -227,7 +227,7 @@
  {
   "input": "And remember, we don't care about order.",
   "model": "nmt",
-  "translatedText": "Et rappelez-vous, nous ne nous soucions pas de l'ordre.",
+  "translatedText": "Et rappelez-vous, on ne se soucis pas de l'ordre.",
   "time_range": [
    222.68,
    224.16
@@ -236,7 +236,7 @@
  {
   "input": "To account for this you divide by two.",
   "model": "nmt",
-  "translatedText": "Pour en tenir compte, divisez par deux.",
+  "translatedText": "Pour en tenir compte, on divise par deux.",
   "time_range": [
    224.74,
    226.42
@@ -245,7 +245,7 @@
  {
   "input": "So for example, seven choose two would look like seven times six divided by two, which is seven times three, or twenty-one, and if you count up the number of distinct pairs of seven items, there are indeed twenty-one of them.",
   "model": "nmt",
-  "translatedText": "Ainsi, par exemple, sept parmi deux ressemblerait à sept fois six divisé par deux, ce qui fait sept fois trois, soit vingt et un, et si vous comptez le nombre de paires distinctes de sept éléments, il y en a effectivement vingt et un.",
+  "translatedText": "Donc par exemple, sept parmi deux ressemblerait à sept fois six divisé par deux, ce qui fait sept fois trois, soit vingt et un, et si on compte le nombre de paires distinctes de sept éléments, il y en a effectivement vingt et un.",
   "time_range": [
    226.42,
    239.86
@@ -263,7 +263,7 @@
  {
   "input": "One idea might be that it should be the number of pairs of chords, since every intersection point comes from two different chords.",
   "model": "nmt",
-  "translatedText": "Une idée pourrait être qu’il s’agisse du nombre de paires d’accords, puisque chaque point d’intersection provient de deux accords différents.",
+  "translatedText": "Une idée pourrait être qu’il s’agisse du nombre de paires de cordes, puisque chaque point d’intersection provient de deux cordes différents.",
   "time_range": [
    245.34,
    252.46
@@ -272,7 +272,7 @@
  {
   "input": "However, that would not quite be right, because the association is not unique.",
   "model": "nmt",
-  "translatedText": "Mais ce ne serait pas tout à fait exact, car l’association n’est pas unique.",
+  "translatedText": "Mais ce ne serait pas tout à fait exact, car cette association n’est pas unique.",
   "time_range": [
    253.02,
    256.7
@@ -281,7 +281,7 @@
  {
   "input": "You can find a pair of chords that don't intersect within the circle.",
   "model": "nmt",
-  "translatedText": "Vous pouvez trouver une paire d'accords qui ne se croisent pas dans le cercle.",
+  "translatedText": "Vous pouvez trouver une paire de cordes qui ne se croisent pas dans le cercle.",
   "time_range": [
    257.1,
    260.26
@@ -299,7 +299,7 @@
  {
   "input": "I'd encourage you to try to pause and think about it for yourself, and if you do that, you give yourself a moment, maybe if you're a little bit lucky, here's one thing you might notice.",
   "model": "nmt",
-  "translatedText": "Je vous encourage à essayer de faire une pause et d'y réfléchir par vous-même, et si vous faites cela, vous vous accordez un moment, peut-être que si vous êtes un peu chanceux, voici une chose que vous remarquerez peut-être.",
+  "translatedText": "Je vous encourage à essayer de faire une pause et d'y réfléchir par vous-même, et si vous faites cela, vous vous accordez un moment, peut-être si vous êtes un peu chanceux, voici une chose que vous pourriez remarquer.",
   "time_range": [
    262.56,
    271.16
@@ -308,7 +308,7 @@
  {
   "input": "Every intersection point is uniquely associated with a quadruplet of points on the exterior.",
   "model": "nmt",
-  "translatedText": "Chaque point d'intersection est associé de manière unique à un quadruplet de points à l'extérieur.",
+  "translatedText": "Chaque point d'intersection est associé de manière unique à un quadruplet de points sur le contour.",
   "time_range": [
    271.9,
    276.92
@@ -317,7 +317,7 @@
  {
   "input": "For a given quadruplet, you look at the two kind of diagonal chords between them, and those will intersect within the circle, and it goes the other way around.",
   "model": "nmt",
-  "translatedText": "Pour un quadruplet donné, vous regardez les deux types de cordes diagonales entre eux, et celles-ci se couperont dans le cercle, et c'est l'inverse.",
+  "translatedText": "Pour un quadruplet donné, vous regardez entre eux les deux de cordes qui ont l'air diagonales, et celles-ci se couperont à l'intérieur du cercle, et ça marche dans l'autre sens.",
   "time_range": [
    277.72,
    285.08
@@ -326,7 +326,7 @@
  {
   "input": "Every intersection point corresponds with some quadruplet of points.",
   "model": "nmt",
-  "translatedText": "Chaque point d'intersection correspond à un quadruplet de points.",
+  "translatedText": "Chaque point d'intersection correspond à un certain quadruplet de points.",
   "time_range": [
    285.38,
    288.74
@@ -335,7 +335,7 @@
  {
   "input": "So, what you want now is to count how many distinct ways can you choose four items given n total choices.",
   "model": "nmt",
-  "translatedText": "Donc, ce que vous voulez maintenant, c'est compter de combien de manières distinctes pouvez-vous choisir quatre éléments étant donné n choix totaux.",
+  "translatedText": "Donc, ce que vous voulez maintenant, c'est compter de combien de manières distinctes pouvez-vous choisir quatre éléments parmi un total de n choix.",
   "time_range": [
    290.66,
    297.46
@@ -344,7 +344,7 @@
  {
   "input": "This is very similar to the previous question.",
   "model": "nmt",
-  "translatedText": "Ceci est très similaire à la question précédente.",
+  "translatedText": "C'est très similaire à la question précédente.",
   "time_range": [
    298.24,
    300.38
@@ -353,7 +353,7 @@
  {
   "input": "The function that answers it is called n choose four, which by definition counts the number of quadruplets from a set of size n, and the way to calculate it is similar to what we saw before.",
   "model": "nmt",
-  "translatedText": "La fonction qui y répond s'appelle n choisissez quatre, qui par définition compte le nombre de quadruplés d'un ensemble de taille n, et la façon de le calculer est similaire à ce que nous avons vu précédemment.",
+  "translatedText": "La fonction qui y répond s'appelle quatre parmi n, qui par définition compte le nombre de quadruplets dans un ensemble de taille n, et la façon dont on le calcule est similaire à ce que nous avons vu précédemment.",
   "time_range": [
    300.76,
    311.0
@@ -380,7 +380,7 @@
  {
   "input": "To account for that, you divide out by the extent to which you've overcounted, the number of permutations of four items, which looks like four factorial.",
   "model": "nmt",
-  "translatedText": "Pour tenir compte de cela, vous divisez selon le degré de surestimation du nombre de permutations de quatre éléments, ce qui ressemble à une factorielle quatre.",
+  "translatedText": "Pour tenir compte de cela, vous divisez selon le degré de surestimation du nombre de permutations de quatre éléments, ce qui ressemble à factorielle quatre.",
   "time_range": [
    331.64,
    339.32
@@ -407,7 +407,7 @@
  {
   "input": "And even if you would never want to count it up by hand, if we had a diagram that has 100 distinct points on the exterior, and we drew all of the connecting lines, you can conclude that there have to be 100 choose four, or just about four million intersection points somewhere in the middle.",
   "model": "nmt",
-  "translatedText": "Et même si vous ne voudriez jamais le compter à la main, si nous avions un diagramme comportant 100 points distincts à l'extérieur et que nous dessinions toutes les lignes de connexion, vous pouvez conclure qu'il doit y en avoir 100 parmi quatre, ou à peu près quatre millions de points d’intersection quelque part au milieu.",
+  "translatedText": "Et même si vous ne voudriez jamais le compter à la main, si nous avions un diagramme comportant 100 points distincts sur le contour et que nous dessinions toutes les lignes qui les connectent, vous pouvez conclure qu'il doit y en avoir quatre parmi cent, soit à peu près quatre millions de points d’intersection quelque part au centre.",
   "time_range": [
    361.32,
    376.94
@@ -416,7 +416,7 @@
  {
   "input": "You've probably guessed this, but these are more than just warm-up questions.",
   "model": "nmt",
-  "translatedText": "Vous l’avez probablement deviné, mais ce sont bien plus que de simples questions d’échauffement.",
+  "translatedText": "Vous l’avez probablement deviné, mais ce sont bien plus que de simples questions préliminaires.",
   "time_range": [
    377.84,
    380.88
@@ -425,7 +425,7 @@
  {
   "input": "They give us the necessary information to answer the question we care about.",
   "model": "nmt",
-  "translatedText": "Ils nous donnent les informations nécessaires pour répondre à la question qui nous intéresse.",
+  "translatedText": "Elles nous donnent les informations nécessaires pour répondre à la question qui nous intéresse.",
   "time_range": [
    381.14,
    384.6
@@ -452,7 +452,7 @@
  {
   "input": "Here I'm using the word graph in the sense of a diagram that has nodes and lines connecting them, and what it means to be planar is that you can draw this diagram without any of the lines intersecting with each other.",
   "model": "nmt",
-  "translatedText": "Ici, j'utilise le mot graphique dans le sens d'un diagramme comportant des nœuds et des lignes qui les relient, et ce que signifie être plan, c'est que vous pouvez dessiner ce diagramme sans qu'aucune des lignes ne se croise.",
+  "translatedText": "Ici, j'utilise le mot graphe dans le sens d'un diagramme comportant des nœuds et des lignes qui les relient, et ce que signifie être planaire, c'est que vous pouvez dessiner ce diagramme sans qu'aucune des lignes ne se croise.",
   "time_range": [
    391.08,
    401.7
@@ -461,7 +461,7 @@
  {
   "input": "In graph theory lingo, you typically call those nodes vertices and the lines connecting them edges, and the wonderful fact that we can leverage is that if you count up the number of vertices, and then you subtract the total number of edges, and then you consider the number of regions that this graph has cut the plane into, including that infinite outer region, then always, no matter what planar graph you started with, you get two.",
   "model": "nmt",
-  "translatedText": "Dans le jargon de la théorie des graphes, vous appelez généralement ces nœuds sommets et les lignes qui les relient arêtes, et le fait merveilleux que nous pouvons exploiter est que si vous comptez le nombre de sommets, puis vous soustrayez le nombre total d'arêtes, et alors vous considérez le nombre de régions dans lesquelles ce graphique a coupé le plan, y compris cette région externe infinie, alors toujours, quel que soit le graphe planaire avec lequel vous avez commencé, vous en obtenez deux.",
+  "translatedText": "Dans le jargon de la théorie des graphes, vous appelez généralement ces nœuds sommets et les lignes qui les relient arêtes, et le fait merveilleux que nous pouvons exploiter est que si vous comptez le nombre de sommets, puis vous soustrayez le nombre total d'arêtes, et qu'ensuite vous considérez le nombre de régions en lesquelles ce graphe a découpé le plan, y compris cette région extérieur, alors toujours, quel que soit le graphe planaire avec lequel vous avez commencé, vous obtenez deux.",
   "time_range": [
    402.28,
    425.3
@@ -470,7 +470,7 @@
  {
   "input": "It's actually very fun.",
   "model": "nmt",
-  "translatedText": "C'est en fait très amusant.",
+  "translatedText": "C'est en réalité très amusant.",
   "time_range": [
    425.84,
    426.8
@@ -479,7 +479,7 @@
  {
   "input": "Try this for yourself.",
   "model": "nmt",
-  "translatedText": "Essayez ceci par vous-même.",
+  "translatedText": "Essayez par vous-même.",
   "time_range": [
    427.0,
    427.78
@@ -488,7 +488,7 @@
  {
   "input": "Draw any graph, make sure the lines don't intersect, and then count the number of vertices, subtract the number of edges, and count the number of regions that it's cut the plane into, and no matter what diagram you chose, the answer always works out to be two.",
   "model": "nmt",
-  "translatedText": "Dessinez n'importe quel graphique, assurez-vous que les lignes ne se coupent pas, puis comptez le nombre de sommets, soustrayez le nombre d'arêtes et comptez le nombre de régions dans lesquelles le plan est coupé, et quel que soit le diagramme que vous avez choisi, la réponse cela revient toujours à deux.",
+  "translatedText": "Dessinez n'importe quel graphe, assurez-vous que les lignes ne se coupent pas, puis comptez le nombre de sommets, soustrayez le nombre d'arêtes et comptez le nombre de régions dans lesquelles le plan est coupé, et quel que soit le diagramme que vous avez choisi, la réponse est toujours deux.",
   "time_range": [
    428.12,
    442.16


### PR DESCRIPTION
Most significant changes is changing chord to "corde" instead of "accord", and n chose k to "k parmi n" instead of "n, choisissez k", both being the correct mathematical terms in French. Also changed a few pronouns that weren't caught by the auto translation, and a few expressions and sentences to match the tone of the video.