### PR TITLE
"Better bayes" french captions complete review

### DIFF
--- a/2020/better-bayes/french/sentence_translations.json
+++ b/2020/better-bayes/french/sentence_translations.json
@@ -17,7 +17,7 @@
   },
   {
     "input": "The paradox is that you could take a test which is highly accurate, in the sense that it gives correct results to a large majority of the people taking it.",
-    "translatedText": "Voici le paradoxe : il est possible qu’un test soit très précis, au sens où il fournit des résultats corrects pour la grande majorité des personnes testées.",
+    "translatedText": "Voici le paradoxe : il est possible qu’un test soit très précis, au sens où il fournit des résultats corrects pour la grande majorité des personnes testées.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 7.5,
@@ -25,7 +25,7 @@
   },
   {
     "input": "And yet, under the right circumstances, when assessing the probability that your particular test result is correct, you can still land on a very low number, arbitrarily low, in fact.",
-    "translatedText": "Mais que, sous certaines conditions, le résultat de votre dépistage en particulier n’ait qu’une probabilité infime — voire arbitrairement faible — d’être correct.",
+    "translatedText": "Mais que, sous certaines conditions, le résultat de votre dépistage en particulier n’ait qu’une probabilité infime — voire arbitrairement faible — d’être correct.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 16.04,
@@ -65,7 +65,7 @@
   },
   {
     "input": "Now, what's up on the screen now is a little bit abstract, which makes it difficult to justify that there really is a substantive difference here, especially when I haven't explained either one yet.",
-    "translatedText": "Bon, pour l’instant, ce qui est à l'écran est un peu abstrait. Ce n’est pas évident de vous convaincre qu’il y a une différence notable, surtout que je n'ai expliqué aucune des formules.",
+    "translatedText": "Bon, pour l’instant, ce qui est à l'écran est un peu abstrait. Ce n’est pas évident de vous convaincre qu’il y a une différence notable, surtout que je n'ai pas encore expliqué les formules.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 61.66,
@@ -73,7 +73,7 @@
   },
   {
     "input": "To see what I'm talking about though, we should really start by spending some time a little more concretely, and just laying out what exactly this paradox is.",
-    "translatedText": "Pour bien comprendre de quoi je parle, prenons le temps de regarder concrètement en quoi consiste ce paradoxe.",
+    "translatedText": "Pour bien comprendre de quoi je parle, prenons le temps de regarder concrètement en quoi consiste le paradoxe.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 71.04,
@@ -81,7 +81,7 @@
   },
   {
     "input": "Picture a thousand women and suppose that 1% of them have breast cancer.",
-    "translatedText": "Prenons 100 femmes, et supposons qu’1% d’entre elles aient un cancer du sein.",
+    "translatedText": "Prenons 100 femmes, et supposons qu’1 % d’entre elles aient un cancer du sein.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 84.02,
@@ -89,7 +89,7 @@
   },
   {
     "input": "And let's say they all undergo a certain breast cancer screening, and that 9 of those with cancer correctly get positive results, and there's one false negative.",
-    "translatedText": "Imaginons qu’elles passent toutes un certain type de dépistage, et que pour les 10 femmes ayant un cancer, il y a 9 vrais positifs, et un faux négatif.",
+    "translatedText": "Imaginons qu’elles passent toutes un certain type de dépistage, et que pour les 10 femmes ayant un cancer, 9 test sont des vrais positifs, et un faux négatif.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 88.68,
@@ -105,7 +105,7 @@
   },
   {
     "input": "So if all you know about a woman is that she does the screening and she gets a positive result, you don't have information about symptoms or anything like that, you know that she's either one of these 9 true positives or one of these 89 false positives.",
-    "translatedText": "Donc, si une femme effectue ce dépistage et obtient un résultat positif, si vous n'avez aucune information complémentaire comme ses symptômes, vous savez qu'elle fait soit partie des 9 vrais positifs, soit des 89 faux positifs.",
+    "translatedText": "Donc, si une femme effectue ce dépistage et obtient un résultat positif, en l’absence d’information complémentaire comme des symptômes, vous savez qu'elle fait soit partie des 9 vrais positifs, soit des 89 faux positifs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 105.72,
@@ -121,7 +121,7 @@
   },
   {
     "input": "In medical parlance, you would call this the positive predictive value of the test, or PPV, the number of true positives divided by the total number of positive test results.",
-    "translatedText": "Dans la terminologie médicale, on nomme ça la valeur prédictive positive du test (PPV en anglais), le nombre de vrais positifs divisé par le nombre total de résultats de test positifs.",
+    "translatedText": "Dans la terminologie médicale, on appelle ça la valeur prédictive positive du test (PPV), le nombre de vrais positifs divisé par le nombre total de résultats de test positifs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 129.08,
@@ -145,7 +145,7 @@
   },
   {
     "input": "Now, hopefully, as I've presented it this way where we're thinking concretely about a sample population, all of this makes perfect sense.",
-    "translatedText": "J'espère qu’en utilisant cet exemple concret d’un échantillon de 100 personnes, tout ça est parfaitement clair.",
+    "translatedText": "J'espère qu’en utilisant cet exemple concret d’un échantillon de 100 personnes, tout ça est clair.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 146.82,
@@ -153,7 +153,7 @@
   },
   {
     "input": "But where it comes across as counterintuitive is if you just look at the accuracy of the test, present it to people as a statistic, and then ask them to make judgments about their test result.",
-    "translatedText": "Mais ça devient contre-intuitif lorsque vous prenez la performance du test, que vous la présentez aux gens sous forme de statistique, et que vous leur demandez de se prononcer sur le résultat de leur test.",
+    "translatedText": "Mais là où ça devient contre-intuitif, c’est que si vous prenez la performance du test, que vous la présentez aux gens sous forme de chiffre, et que vous leur demandez de réagir au résultat de leur test.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 153.96,
@@ -177,7 +177,7 @@
   },
   {
     "input": "This is known as the test sensitivity, as in how sensitive is it to detecting the presence of the disease.",
-    "translatedText": "C’est ce qu’on appelle la sensibilité du test, c’est-à-dire : quelle est sa sensibilité pour détecter la présence de la maladie ?",
+    "translatedText": "C’est ce qu’on appelle la sensibilité du test, c’est-à-dire : quelle est sa sensibilité pour détecter la présence de la maladie ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 171.7,
@@ -185,14 +185,14 @@
   },
   {
     "input": "In our example, test sensitivity is 9 in 10, or 90%.",
-    "translatedText": "Dans notre exemple, la sensibilité du test est de 9 sur 10, soit 90 %.",
+    "translatedText": "Dans notre exemple, la sensibilité du test est de 9 sur 10, soit 90 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 178.26,
     "end": 181.26
   },
   {
-    "input": "And another way to say the same fact would be to say the false negative rate is 10%.",
+    "input": "And another way to say the same fact would be to say the false negative rate is 10 %.",
     "translatedText": "Et une autre façon de dire la même chose serait de dire que le taux de faux négatifs est de 10 %.",
     "model": "google_nmt",
     "n_reviews": 1,
@@ -209,7 +209,7 @@
   },
   {
     "input": "In our example, the specificity is about 91%.",
-    "translatedText": "Dans notre exemple, la spécificité est d'environ 91 %.",
+    "translatedText": "Dans notre exemple, la spécificité est d'environ 91 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 203.08,
@@ -217,7 +217,7 @@
   },
   {
     "input": "Or another way to say the same fact would be to say the false positive rate is 9%.",
-    "translatedText": "Ici, une autre manière de le dire est que le taux de faux positifs est de 9 %.",
+    "translatedText": "Une autre manière de le dire est que le taux de faux positifs est de 9 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 206.58,
@@ -225,7 +225,7 @@
   },
   {
     "input": "So the paradox here is that in one sense, the test is over 90% accurate.",
-    "translatedText": "Le paradoxe ici est donc que, dans un sens, le test est précis à plus de 90 %.",
+    "translatedText": "Le paradoxe ici est donc que, d’un côté, le test est précis à plus de 90 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 211.66,
@@ -233,7 +233,7 @@
   },
   {
     "input": "It gives correct results to over 90% of the patients who take it.",
-    "translatedText": "Il donne des résultats corrects à plus de 90 % des patients qui se font dépister.",
+    "translatedText": "Il donne des résultats corrects à plus de 90 % des patients qui se font dépister.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 217.02,
@@ -257,7 +257,7 @@
   },
   {
     "input": "In 2006 and 2007, the psychologist Gerd Gigerenzer gave a series of statistics seminars to practicing gynecologists, and he opened with the following example.",
-    "translatedText": "En 2006 et 2007, le psychologue Gerd Gigerenzer a donné une série de conférences de statistiques à des gynécologues en exercice, qu’il commençait par l'exemple suivant.",
+    "translatedText": "Entre 2006 et 2007, le psychologue Gerd Gigerenzer a donné une série de séminaires de statistiques à des gynécologues en activité, qu’il commençait avec l'exemple suivant :",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 237.94,
@@ -265,7 +265,7 @@
   },
   {
     "input": "A 50-year-old woman, no symptoms, participates in a routine mammography screening.",
-    "translatedText": "Une femme de 50 ans, sans symptômes, participe à un dépistage de routine par mammographie.",
+    "translatedText": "Une femme de 50 ans, sans symptômes, effectue un dépistage de routine par mammographie.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 246.8,
@@ -273,7 +273,7 @@
   },
   {
     "input": "She tests positive, is alarmed, and wants to know from you whether she has breast cancer for certain or what her chances are.",
-    "translatedText": "Son test est positif. Elle est inquiète et veut savoir s'il est est certain qu’elle a un cancer du sein, ou le risque que ce soit effectivement le cas.",
+    "translatedText": "Son test est positif. Elle est inquiète et veut savoir s'il est certain qu’elle a un cancer du sein, ou quel est le risque que ce soit le cas.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 252.28,
@@ -289,7 +289,7 @@
   },
   {
     "input": "In that seminar, the doctors were then told that the prevalence of breast cancer for women of this age is about 1%, and then to suppose that the test sensitivity is 90% and that its specificity was 91%.",
-    "translatedText": "Les informations suivantes ont ensuite été données à l’audience : la prévalence du cancer du sein chez les femmes de cet âge est d'environ 1 %, et vous pouvez supposer que la sensibilité du test est de 90 % et que sa spécificité est de 91 %.",
+    "translatedText": "Les informations suivantes ont ensuite été données à l’audience : la prévalence du cancer du sein chez les femmes de cet âge est d'environ 1 %, et vous pouvez supposer que la sensibilité du test est de 90 % et que sa spécificité est de 91 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 262.58,
@@ -313,7 +313,7 @@
   },
   {
     "input": "So, having already thought it through, you and I know the answer.",
-    "translatedText": "Vu qu’on y a déjà réfléchi, vous et moi on connaissons déjà la réponse.",
+    "translatedText": "Vu qu’on vient juste d’y réfléchir, on connaît déjà la réponse.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 279.76,
@@ -329,7 +329,7 @@
   },
   {
     "input": "However, the doctors in this session were not primed with the suggestion to picture a concrete sample of a thousand individuals, the way that you and I had.",
-    "translatedText": "En revanche, les médecins présents lors de ces conférences n’ont pas eu la suggestion d’imaginer un échantillon concret comme nous l’avons fait.",
+    "translatedText": "En revanche, on n’a pas proposé aux médecins présents lors de ces séminaires d’imaginer un échantillon de population concret comme on l’a fait ici.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 284.6,
@@ -337,7 +337,7 @@
   },
   {
     "input": "All they saw were these numbers.",
-    "translatedText": "Tout ce qu’ils ont vu, c’était des chiffres.",
+    "translatedText": "Tout ce qu’ils voyaient, c’était des chiffres.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 292.04,
@@ -345,7 +345,7 @@
   },
   {
     "input": "They were then asked, how many women who test positive actually have breast cancer?",
-    "translatedText": "On leur a ensuite demandé combien de femmes dont le test était positif avaient réellement un cancer du sein ?",
+    "translatedText": "On leur a ensuite demandé combien de femmes dont le test était positif avaient réellement un cancer du sein ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 294.14,
@@ -353,7 +353,7 @@
   },
   {
     "input": "What is the best answer?",
-    "translatedText": "Quelle est la meilleure réponse?",
+    "translatedText": "Quelle est la meilleure réponse ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 298.62,
@@ -361,7 +361,7 @@
   },
   {
     "input": "And they were presented with these four choices.",
-    "translatedText": "Parmi ces quatre réponses.",
+    "translatedText": "Parmi ces quatre propositions.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 299.9,
@@ -369,7 +369,7 @@
   },
   {
     "input": "In one of the sessions, over half the doctors present said that the correct answer was 9 in 10, which is way off.",
-    "translatedText": "Au cours d'une des conférences, plus de la moitié des médecins pensaient que la réponse était 9 sur 10, ce qui est très loin de la bonne réponse.",
+    "translatedText": "Au cours d’un des séminaires, plus de la moitié des médecins on proposé la réponse « 9 sur 10 », ce qui est très loin de la bonne réponse.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 301.68,
@@ -385,7 +385,7 @@
   },
   {
     "input": "It might seem a little extreme to be calling this a paradox.",
-    "translatedText": "Ça peut sembler un peu extrême d’appeler ça un paradoxe.",
+    "translatedText": "Ça peut sembler un peu exagéré d’appeler ça un paradoxe.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 316.66,
@@ -409,7 +409,7 @@
   },
   {
     "input": "But, as these seminars with Gigerenzer show, people, including doctors, definitely find it counterintuitive that a test with high accuracy can give you such a low predictive value.",
-    "translatedText": "Mais comme le montrent ces conférences de Gigerenzer, les gens, y compris les médecins, trouvent clairement contre-intuitif qu’un test d’une grande performance puisse donner une valeur prédictive aussi faible.",
+    "translatedText": "Mais comme le montrent les séminaires de Gigerenzer, les gens, y compris les médecins, trouvent clairement contre-intuitif qu’un test d’une grande performance puisse fournir une valeur prédictive aussi faible.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 324.2,
@@ -417,7 +417,7 @@
   },
   {
     "input": "We might call this a veridical paradox, which refers to facts that are provably true, but which nevertheless can feel false when phrased a certain way.",
-    "translatedText": "Nous pourrions appeler cela un paradoxe véridique, qui fait référence à des faits dont la vérité est prouvée, mais qui peuvent néanmoins sembler faux lorsqu’ils sont formulés d’une certaine manière.",
+    "translatedText": "Nous pourrions appeler ça un « paradoxe véridique », qui fait référence à des faits dont la vérité est avérée, mais qui peuvent néanmoins sembler faux lorsqu’ils sont formulés d’une certaine manière.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 335.2,
@@ -433,7 +433,7 @@
   },
   {
     "input": "The question is how we can combat this.",
-    "translatedText": "La question est de savoir comment lutter contre ça.",
+    "translatedText": "La question c’est : comment lutter contre ça ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 349.58,
@@ -449,7 +449,7 @@
   },
   {
     "input": "Or, if I changed things and asked, what if it was 10% of the population who had breast cancer?",
-    "translatedText": "Et si je modifie les valeurs, et vous demande ce qu’il en serait si la prévalence du cancer du sein était de 10%",
+    "translatedText": "Et si je modifie les valeurs, et vous demande ce qu’il en serait si la prévalence du cancer du sein était de 10 %",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 364.76,
@@ -457,7 +457,7 @@
   },
   {
     "input": "You should be able to quickly turn around and say that the final answer would be a little over 50%.",
-    "translatedText": "Vous devriez pouvoir rapidement adapter votre réponse et me dire que la valeur prédictive serait d'un peu plus que 50 %.",
+    "translatedText": "Vous devriez pouvoir rapidement modifier votre réponse et me dire que la valeur prédictive serait d'un peu plus que 50 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 370.12,
@@ -465,7 +465,7 @@
   },
   {
     "input": "Or, if I said imagine a really low prevalence, something like 0.1% of patients having cancer, you should again quickly estimate that the predictive value of the test is around 1 in 100,",
-    "translatedText": "Ou, disons que je vous donne une prévalence très faible, comme 0.1% de patients atteints de cancer, vous devriez là encore pouvoir estimer rapidement que la valeur prédictive du test est d'environ 1 sur 100.",
+    "translatedText": "Ou, disons que je vous donne une prévalence très faible, comme 0,1 % de patients atteints de cancer, vous devriez là encore pouvoir estimer rapidement que la valeur prédictive du test est d'environ 1 sur 100.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 375.92,
@@ -473,7 +473,7 @@
   },
   {
     "input": "that 1 in 100 of those with positive test results in that case would have cancer.",
-    "translatedText": "c’est-à-dire qu’une personne sur 100 avec des résultats positifs aurait un cancer.",
+    "translatedText": "C’est-à-dire qu’une personne sur 100 avec des résultats positifs aurait un cancer.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 386.76,
@@ -489,7 +489,7 @@
   },
   {
     "input": "I tell you to imagine the specificity is 99%.",
-    "translatedText": "Imaginons que la spécificité soit de 99 %.",
+    "translatedText": "Imaginons que la spécificité soit de 99 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 395.44,
@@ -497,7 +497,7 @@
   },
   {
     "input": "There, you should be able to relatively quickly estimate that the answer is a little less than 50%.",
-    "translatedText": "Là, vous devriez pouvoir estimer assez rapidement que la réponse est un peu inférieure à 50 %.",
+    "translatedText": "Là, vous devriez pouvoir estimer assez rapidement que la réponse est un peu inférieure à 50 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 398.4,
@@ -505,7 +505,7 @@
   },
   {
     "input": "The hope is that you're doing all of this with minimal calculations in your head.",
-    "translatedText": "Le but est que vous puissiez faire tout ça avec un minimum de calculs dans votre tête.",
+    "translatedText": "Le but est que vous puissiez faire tout ça de tête, avec un minimum de calculs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 404.32,
@@ -513,7 +513,7 @@
   },
   {
     "input": "Now, the goals of quick calculations might feel very different from the goals of addressing whatever misconception underlies this paradox, but they actually go hand in hand.",
-    "translatedText": "L’objectif de ces estimations rapides pourrait sembler très différent du fait de corriger les idées qui sous-tendent ce paradoxe, mais les deux se rejoignent.",
+    "translatedText": "L’objectif de ces estimations rapides pourrait sembler très différent du fait de corriger les idées qui sous-tendent ce paradoxe, mais les deux sont liés.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 408.54,
@@ -529,7 +529,7 @@
   },
   {
     "input": "On the side of addressing misconceptions, what would you tell to the people in that seminar who answered 9 and 10?",
-    "translatedText": "Du côté des fausses intuitions, qu’auriez-vous envie de dire aux médecins qui ont répondu « 9 sur 10 » lors de la conférence ?",
+    "translatedText": "Du côté des idées erronnées, qu’auriez-vous envie de dire aux médecins qui ont répondu « 9 sur 10 » lors de la conférence ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 418.46,
@@ -537,7 +537,7 @@
   },
   {
     "input": "What fundamental misconception are they revealing?",
-    "translatedText": "En quoi leur raisonnement est-il fondamentalement faux ?",
+    "translatedText": "En quoi leur raisonnement est-il fondamentalement faux ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 424.48,
@@ -545,7 +545,7 @@
   },
   {
     "input": "What I might tell them is that in much the same way that you shouldn't think of tests as telling you deterministically whether you have a disease, you shouldn't even think of them as telling you your chances of having a disease.",
-    "translatedText": "On pourrait leur dire que, de la même manière qu’on ne devrait pas considérer que les tests peuvent déterminer si quelqu’un est malade ou non, on ne devrait même pas considérer qu’ils nous donnent le risque que cette personne soit malade.",
+    "translatedText": "On pourrait leur dire que, de la même manière qu’on ne devrait pas considérer que les tests peuvent déterminer si quelqu’un est malade ou pas, on ne devrait même pas considérer qu’ils nous donnent le risque que cette personne soit malade.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 428.18,
@@ -585,7 +585,7 @@
   },
   {
     "input": "The accuracy of a test is telling us about the strength of this updating.",
-    "translatedText": "La performance d’un test se traduit dans la valeur de cette mise à jour.",
+    "translatedText": "La performance d’un test se traduit dans la taille de cette mise à jour.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 461.02,
@@ -601,7 +601,7 @@
   },
   {
     "input": "What does this have to do with quick approximations?",
-    "translatedText": "Alors, quel rapport avec nos estimations rapides ?",
+    "translatedText": "Du coup, quel rapport avec nos estimations rapides ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 467.9,
@@ -617,7 +617,7 @@
   },
   {
     "input": "You see, one of the things that makes test statistics so very confusing is that there are at least 4 numbers that you'll hear associated with them.",
-    "translatedText": "Une des choses qui génère de la confusion concernant la performance des tests est qu’on vous parlera d’au moins 4 chiffres différents. ",
+    "translatedText": "Une des choses qui génère de la confusion concernant la performance des tests est qu’on parle généralement d’au moins 4 chiffres différents. ",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 482.42,
@@ -625,7 +625,7 @@
   },
   {
     "input": "For those with the disease, there's the sensitivity and the false negative rate, and then for those without, there's the specificity and the false positive rate, and none of these numbers actually tell you the thing you want to know.",
-    "translatedText": "La sensibilité et le taux de faux négatifs pour les personnes atteintes de la maladie ; la spécificité et le taux de faux positifs pour celles qui ne le sont pas. Mais aucun de ces chiffres ne dit vraiment ce que vous voulez savoir.",
+    "translatedText": "La sensibilité et le taux de faux négatifs pour les personnes atteintes de la maladie ; la spécificité et le taux de faux positifs pour celles qui ne le sont pas. Mais aucun de ces chiffres ne nous dit vraiment ce qu’on veut savoir.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 488.9,
@@ -633,7 +633,7 @@
   },
   {
     "input": "Luckily, if you want to interpret a positive test result, you can pull out just one number to focus on from all this.",
-    "translatedText": "Heureusement, si vous voulez interpréter un résultat de test positif, il y a un chiffre sur lequel vous pouvez vous concentrer.",
+    "translatedText": "Heureusement, si on veut interpréter un résultat de test positif, il y a un chiffre sur lequel on peut se concentrer.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 499.5,
@@ -649,7 +649,7 @@
   },
   {
     "input": "In other words, how much more likely are you to see the positive test result with cancer versus without?",
-    "translatedText": "Autrement dit, dans quelle mesure avez-vous plus de chances de voir un résultat de test positif entre un cas avec un cancer et un cas sans ?",
+    "translatedText": "Autrement dit, dans quelle mesure a-t-on plus de chances de voir un résultat de test positif entre un cas ayant un cancer et un cas sans ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 509.16,
@@ -689,7 +689,7 @@
   },
   {
     "input": "So based on this rule of thumb, if I asked you what would happen if the prior from our example was instead 1 in 1000, you could quickly estimate that the effect of the test should be to update those chances to around 1 in 100.",
-    "translatedText": "Donc, si je vous demande ce qui se passerait si la probabilité a priori de notre exemple était plutôt de 1 sur 1000, vous devriez pouvoir prendre le résultat du test et estimer rapidement que ça a pour conséquence de mettre à jour cette probabilité à environ 1 sur 100.",
+    "translatedText": "Donc, si je vous demande ce qui se passerait si la probabilité a priori de notre exemple était plutôt de 1 sur 1000, vous devriez pouvoir estimer rapidement que le résultat du test a pour conséquence de mettre à jour cette probabilité à environ 1 sur 100.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 539.4,
@@ -705,7 +705,7 @@
   },
   {
     "input": "In this case, you might picture 10,000 patients where only 10 of them really have cancer.",
-    "translatedText": "Vous pourriez imaginer 10 000 patients, parmi lesquels 10 d’entre eux sont atteints d’un cancer.",
+    "translatedText": "Vous pourriez imaginer 10000 patients, parmi lesquels 10 d’entre eux sont atteints d’un cancer.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 556.7,
@@ -713,7 +713,7 @@
   },
   {
     "input": "And then based on that 90% sensitivity, we would expect 9 of those cancer cases to give true positives.",
-    "translatedText": "Et, en partant sur une sensibilité de 90 %, on s’attend à ce que sur les 10 cas de cancer, 9 résultats de tests soient des vrais positifs.",
+    "translatedText": "Et, en partant sur une sensibilité de 90 %, on s’attend à ce que sur les 10 cas de cancer, 9 résultats de tests soient des vrais positifs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 562.14,
@@ -721,7 +721,7 @@
   },
   {
     "input": "And on the other side, a 91% specificity means that 9% of those without cancer are getting false positives.",
-    "translatedText": "D’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des résultats faux positifs.",
+    "translatedText": "D’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des résultats faux positifs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 569,
@@ -729,7 +729,7 @@
   },
   {
     "input": "So we'd expect 9% of the remaining patients, which is around 900, to give false positive results.",
-    "translatedText": "On s’attend donc à ce que 9 % des patients restants, soit environ 900, aient des résultats faussement positifs.",
+    "translatedText": "On s’attend donc à ce que 9 % des patients restants, soit environ 900, aient des résultats faussement positifs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 576.66,
@@ -745,7 +745,7 @@
   },
   {
     "input": "So the probability that a randomly chosen positive case from this population actually has cancer is only around 1%, just like the rule of thumb predicted.",
-    "translatedText": "Donc la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédisait l’approximation.",
+    "translatedText": "Donc, la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédisait l’approximation.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 587.9,
@@ -761,7 +761,7 @@
   },
   {
     "input": "For example, it would predict that a prior of 10% gets updated all the way to 100% certainty.",
-    "translatedText": "Par exemple, elle prédirait qu'un a priori de 10 % serait mis à jour à une valeur de 100 %.",
+    "translatedText": "Par exemple, elle prédirait qu'un a priori de 10 % serait mis à jour vers une valeur de 100 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 602.42,
@@ -769,7 +769,7 @@
   },
   {
     "input": "But that can't be right.",
-    "translatedText": "Mais ça ne peut pas être vrai.",
+    "translatedText": "Mais ça n’a pas de sens.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 608.36,
@@ -793,7 +793,7 @@
   },
   {
     "input": "Again, based on the 90% sensitivity of the test, we'd expect 9 of those true cancer cases to get positive results.",
-    "translatedText": "De nouveau, en prenant une sensibilité de 90 % du test, nous nous attendons à ce que 9 des véritables cas de cancer fournissent des résultats positifs.",
+    "translatedText": "De nouveau, en prenant une sensibilité de 90 % du test, nous nous attendons à ce que 9 des véritables cas de cancer fournissent des résultats positifs.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 618.54,
@@ -809,7 +809,7 @@
   },
   {
     "input": "How many do we expect there?",
-    "translatedText": "combien doit-on en trouver ?",
+    "translatedText": "Combien va-t-on en trouver ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 626.98,
@@ -817,7 +817,7 @@
   },
   {
     "input": "About 9% of the remaining 90. About 8.",
-    "translatedText": "Environ 9% des 90 restants, soit environ 8.",
+    "translatedText": "Environ 9 % des 90 restants, soit environ 8.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 629.88,
@@ -841,7 +841,7 @@
   },
   {
     "input": "At this point, having dared to dream that Bayesian updating could look as simple as multiplication, you might tear down your hopes and pragmatically acknowledge that sometimes life is just more complicated than that.",
-    "translatedText": "À ce stade, tout espoir que cette mise à jour bayésienne puisse être aussi simple qu’une multiplication semble perdu, et on a envie de se dire que parfois les choses ne sont pas aussi simple qu’on aimerait.",
+    "translatedText": "À ce stade, tout espoir que cette mise à jour bayésienne puisse être aussi simple qu’une multiplication à l’air perdu, et on se dit que parfois ce n’est pas aussi simple qu’on aimerait.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 648.02,
@@ -849,7 +849,7 @@
   },
   {
     "input": "Except it's not.",
-    "translatedText": "Sauf que ce n'est pas vrai !",
+    "translatedText": "Sauf que ce n'est pas le cas !",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 659.92,
@@ -857,7 +857,7 @@
   },
   {
     "input": "This rule of thumb turns into a precise mathematical fact as long as we shift away from talking about probabilities to instead talking about odds.",
-    "translatedText": "Cette approximation peut devenir un calcul exact, à condition que l’on ne considère plus des probabilités, mais des cotes.",
+    "translatedText": "Cette approximation peut devenir exacte, à condition que l’on ne considère plus des probabilités, mais des cotes.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 661.62,
@@ -881,7 +881,7 @@
   },
   {
     "input": "Things like 1 in 5 or 1 in 10.",
-    "translatedText": "Par exemple 1 sur 5, ou 1 sur 10…",
+    "translatedText": "Par exemple 1 sur 5, ou 1 sur 10.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 683.4,
@@ -945,7 +945,7 @@
   },
   {
     "input": "Think about what the prior odds are really saying.",
-    "translatedText": "Réfléchissez à ce que signifie vraiment la cote a priori.",
+    "translatedText": "Réfléchissez à ce que veut vraiment dire une cote a priori.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 743.44,
@@ -969,7 +969,7 @@
   },
   {
     "input": "When you filter down just to those with positive test results, the number of people with cancer gets scaled down, scaled down by the probability of seeing a positive test result given that someone has cancer.",
-    "translatedText": "Si on ne regarde que les personnes ayant un test positif, l’ensemble de celles qui ont un cancer a diminué, par rapport au groupe initial, d’un facteur égal à la probabilité d’obtenir un test positif sur une personne malade.",
+    "translatedText": "Si on ne regarde que les personnes ayant un test positif, l’ensemble de celles qui ont un cancer a diminué par rapport au groupe initial d’un facteur égal à la probabilité d’obtenir un test positif pour une personne malade.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 753.36,
@@ -985,7 +985,7 @@
   },
   {
     "input": "So the ratio between these two counts, the new odds upon seeing the test, looks just like the prior odds except multiplied by this term here, which is exactly the Bayes' factor.",
-    "translatedText": "Le rapport des effectifs de ces groupes, qui est la nouvelle cote post-tests, a la même forme que la cote pre-tests, mais multipliée par ce terme, qui est précisément le facteur de Bayes.",
+    "translatedText": "Le rapport des effectifs de ces groupes, qui est la nouvelle cote a posteriori, a la même forme que la cote pre-tests, mais multipliée par ce terme, qui est précisément le facteur de Bayes.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 774.18,
@@ -1009,7 +1009,7 @@
   },
   {
     "input": "How much more likely are you to see a positive result with cancer versus without?",
-    "translatedText": "Quand avez-vous plus de chances d’avoir un résultat positif pour une personne malade plutôt que saine ?",
+    "translatedText": "Quand est-ce plus probable d’avoir un résultat positif pour une personne malade plutôt que saine ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 796.88,
@@ -1025,7 +1025,7 @@
   },
   {
     "input": "So by our rule, this gets updated to 10 to 99, which if you want you could convert back to a probability.",
-    "translatedText": "Donc, d’après notre règle, la cote est mise à jour à 10 pour 99. Et vous pouvez la reconvertir en probabilité si besoin.",
+    "translatedText": "Donc, d’après notre règle, la cote est mise à jour à 10 pour 99. Et vous pouvez la reconvertir en probabilité au besoin.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 806.9,
@@ -1041,7 +1041,7 @@
   },
   {
     "input": "If instead, the prior was 10%, which was the example that tripped up our rule of thumb earlier, expressed as odds, this looks like 1 to 9.",
-    "translatedText": "Si l'a priori était plutôt de 10 %, comme dans l’exemple qui mettait notre approximation en défaut un peu plus tôt, on aurait une cote de 1 pour 9.",
+    "translatedText": "Si l'a priori était plutôt de 10 %, comme dans l’exemple qui faisait dérailler notre approximation tout à l’heure, on aurait une cote de 1 pour 9.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 818.2,
@@ -1073,7 +1073,7 @@
   },
   {
     "input": "You would write it as 10 out of 19, or about 53%.",
-    "translatedText": "Ça donnerait 10 sur 19, soit environ 53 %.",
+    "translatedText": "Ça nous donnerait 10 sur 19, soit environ 53 %.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 839.18,
@@ -1113,7 +1113,7 @@
   },
   {
     "input": "The test is doing more work for us.",
-    "translatedText": "Le test joue davantage en notre faveur.",
+    "translatedText": "Le test nous aide plus.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 860.84,
@@ -1137,7 +1137,7 @@
   },
   {
     "input": "But honestly, if you're just going for a gut feel, it's fine to stick with the odds.",
-    "translatedText": "Mais honnêtement, si vous voulez juste vous faire une idée, les cotes sont largement suffisantes.",
+    "translatedText": "Mais honnêtement, si vous voulez juste vous faire une idée, une cote est amplement suffisante.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 877.56,
@@ -1153,7 +1153,7 @@
   },
   {
     "input": "For anybody who's a little hasty in connecting test accuracy directly to your probability of having a disease, it's worth emphasizing that you could administer the same test with the same accuracy to multiple different patients who all get the same exact result, but if they're coming from different contexts, that result can mean wildly different things.",
-    "translatedText": "Si une personne a envie d’associer un peu trop vite le résultat d’un test à la probabilité d’avoir une maladie, on peut lui rappeler qu’il est possible de faire passer exactement le même test, avec la même précision, à plusieurs patients différents et que ces patients obtiennent tous exactement le même résultat. Pourtant, en fonction du contexte, ces résultats peuvent signifier des choses incroyablement différentes.",
+    "translatedText": "Si une personne est tentée d’associer un peu trop vite le résultat d’un test à la probabilité d’avoir une maladie, on peut lui montrer qu’il est possible de faire passer exactement le même test, avec la même précision, à plusieurs patients différents, que ces patients obtiennent tous exactement le même résultat. Pourtant, en fonction du contexte, ces résultats peuvent signifier des choses incroyablement différentes.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 888.24,
@@ -1185,7 +1185,7 @@
   },
   {
     "input": "If there are other known factors, things like symptoms, or in the case of a contagious disease, things like known contacts, those also factor into the prior, and they could potentially make a huge difference.",
-    "translatedText": "Si on connaît d’autres éléments, comme par exemple les symptômes, ou, dans le cas d'une maladie contagieuse, les personnes contact, ceux-ci sont pris en compte dans l’a priori et peuvent potentiellement faire une énorme différence.",
+    "translatedText": "Si on connaît d’autres éléments, comme par exemple les symptômes, ou, dans le cas d'une maladie contagieuse, les personnes contact, ceux-ci peuvent être pris en compte dans l’a priori et potentiellement faire une énorme différence.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 929.78,
@@ -1193,7 +1193,7 @@
   },
   {
     "input": "As another side note, so far we've only talked about positive test results, but way more often you would be seeing a negative test result.",
-    "translatedText": "Par ailleurs, jusqu'ici, on n’a parlé que de résultats de tests positifs, mais on voit bien plus de résultats  négatif en pratique.",
+    "translatedText": "Par ailleurs, jusqu'ici, on n’a parlé que de résultats de tests positifs, mais on observe bien plus de résultats négatifs en pratique.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 940.76,
@@ -1201,7 +1201,7 @@
   },
   {
     "input": "The logic there is completely the same, but the Bayes factor that you compute is going to look different.",
-    "translatedText": "La logique est exactement la même, mais le facteur de Bayes que vous calculez aura une allure différente.",
+    "translatedText": "La logique reste exactement la même, mais le facteur de Bayes que vous calculez aura une allure différente.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 948.1,
@@ -1209,7 +1209,7 @@
   },
   {
     "input": "Instead, you look at the probability of seeing this negative test result with the disease versus without the disease.",
-    "translatedText": "À la place on regardera la probabilité d’obtenir un résultat de test négatif en présence de la maladie, et au contraire, en son absence.",
+    "translatedText": "À la place on regardera la probabilité d’obtenir un résultat de test négatif en présence de la maladie, et (au contraire) en son absence.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 952.76,
@@ -1217,7 +1217,7 @@
   },
   {
     "input": "So in our cancer example, this would have been the 10% false negative rate divided by the 91% specificity, or about 1 in 9.",
-    "translatedText": "Du coup, dans notre exemple sur le cancer, cela aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
+    "translatedText": "Du coup, dans notre exemple sur le cancer, ça aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 958.64,
@@ -1241,7 +1241,7 @@
   },
   {
     "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the Bayes factor.",
-    "translatedText": "Elle vous dit que le risque d'avoir une maladie compte tenu du résultat d'un test est égal au risque estimé avant de passer le test, la cote a priori, multiplié par le facteur de Bayes.",
+    "translatedText": "Elle nous dit que le risque d'avoir une maladie compte tenu du résultat d'un test est égal au risque estimé avant de passer le test, la cote a priori, multiplié par le facteur de Bayes.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 978.76,
@@ -1257,7 +1257,7 @@
   },
   {
     "input": "In case you haven't seen it before, it's essentially just what we were doing with sample populations, but you wrap it all up symbolically.",
-    "translatedText": "Si vous ne l’avez jamais vu, ça revient essentiellement à ce qu’on a fait avec nos populations fictives, mais exprimé de manière symbolique.",
+    "translatedText": "Si vous ne l’avez jamais vue, ça revient essentiellement à ce qu’on a fait avec nos populations fictives, mais exprimé de manière symbolique.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 993.06,
@@ -1265,7 +1265,7 @@
   },
   {
     "input": "Remember how every time we were counting the number of true positives and then dividing it by the sum of the true positives and the false positives?",
-    "translatedText": "Vous vous souvenez qu’à chaque fois on prenait le nombre de vrais positifs et qu’on le divisait par la somme des vrais positifs et des faux positifs ?",
+    "translatedText": "Vous vous souvenez qu’à chaque fois, on prenait le nombre de vrais positifs et qu’on le divisait par la somme des vrais positifs et des faux positifs ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 999.5,
@@ -1281,7 +1281,7 @@
   },
   {
     "input": "So the proportion of true positives in the population comes from the prior probability of having the disease multiplied by the probability of seeing a positive test result in that case.",
-    "translatedText": "La proportion de vrais positifs dans la population est égale à la probabilité a priori d’être atteint de la maladie multipliée par la probabilité d’observer un résultat de test positif dans ce cas-là.",
+    "translatedText": "La proportion de vrais positifs dans la population est égale à la probabilité a priori d’être atteint de la maladie, multipliée par la probabilité d’observer un résultat de test positif dans ce cas-là.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1012.26,
@@ -1305,7 +1305,7 @@
   },
   {
     "input": "And this is one of those formulas where once you say it out loud it seems like a bit much, but it really is no different from what we were doing with sample populations.",
-    "translatedText": "Et c’est vrai que la formule a l’air un peu costaud, vue comme ça, mais ça correspond simplement à ce qu’on a vu tout à l’heure avec nos populations fictives.",
+    "translatedText": "Et c’est vrai que la formule a l’air un peu touffue, vue comme ça, mais ça correspond simplement à ce qu’on a vu tout à l’heure avec nos populations fictives.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1041.38,
@@ -1345,7 +1345,7 @@
   },
   {
     "input": "If nothing else, it helps emphasize which parts of the formula are coming from statistics about the test accuracy.",
-    "translatedText": "Ça permet au minimum de souligner quels éléments dans les formules proviennent des mesures sur la performance du test.",
+    "translatedText": "Ça permet au minimum de souligner quels éléments dans les formules proviennent des caractéristiques de performance du test.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1080.66,
@@ -1377,7 +1377,7 @@
   },
   {
     "input": "It's really nice if you want to swap out different priors and easily see their effects.",
-    "translatedText": "C'est vraiment pratique pour changer la valeur de l’a priori et observer l’effet que ça produit.",
+    "translatedText": "C'est vraiment pratique pour changer la valeur de l’a priori et observer l’effet produit.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1102.48,
@@ -1409,7 +1409,7 @@
   },
   {
     "input": "The odds framing also makes things really nice if you want to do multiple different Bayesian updates based on multiple pieces of evidence.",
-    "translatedText": "La formulation avec cotes est aussi très pratique lorsqu’on veut effectuer des mises à jour bayésiennes en série basées sur plusieurs observations.",
+    "translatedText": "La formulation avec les cotes est aussi très pratique lorsqu’on veut effectuer des mises à jour bayésiennes en série basées sur plusieurs observations.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1115.96,
@@ -1425,7 +1425,7 @@
   },
   {
     "input": "Or you wanted to think about how the presence of symptoms plays into it.",
-    "translatedText": "Ou que vous vouliez inclure une information concernant la présence de certains symptômes.",
+    "translatedText": "Ou que vous voulez inclure une information concernant la présence de certains symptômes.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1125.36,
@@ -1433,7 +1433,7 @@
   },
   {
     "input": "For each piece of new evidence you see, you always ask the question, how much more likely would you be to see that with the disease versus without the disease?",
-    "translatedText": "Dès qu’on obtient une nouvelle information, on va toujours se demander : dans quel cas est-ce qu’il est plus probable d’observer cette information, avec ou sans la maladie ?",
+    "translatedText": "Dès qu’on obtient une nouvelle information, on va toujours se demander : dans quel cas est-ce qu’il est plus probable d’observer cette information, en présence de la maladie, ou non ?",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1129.12,
@@ -1457,7 +1457,7 @@
   },
   {
     "input": "I mean, if you hear that a test has, for example, a 9% false positive rate, that's just such a disastrously ambiguous phrase.",
-    "translatedText": "Par exemple, si on nous dit qu’un test A, a un taux de faux positifs de 9 %, c’est une assertion incroyablement ambiguë.",
+    "translatedText": "Par exemple, si on nous dit qu’un test A a un taux de faux positifs de 9 %, c’est une assertion incroyablement ambiguë.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1150.74,
@@ -1465,7 +1465,7 @@
   },
   {
     "input": "It's so easy to misinterpret it to mean there's a 9% chance that your positive test result is false.",
-    "translatedText": "C’est très facile de se méprendre et croire qu'il y a 9 % de chances que votre résultat positif soit faux.",
+    "translatedText": "C’est très facile de se méprendre et penser qu'il y a 9 % de chances que votre résultat positif soit faux.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1157.78,
@@ -1489,7 +1489,7 @@
   },
   {
     "input": "The entire framing of what a Bayes' factor is, is that it's something that acts on a prior.",
-    "translatedText": "L’idée au cœur de la définition du facteur de Bayes, c'est qu’il prend et agit sur un a priori.",
+    "translatedText": "L’idée au cœur de la définition du facteur de Bayes, c'est qu’il prend un a priori et agit dessus.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1174.64,
@@ -1497,7 +1497,7 @@
   },
   {
     "input": "It forces your hand to acknowledge the prior as something that's separate entirely, and highly necessary to drawing any conclusion.",
-    "translatedText": "Et ça oblige à considérer cet priori comme quelque chose de complètement distinct, et d’obligatoire pour pouvoir tirer une quelconque conclusion.",
+    "translatedText": "Et ça oblige à considérer cet priori comme quelque chose de complètement distinct, et absolument nécessaire pour pouvoir tirer une quelconque conclusion.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1179.5,
@@ -1513,7 +1513,7 @@
   },
   {
     "input": "If you view it not simply as something to plug numbers into, but as an encapsulation of the sample population idea that we've been using throughout, you could very easily argue that that's actually much better for your intuition.",
-    "translatedText": "Si on ne la voit pas juste comme une formule à évaluer avec des valeurs données, mais comme portant cette idée de population fictive qu’on a utilisée tout du long, on pourrait se dire qu’elle est en fait bien meilleure pour notre intuition.",
+    "translatedText": "Si on ne la voit pas juste comme une formule à évaluer avec des valeurs données, mais comme portant cette idée de population fictive qu’on a utilisée tout du long, on pourrait se dire qu’elle est en fait bien plus utile à notre intuition.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1191.08,
@@ -1521,7 +1521,7 @@
   },
   {
     "input": "After all, it's what we were routinely falling back on in order to check ourselves that the Bayes' factor computation even made sense in the first place.",
-    "translatedText": "Après tout, c’est sur cette formule qu’on se basait à chaque fois pour vérifier que nos calculs incluant le facteur Bayes avaient bien du sens.",
+    "translatedText": "Après tout, c’est sur cette formule qu’on se basait à chaque fois pour vérifier que nos calculs incluant un facteur Bayes avaient bien du sens.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 1202.56,

--- a/2020/better-bayes/french/sentence_translations.json
+++ b/2020/better-bayes/french/sentence_translations.json
@@ -513,49 +513,49 @@
   },
   {
     "input": "Now, the goals of quick calculations might feel very different from the goals of addressing whatever misconception underlies this paradox, but they actually go hand in hand.",
-    "translatedText": "Les objectifs des calculs rapides peuvent sembler très différents de ceux visant à répondre aux idées fausses qui sous-tendent ce paradoxe, mais ils vont en réalité de pair.",
+    "translatedText": "L’objectif de ces estimations rapides pourrait sembler très différent du fait de corriger les idées qui sous-tendent ce paradoxe, mais les deux se rejoignent.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 408.54,
     "end": 416.5
   },
   {
     "input": "Let me show you what I mean.",
-    "translatedText": "Laissez-moi vous montrer ce que je veux dire.",
+    "translatedText": "Regardons ça plus en détail.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 416.9,
     "end": 417.68
   },
   {
     "input": "On the side of addressing misconceptions, what would you tell to the people in that seminar who answered 9 and 10?",
-    "translatedText": "En ce qui concerne la lutte contre les idées fausses, que diriez-vous aux personnes participant à ce séminaire qui ont répondu aux questions 9 et 10?",
+    "translatedText": "Du côté des fausses intuitions, qu’auriez-vous envie de dire aux médecins qui ont répondu « 9 sur 10 » lors de la conférence ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 418.46,
     "end": 423.98
   },
   {
     "input": "What fundamental misconception are they revealing?",
-    "translatedText": "Quelle idée fausse fondamentale révèlent-ils?",
+    "translatedText": "En quoi leur raisonnement est-il fondamentalement faux ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 424.48,
     "end": 426.9
   },
   {
     "input": "What I might tell them is that in much the same way that you shouldn't think of tests as telling you deterministically whether you have a disease, you shouldn't even think of them as telling you your chances of having a disease.",
-    "translatedText": "Ce que je pourrais leur dire, c'est que de la même manière que vous ne devriez pas considérer les tests comme vous indiquant de manière déterministe si vous avez une maladie, vous ne devriez même pas les considérer comme vous indiquant vos chances d'avoir une maladie.",
+    "translatedText": "On pourrait leur dire que, de la même manière qu’on ne devrait pas considérer que les tests peuvent déterminer si quelqu’un est malade ou non, on ne devrait même pas considérer qu’ils nous donnent le risque que cette personne soit malade.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 428.18,
     "end": 438.6
   },
   {
     "input": "Instead, the healthy view of what tests do is that they update your chances.",
-    "translatedText": "Au lieu de cela, la vision saine de ce que font les tests est qu’ils mettent à jour vos chances.",
+    "translatedText": "Une description plus exacte est que les test nous permettent de mettre à jour nos estimations.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 439.56,
     "end": 444.46
   },
@@ -563,79 +563,79 @@
     "input": "In our example, before taking the test, a patient's chances of having cancer were 1 in 100.",
     "translatedText": "Dans notre exemple, avant de passer le test, le risque d’avoir un cancer était de 1 sur 100.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 446.04,
     "end": 450.68
   },
   {
     "input": "In Bayesian terms, we call this the prior probability.",
-    "translatedText": "En termes bayésiens, nous appelons cela la probabilité a priori.",
+    "translatedText": "En termes bayésiens, on appelle ça la probabilité a priori.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 451.12,
     "end": 453.64
   },
   {
     "input": "The effect of this test was to update that prior by almost an order of magnitude, up to around 1 in 11.",
-    "translatedText": "L’effet de ce test a été de mettre à jour le précédent de près d’un ordre de grandeur, jusqu’à environ 1 sur 11.",
+    "translatedText": "L’effet de ce test a été de mettre à jour cet a priori par quasiment un facteur 10, à 1 sur 11.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 454.38,
     "end": 460.36
   },
   {
     "input": "The accuracy of a test is telling us about the strength of this updating.",
-    "translatedText": "La précision d’un test nous renseigne sur la force de cette mise à jour.",
+    "translatedText": "La performance d’un test se traduit dans la valeur de cette mise à jour.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 461.02,
     "end": 464.82
   },
   {
     "input": "It's not telling us a final answer.",
-    "translatedText": "Cela ne nous donne pas de réponse définitive.",
+    "translatedText": "Elle ne nous donne pas de réponse définitive.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 465.12,
     "end": 466.74
   },
   {
     "input": "What does this have to do with quick approximations?",
-    "translatedText": "Qu’est-ce que cela a à voir avec des approximations rapides?",
+    "translatedText": "Alors, quel rapport avec nos estimations rapides ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 467.9,
     "end": 469.64
   },
   {
     "input": "Well, a key number for those approximations is something called the Bayes factor, and the very act of defining this number serves to reinforce this central lesson about reframing what it is the tests do.",
-    "translatedText": "Eh bien, un nombre clé pour ces approximations est ce qu’on appelle le facteur Bayes, et le fait même de définir ce nombre sert à renforcer cette leçon centrale sur le recadrage de ce que font les tests.",
+    "translatedText": "Eh bien, un élément clé pour ces estimations est ce qu’on appelle le facteur de Bayes. Et le fait même de définir ce nombre vient consolider notre compréhension de ce que disent réellement les tests.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 470.3,
     "end": 481.4
   },
   {
     "input": "You see, one of the things that makes test statistics so very confusing is that there are at least 4 numbers that you'll hear associated with them.",
-    "translatedText": "Vous voyez, l'une des choses qui rendent les statistiques de test si confuses est qu'il y a au moins 4 nombres que vous entendrez associés à celles-ci.",
+    "translatedText": "Une des choses qui génère de la confusion concernant la performance des tests est qu’on vous parlera d’au moins 4 chiffres différents. ",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 482.42,
     "end": 488.9
   },
   {
     "input": "For those with the disease, there's the sensitivity and the false negative rate, and then for those without, there's the specificity and the false positive rate, and none of these numbers actually tell you the thing you want to know.",
-    "translatedText": "Pour ceux qui sont atteints de la maladie, il y a la sensibilité et le taux de faux négatifs, et pour ceux qui ne le sont pas, il y a la spécificité et le taux de faux positifs, et aucun de ces chiffres ne vous dit réellement ce que vous voulez savoir.",
+    "translatedText": "La sensibilité et le taux de faux négatifs pour les personnes atteintes de la maladie ; la spécificité et le taux de faux positifs pour celles qui ne le sont pas. Mais aucun de ces chiffres ne dit vraiment ce que vous voulez savoir.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 488.9,
     "end": 498.8
   },
   {
     "input": "Luckily, if you want to interpret a positive test result, you can pull out just one number to focus on from all this.",
-    "translatedText": "Heureusement, si vous souhaitez interpréter un résultat de test positif, vous pouvez tirer un seul chiffre sur lequel vous concentrer.",
+    "translatedText": "Heureusement, si vous voulez interpréter un résultat de test positif, il y a un chiffre sur lequel vous pouvez vous concentrer.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 499.5,
     "end": 505.62
   },
@@ -643,175 +643,175 @@
     "input": "Take the sensitivity divided by the false positive rate.",
     "translatedText": "Prenez la sensibilité divisée par le taux de faux positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 506.04,
     "end": 508.6
   },
   {
     "input": "In other words, how much more likely are you to see the positive test result with cancer versus without?",
-    "translatedText": "En d’autres termes, dans quelle mesure avez-vous plus de chances de voir un résultat de test positif avec un cancer plutôt qu’avec un cancer?",
+    "translatedText": "Autrement dit, dans quelle mesure avez-vous plus de chances de voir un résultat de test positif entre un cas avec un cancer et un cas sans ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 509.16,
     "end": 514.74
   },
   {
     "input": "In our example, this number is 10.",
-    "translatedText": "Dans notre exemple, ce nombre est 10.",
+    "translatedText": "Dans notre exemple, ce nombre est égal à 10.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 514.74,
     "end": 517.14
   },
   {
     "input": "This is the Bayes factor, also sometimes called the likelihood ratio.",
-    "translatedText": "Il s’agit du facteur Bayes, aussi parfois appelé rapport de vraisemblance.",
+    "translatedText": "Il s’agit du facteur de Bayes, aussi parfois appelé rapport de vraisemblance.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 517.9,
     "end": 521.72
   },
   {
     "input": "A very handy rule of thumb is that to update a small prior, or at least to approximate the answer, you simply multiply it by the Bayes factor.",
-    "translatedText": "Une règle empirique très pratique est que pour mettre à jour un petit a priori, ou au moins pour approximer la réponse, il vous suffit de le multiplier par le facteur Bayes.",
+    "translatedText": "Voici une approximation très pratique pour mettre à jour une probabilité a priori lorsqu’elle est faible : il vous suffit de la multiplier par le facteur Bayes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 523.1,
     "end": 530.02
   },
   {
     "input": "So in our example, where the prior was 1 in 100, you would estimate that the final answer should be around 1 in 10, which is in fact slightly above the true correct answer.",
-    "translatedText": "Ainsi, dans notre exemple, où la réponse a priori était de 1 sur 100, vous estimeriez que la réponse finale devrait être d'environ 1 sur 10, ce qui est en fait légèrement supérieur à la vraie bonne réponse.",
+    "translatedText": "Avec une probabilité a priori de 1 sur 100, vous pouvez donc estimer que la probabilité a posteriori sera d'environ 1 sur 10, ce qui est effectivement légèrement au-dessus de la valeur réelle.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 530.76,
     "end": 538.82
   },
   {
     "input": "So based on this rule of thumb, if I asked you what would happen if the prior from our example was instead 1 in 1000, you could quickly estimate that the effect of the test should be to update those chances to around 1 in 100.",
-    "translatedText": "Donc, sur la base de cette règle empirique, si je vous demandais ce qui se passerait si le facteur a priori de notre exemple était plutôt de 1 sur 1000, vous pourriez rapidement estimer que l'effet du test devrait être de mettre à jour ces chances à environ 1 sur 100.",
+    "translatedText": "Donc, si je vous demande ce qui se passerait si la probabilité a priori de notre exemple était plutôt de 1 sur 1000, vous devriez pouvoir prendre le résultat du test et estimer rapidement que ça a pour conséquence de mettre à jour cette probabilité à environ 1 sur 100.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 539.4,
     "end": 551.42
   },
   {
     "input": "And in fact, take a moment to check yourself by thinking through a sample population.",
-    "translatedText": "Et en fait, prenez un moment pour vous vérifier en réfléchissant à un échantillon de population.",
+    "translatedText": "Prenez donc un moment pour vérifier que vous avez bien compris en imaginant une population.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 552.36,
     "end": 555.72
   },
   {
     "input": "In this case, you might picture 10,000 patients where only 10 of them really have cancer.",
-    "translatedText": "Dans ce cas, vous pourriez imaginer 10 000 patients dont seulement 10 d’entre eux sont réellement atteints d’un cancer.",
+    "translatedText": "Vous pourriez imaginer 10 000 patients, parmi lesquels 10 d’entre eux sont atteints d’un cancer.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 556.7,
     "end": 560.88
   },
   {
     "input": "And then based on that 90% sensitivity, we would expect 9 of those cancer cases to give true positives.",
-    "translatedText": "Et puis, sur la base de cette sensibilité de 90 %, nous nous attendrions à ce que 9 de ces cas de cancer donnent de vrais positifs.",
+    "translatedText": "Et, en partant sur une sensibilité de 90 %, on s’attend à ce que sur les 10 cas de cancer, 9 résultats de tests soient des vrais positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 562.14,
     "end": 567.9
   },
   {
     "input": "And on the other side, a 91% specificity means that 9% of those without cancer are getting false positives.",
-    "translatedText": "Et d’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des faux positifs.",
+    "translatedText": "D’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des résultats faux positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 569,
     "end": 575.76
   },
   {
     "input": "So we'd expect 9% of the remaining patients, which is around 900, to give false positive results.",
-    "translatedText": "Nous nous attendons donc à ce que 9 % des patients restants, soit environ 900, donnent des résultats faussement positifs.",
+    "translatedText": "On s’attend donc à ce que 9 % des patients restants, soit environ 900, aient des résultats faussement positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 576.66,
     "end": 581.86
   },
   {
     "input": "Here, with such a low prevalence, the false positives really do dominate the true positives.",
-    "translatedText": "Ici, avec une prévalence aussi faible, les faux positifs dominent réellement les vrais positifs.",
+    "translatedText": "Ici, avec une prévalence aussi faible, les faux positifs dominent vraiment les vrais positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 582.7,
     "end": 587.82
   },
   {
     "input": "So the probability that a randomly chosen positive case from this population actually has cancer is only around 1%, just like the rule of thumb predicted.",
-    "translatedText": "Ainsi, la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédit la règle empirique.",
+    "translatedText": "Donc la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédisait l’approximation.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 587.9,
     "end": 597.02
   },
   {
     "input": "Now, this rule of thumb clearly cannot work for higher priors.",
-    "translatedText": "Or, cette règle empirique ne peut clairement pas fonctionner pour des priorités plus élevées.",
+    "translatedText": "Or, cette approximation ne fonctionne clairement pas pour des valeurs d’a priori plus élevées.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 598.7,
     "end": 601.92
   },
   {
     "input": "For example, it would predict that a prior of 10% gets updated all the way to 100% certainty.",
-    "translatedText": "Par exemple, il prédirait qu'un a priori de 10 % est mis à jour jusqu'à une certitude de 100 %.",
+    "translatedText": "Par exemple, elle prédirait qu'un a priori de 10 % serait mis à jour à une valeur de 100 %.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 602.42,
     "end": 607.86
   },
   {
     "input": "But that can't be right.",
-    "translatedText": "Mais cela ne peut pas être vrai.",
+    "translatedText": "Mais ça ne peut pas être vrai.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 608.36,
     "end": 609.32
   },
   {
     "input": "In fact, take a moment to think through what the answer should be, again, using a sample population.",
-    "translatedText": "En fait, prenez un moment pour réfléchir à la réponse, toujours en utilisant un échantillon de population.",
+    "translatedText": "Prenons un moment pour réfléchir à ce que devrait être la vraie valeur, en utilisant toujours une population fictive.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 610.02,
     "end": 614.5
   },
   {
     "input": "Maybe this time we picture 10 out of 100 having cancer.",
-    "translatedText": "Peut-être que cette fois, nous imaginons que 10 personnes sur 100 auront un cancer.",
+    "translatedText": "Cette fois, imaginons que 10 personnes sur 100 ont un cancer.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 615.06,
     "end": 617.86
   },
   {
     "input": "Again, based on the 90% sensitivity of the test, we'd expect 9 of those true cancer cases to get positive results.",
-    "translatedText": "Encore une fois, sur la base de la sensibilité de 90 % du test, nous nous attendons à ce que 9 de ces véritables cas de cancer obtiennent des résultats positifs.",
+    "translatedText": "De nouveau, en prenant une sensibilité de 90 % du test, nous nous attendons à ce que 9 des véritables cas de cancer fournissent des résultats positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 618.54,
     "end": 624.92
   },
   {
     "input": "But what about the false positives?",
-    "translatedText": "Mais qu’en est-il des faux positifs?",
+    "translatedText": "Mais concernant les faux positifs,",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 624.92,
     "end": 626.6
   },
   {
     "input": "How many do we expect there?",
-    "translatedText": "Combien en attend-on là-bas?",
+    "translatedText": "combien doit-on en trouver ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 626.98,
     "end": 628.1
   },
@@ -819,151 +819,151 @@
     "input": "About 9% of the remaining 90. About 8.",
     "translatedText": "Environ 9% des 90 restants, soit environ 8.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 629.88,
     "end": 632.62
   },
   {
     "input": "So, upon seeing a positive test result, it tells you that you're either one of these 9 true positives or one of the 8 false positives.",
-    "translatedText": "Ainsi, lorsque vous voyez un résultat de test positif, cela vous indique que vous êtes soit l'un de ces 9 vrais positifs, soit l'un des 8 faux positifs.",
+    "translatedText": "Donc, quand vous voyez un résultat de test positif, vous avez devant vous soit l'un des 9 vrais positifs, soit l'un des 8 faux positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 633.82,
     "end": 641.14
   },
   {
     "input": "So this means the chances are a little over 50%, roughly 9 out of 17, or 53%.",
-    "translatedText": "Cela signifie donc que les chances sont d'un peu plus de 50 %, soit environ 9 sur 17, soit 53 %.",
+    "translatedText": "On a donc un peu plus d’une chance sur deux. 9 sur 17, soit à peu près 53 %.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 641.86,
     "end": 646.92
   },
   {
     "input": "At this point, having dared to dream that Bayesian updating could look as simple as multiplication, you might tear down your hopes and pragmatically acknowledge that sometimes life is just more complicated than that.",
-    "translatedText": "À ce stade, après avoir osé rêver que la mise à jour bayésienne puisse paraître aussi simple que la multiplication, vous pourriez détruire vos espoirs et reconnaître de manière pragmatique que parfois la vie est simplement plus compliquée que cela.",
+    "translatedText": "À ce stade, tout espoir que cette mise à jour bayésienne puisse être aussi simple qu’une multiplication semble perdu, et on a envie de se dire que parfois les choses ne sont pas aussi simple qu’on aimerait.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 648.02,
     "end": 657.7
   },
   {
     "input": "Except it's not.",
-    "translatedText": "Sauf que ce n'est pas le cas.",
+    "translatedText": "Sauf que ce n'est pas vrai !",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 659.92,
     "end": 661.12
   },
   {
     "input": "This rule of thumb turns into a precise mathematical fact as long as we shift away from talking about probabilities to instead talking about odds.",
-    "translatedText": "Cette règle empirique se transforme en un fait mathématique précis, à condition que l’on cesse de parler de probabilités pour parler de probabilités.",
+    "translatedText": "Cette approximation peut devenir un calcul exact, à condition que l’on ne considère plus des probabilités, mais des cotes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 661.62,
     "end": 669
   },
   {
     "input": "If you've ever heard someone talk about the chances of an event being 1 to 1 or 2 to 1, things like that, you already know about odds.",
-    "translatedText": "Si vous avez déjà entendu quelqu'un parler des chances qu'un événement soit de 1 contre 1 ou de 2 contre 1, des choses comme ça, vous connaissez déjà les probabilités.",
+    "translatedText": "Si vous avez déjà entendu quelqu'un dire quelque chose comme : « 1 pour 1 », ou « à 2 contre 1 », vous savez déjà ce que c’est qu’une cote.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 670.32,
     "end": 677.06
   },
   {
     "input": "With probability, we're taking the ratio of the number of positive cases out of all possible cases, right?",
-    "translatedText": "Avec probabilité, on prend le ratio du nombre de cas positifs sur tous les cas possibles, n'est-ce pas?",
+    "translatedText": "Pour une probabilité, on prend le rapport entre le nombre de cas positifs et l’ensemble des cas.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 677.06,
     "end": 683.06
   },
   {
     "input": "Things like 1 in 5 or 1 in 10.",
-    "translatedText": "Des choses comme 1 sur 5 ou 1 sur 10.",
+    "translatedText": "Par exemple 1 sur 5, ou 1 sur 10…",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 683.4,
     "end": 685.28
   },
   {
     "input": "With odds, what you do is take the ratio of all positive cases to all negative cases.",
-    "translatedText": "Avec les probabilités, vous faites le rapport entre tous les cas positifs et tous les cas négatifs.",
+    "translatedText": "Avec les cotes, on fait le rapport entre tous les cas positifs et tous les cas négatifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 685.88,
     "end": 690.32
   },
   {
     "input": "You commonly see odds written with a colon to emphasize the distinction, but it's still just a fraction, just a number.",
-    "translatedText": "Vous voyez généralement les cotes écrites avec deux points pour souligner la distinction, mais ce n'est toujours qu'une fraction, juste un nombre.",
+    "translatedText": "Généralement, on note les cotes en utilisant deux points pour les distinguer d’une probabilité, mais ça reste bien une fraction, un nombre.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 691.54,
     "end": 697.06
   },
   {
     "input": "So an event with a 50% probability would be described as having 1 to 1 odds. A 10% probability is the same as 1 to 9 odds. An 80% probability is the same as 4 to 1 odds. You get the point.",
-    "translatedText": "Ainsi, un événement avec une probabilité de 50 % serait décrit comme ayant une cote de 1 contre 1, une probabilité de 10 % équivaut à une cote de 1 sur 9, une probabilité de 80 % équivaut à une cote de 4 contre 1, vous obtenez le point.",
+    "translatedText": "Du coup, un événement avec une probabilité de 50 % a une cote de 1 pour 1, une probabilité de 10 % équivaut à une cote de 1 pour 9, une probabilité de 80 %, une cote de 4 pour 1. Vous voyez l’idée.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 697.94,
     "end": 710.46
   },
   {
     "input": "It's the same information. It still describes the chances of a random event, but it's presented a little differently, like a different unit system.",
-    "translatedText": "C'est la même information, elle décrit toujours les chances d'un événement aléatoire, mais elle est présentée un peu différemment, comme un système d'unités différent.",
+    "translatedText": "C'est la même information : on décrit toujours les chances qu'un événement aléatoire se produise, mais avec une échelle un peu différente.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 711.48,
     "end": 718.34
   },
   {
     "input": "Probabilities are constrained between 0 and 1, with even chances sitting at 0.5.",
-    "translatedText": "Les probabilités sont contraintes entre 0 et 1, les chances paires étant égales à 0.5.",
+    "translatedText": "Une probabilité est un nombre entre 0 et 1. On a autant de chances d’avoir un résultat que l’autre à 0,5.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 719.32,
     "end": 723.68
   },
   {
     "input": "But odds range from 0 up to infinity, with even chances sitting at the number 1.",
-    "translatedText": "Mais les cotes vont de 0 à l’infini, les chances paires se situant au numéro 1.",
+    "translatedText": "Mais une va de 0 à l’infini, et des chances égales se situent alors à 1.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 724.8,
     "end": 729.54
   },
   {
     "input": "The beauty here is that a completely accurate, not even approximating things way to frame Bayes' rule is to say, express your prior using odds, and then just multiply by the Bayes' factor.",
-    "translatedText": "La beauté ici est qu'une façon tout à fait précise, même pas approximative, de cadrer la règle de Bayes est de dire, d'exprimer votre a priori en utilisant les cotes, puis de simplement multiplier par le facteur de Bayes.",
+    "translatedText": "Ce qui est beau ici, c’est que cette description du théorème de Bayes est tout à fait exacte : écrivez votre a priori comme une cote, et multipliez le simplement par le facteur de Bayes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 731.88,
     "end": 742.36
   },
   {
     "input": "Think about what the prior odds are really saying.",
-    "translatedText": "Pensez à ce que disent réellement les cotes antérieures.",
+    "translatedText": "Réfléchissez à ce que signifie vraiment la cote a priori.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 743.44,
     "end": 745.22
   },
   {
     "input": "It's the number of people with cancer divided by the number without it.",
-    "translatedText": "C'est le nombre de personnes atteintes de cancer divisé par le nombre de personnes qui n'en souffrent pas.",
+    "translatedText": "C'est le nombre de personnes malades divisé par le nombre de personnes saines.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 745.58,
     "end": 749.26
   },
   {
     "input": "Here, let's just write that down as a normal fraction for a moment so we can multiply it.",
-    "translatedText": "Ici, écrivons cela sous forme de fraction normale pendant un instant afin de pouvoir la multiplier.",
+    "translatedText": "Mettons ça sous forme de fraction pour pouvoir le multiplier.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 749.7,
     "end": 753.36
   },

--- a/2020/better-bayes/french/sentence_translations.json
+++ b/2020/better-bayes/french/sentence_translations.json
@@ -929,7 +929,7 @@
   },
   {
     "input": "But odds range from 0 up to infinity, with even chances sitting at the number 1.",
-    "translatedText": "Mais une va de 0 à l’infini, et des chances égales se situent alors à 1.",
+    "translatedText": "Mais une cote va de 0 à l’infini, et un partage équitable des chances se situe alors à 1.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 724.8,
@@ -961,7 +961,7 @@
   },
   {
     "input": "Here, let's just write that down as a normal fraction for a moment so we can multiply it.",
-    "translatedText": "Mettons ça sous forme de fraction pour pouvoir le multiplier.",
+    "translatedText": "Mettons-le sous forme de fraction pour pouvoir le multiplier.",
     "model": "google_nmt",
     "n_reviews": 1,
     "start": 749.7,

--- a/2020/better-bayes/french/sentence_translations.json
+++ b/2020/better-bayes/french/sentence_translations.json
@@ -1,1578 +1,1578 @@
 [
- {
-  "input": "Some of you may have heard this paradoxical fact about medical tests.",
-  "translatedText": "Certains d’entre vous ont peut-être entendu ce fait paradoxal concernant les tests médicaux.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 0.0,
-  "end": 3.14
- },
- {
-  "input": "It's very commonly used to introduce the topic of Bayes' rule in probability.",
-  "translatedText": "Il est très couramment utilisé pour introduire le sujet de la règle de Bayes en probabilité.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 3.58,
-  "end": 6.74
- },
- {
-  "input": "The paradox is that you could take a test which is highly accurate, in the sense that it gives correct results to a large majority of the people taking it.",
-  "translatedText": "Le paradoxe est que l’on pourrait passer un test très précis, dans le sens où il donne des résultats corrects à une grande majorité des personnes qui le passent.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 7.5,
-  "end": 15.66
- },
- {
-  "input": "And yet, under the right circumstances, when assessing the probability that your particular test result is correct, you can still land on a very low number, arbitrarily low, in fact.",
-  "translatedText": "Et pourtant, dans de bonnes circonstances, lorsque vous évaluez la probabilité que le résultat de votre test soit correct, vous pouvez toujours tomber sur un chiffre très faible, arbitrairement faible, en fait.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 16.04,
-  "end": 26.3
- },
- {
-  "input": "In short, an accurate test is not necessarily a very predictive test.",
-  "translatedText": "Bref, un test précis n’est pas forcément un test très prédictif.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 26.78,
-  "end": 31.82
- },
- {
-  "input": "Now when people think about math and formulas, they don't often think of it as a design process.",
-  "translatedText": "Aujourd’hui, lorsque les gens pensent aux mathématiques et aux formules, ils n’y pensent pas souvent comme à un processus de conception.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 33.06,
-  "end": 37.44
- },
- {
-  "input": "I mean, maybe in the case of notation it's easy to see that different choices are possible, but when it comes to the structure of the formulas themselves and how we use them, that's something that people typically view as fixed.",
-  "translatedText": "Je veux dire, peut-être que dans le cas de la notation, il est facile de voir que différents choix sont possibles, mais lorsqu'il s'agit de la structure des formules elles-mêmes et de la manière dont nous les utilisons, c'est quelque chose que les gens considèrent généralement comme fixe.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 38.08,
-  "end": 49.68
- },
- {
-  "input": "In this video, you and I will dig into this paradox, but instead of using it to talk about the usual version of Bayes' rule, I'd like to motivate an alternate version, an alternate design choice.",
-  "translatedText": "Dans cette vidéo, vous et moi allons creuser ce paradoxe, mais au lieu de l'utiliser pour parler de la version habituelle de la règle de Bayes, j'aimerais motiver une version alternative, un choix de conception alternatif.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 50.68,
-  "end": 60.56
- },
- {
-  "input": "Now, what's up on the screen now is a little bit abstract, which makes it difficult to justify that there really is a substantive difference here, especially when I haven't explained either one yet.",
-  "translatedText": "Maintenant, ce qui se passe à l'écran est un peu abstrait, ce qui rend difficile de justifier qu'il y ait vraiment une différence substantielle ici, surtout quand je n'ai encore expliqué ni l'un ni l'autre.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 61.66,
-  "end": 70.54
- },
- {
-  "input": "To see what I'm talking about though, we should really start by spending some time a little more concretely, and just laying out what exactly this paradox is.",
-  "translatedText": "Mais pour voir de quoi je parle, nous devrions vraiment commencer par passer un peu de temps un peu plus concrètement, et simplement exposer ce qu'est exactement ce paradoxe.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 71.04,
-  "end": 78.1
- },
- {
-  "input": "Picture a thousand women and suppose that 1% of them have breast cancer.",
-  "translatedText": "1% des femmes ont un cancer du sein Imaginez un millier de femmes et supposez que 1% d'entre elles ont un cancer du sein.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 84.02,
-  "end": 87.94
- },
- {
-  "input": "And let's say they all undergo a certain breast cancer screening, and that 9 of those with cancer correctly get positive results, and there's one false negative.",
-  "translatedText": "Et disons qu'elles subissent toutes un certain dépistage du cancer du sein, et que 9 de celles atteintes d'un cancer obtiennent correctement des résultats positifs, et qu'il y ait un faux négatif.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 88.68,
-  "end": 96.68
- },
- {
-  "input": "And then suppose that among the remainder without cancer, 89 get false positives, and 901 correctly get negative results.",
-  "translatedText": "Et supposons ensuite que parmi les autres sans cancer, 89 obtiennent des faux positifs et 901 obtiennent correctement des résultats négatifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 97.48,
-  "end": 104.92
- },
- {
-  "input": "So if all you know about a woman is that she does the screening and she gets a positive result, you don't have information about symptoms or anything like that, you know that she's either one of these 9 true positives or one of these 89 false positives.",
-  "translatedText": "Donc, si tout ce que vous savez sur une femme, c'est qu'elle fait le dépistage et qu'elle obtient un résultat positif, que vous n'avez aucune information sur les symptômes ou quoi que ce soit du genre, vous savez qu'elle est soit l'un de ces 9 vrais positifs, soit l'un de ces 89 faux positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 105.72,
-  "end": 118.26
- },
- {
-  "input": "So the probability that she's in the cancer group given the test result is 9 divided by 9 plus 89, which is approximately 1 in 11.",
-  "translatedText": "Ainsi, la probabilité qu'elle appartienne au groupe des cancers compte tenu du résultat du test est de 9 divisé par 9 plus 89, soit environ 1 sur 11.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 119.36,
-  "end": 128.14
- },
- {
-  "input": "In medical parlance, you would call this the positive predictive value of the test, or PPV, the number of true positives divided by the total number of positive test results.",
-  "translatedText": "Dans le langage médical, on appellerait cela la valeur prédictive positive du test, ou PPV, le nombre de vrais positifs divisé par le nombre total de résultats de test positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 129.08,
-  "end": 138.62
- },
- {
-  "input": "You can see where the name comes from.",
-  "translatedText": "Vous pouvez voir d'où vient le nom.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 138.62,
-  "end": 140.44
- },
- {
-  "input": "To what extent does a positive test result actually predict that you have the disease?",
-  "translatedText": "Dans quelle mesure un résultat de test positif prédit-il réellement que vous souffrez de la maladie?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 140.74,
-  "end": 145.36
- },
- {
-  "input": "Now, hopefully, as I've presented it this way where we're thinking concretely about a sample population, all of this makes perfect sense.",
-  "translatedText": "J'espère que, comme je l'ai présenté de cette façon, en pensant concrètement à un échantillon de population, tout cela est parfaitement logique.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 146.82,
-  "end": 153.46
- },
- {
-  "input": "But where it comes across as counterintuitive is if you just look at the accuracy of the test, present it to people as a statistic, and then ask them to make judgments about their test result.",
-  "translatedText": "Mais là où cela semble contre-intuitif, c’est si vous examinez simplement l’exactitude du test, le présentez aux gens sous forme de statistique, puis demandez-leur de porter un jugement sur le résultat de leur test.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 153.96,
-  "end": 163.2
- },
- {
-  "input": "Test accuracy is not actually one number, but two.",
-  "translatedText": "La précision des tests n’est pas en réalité un chiffre, mais deux.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 164.02,
-  "end": 166.26
- },
- {
-  "input": "First, you ask how often is the test correct on those with the disease.",
-  "translatedText": "Tout d’abord, vous demandez-vous, à quelle fréquence un test est-il correct sur les personnes atteintes de la maladie?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 166.26,
-  "end": 171.12
- },
- {
-  "input": "This is known as the test sensitivity, as in how sensitive is it to detecting the presence of the disease.",
-  "translatedText": "C’est ce qu’on appelle la sensibilité du test, c’est-à-dire : quelle est sa sensibilité pour détecter la présence de la maladie?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 171.7,
-  "end": 177.44
- },
- {
-  "input": "In our example, test sensitivity is 9 in 10, or 90%.",
-  "translatedText": "Dans notre exemple, la sensibilité du test est de 9 sur 10, soit 90 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 178.26,
-  "end": 181.26
- },
- {
-  "input": "And another way to say the same fact would be to say the false negative rate is 10%.",
-  "translatedText": "Et une autre façon de dire le même fait serait de dire que le taux de faux négatifs est de 10 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 182.02,
-  "end": 186.68
- },
- {
-  "input": "And then a separate, not necessarily related number is how often it's correct for those without the disease, which is known as the test specificity, as in are positive results caused specifically by the disease, or are there confounding triggers giving false positives.",
-  "translatedText": "Et puis un chiffre distinct, pas nécessairement lié, est la fréquence à laquelle il est correct pour les personnes non atteintes de la maladie, ce que l'on appelle la spécificité du test, comme dans : les résultats positifs sont-ils causés spécifiquement par la maladie, ou y a-t-il des déclencheurs confondants donnant des faux positifs?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 186.68,
-  "end": 202.06
- },
- {
-  "input": "In our example, the specificity is about 91%.",
-  "translatedText": "Dans notre exemple, la spécificité est d'environ 91 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 203.08,
-  "end": 206.58
- },
- {
-  "input": "Or another way to say the same fact would be to say the false positive rate is 9%.",
-  "translatedText": "Ou bien, une autre façon de dire le même fait serait de dire que le taux de faux positifs est de 9 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 206.58,
-  "end": 211.66
- },
- {
-  "input": "So the paradox here is that in one sense, the test is over 90% accurate.",
-  "translatedText": "Le paradoxe ici est donc que, dans un sens, le test est précis à plus de 90 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 211.66,
-  "end": 216.76
- },
- {
-  "input": "It gives correct results to over 90% of the patients who take it.",
-  "translatedText": "Il donne des résultats corrects à plus de 90 % des patients qui le prennent.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 217.02,
-  "end": 220.66
- },
- {
-  "input": "And yet, if you learn that someone gets a positive result without any added information, there's actually only a 1 in 11 chance that that particular result is accurate.",
-  "translatedText": "Et pourtant, si vous apprenez qu’une personne obtient un résultat positif sans aucune information supplémentaire, il n’y a en réalité qu’une chance sur 11 que ce résultat particulier soit exact.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 220.66,
-  "end": 229.6
- },
- {
-  "input": "This is a bit of a problem, because of all of the places for math to be counterintuitive, medical tests are one area where it matters a lot.",
-  "translatedText": "C'est un peu un problème, car les mathématiques peuvent être contre-intuitives à tous les niveaux, et les tests médicaux sont un domaine où cela compte beaucoup.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 230.62,
-  "end": 237.18
- },
- {
-  "input": "In 2006 and 2007, the psychologist Gerd Gigerenzer gave a series of statistics seminars to practicing gynecologists, and he opened with the following example.",
-  "translatedText": "En 2006 et 2007, le psychologue Gerd Gigerenzer a donné une série de séminaires de statistiques à des gynécologues en exercice, et il a commencé par l'exemple suivant.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 237.94,
-  "end": 246.8
- },
- {
-  "input": "A 50-year-old woman, no symptoms, participates in a routine mammography screening.",
-  "translatedText": "Une femme de 50 ans, sans symptômes, participe à un dépistage de routine par mammographie.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 246.8,
-  "end": 251.74
- },
- {
-  "input": "She tests positive, is alarmed, and wants to know from you whether she has breast cancer for certain or what her chances are.",
-  "translatedText": "Son test est positif, elle est alarmée et veut savoir si elle a un cancer du sein avec certitude ou quelles sont ses chances.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 252.28,
-  "end": 258.38
- },
- {
-  "input": "Apart from the screening result, you know nothing else about this woman.",
-  "translatedText": "Hormis le résultat du dépistage, vous ne savez rien d’autre sur cette femme.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 258.88,
-  "end": 261.74
- },
- {
-  "input": "In that seminar, the doctors were then told that the prevalence of breast cancer for women of this age is about 1%, and then to suppose that the test sensitivity is 90% and that its specificity was 91%.",
-  "translatedText": "Lors de ce séminaire, on a ensuite expliqué aux médecins que la prévalence du cancer du sein chez les femmes de cet âge est d'environ 1 %, puis de supposer que la sensibilité du test est de 90 % et que sa spécificité est de 91 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 262.58,
-  "end": 274.18
- },
- {
-  "input": "You might notice these are exactly the same numbers from the example that you and I just looked at.",
-  "translatedText": "Vous remarquerez peut-être que ce sont exactement les mêmes chiffres que ceux de l’exemple que vous et moi venons de regarder.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 274.18,
-  "end": 278.18
- },
- {
-  "input": "This is where I got them.",
-  "translatedText": "C'est là que je les ai eu.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 278.36,
-  "end": 279.44
- },
- {
-  "input": "So, having already thought it through, you and I know the answer.",
-  "translatedText": "Donc, après y avoir déjà réfléchi, vous et moi connaissons la réponse.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 279.76,
-  "end": 282.6
- },
- {
-  "input": "It's about 1 in 11.",
-  "translatedText": "C'est environ 1 sur 11.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 282.88,
-  "end": 283.84
- },
- {
-  "input": "However, the doctors in this session were not primed with the suggestion to picture a concrete sample of a thousand individuals, the way that you and I had.",
-  "translatedText": "Cependant, les médecins présents à cette séance n'étaient pas préparés à la suggestion d'imaginer un échantillon concret d'un millier d'individus, comme vous et moi l'avons fait.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 284.6,
-  "end": 291.54
- },
- {
-  "input": "All they saw were these numbers.",
-  "translatedText": "Tout ce qu’ils ont vu, ce sont ces chiffres.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 292.04,
-  "end": 293.34
- },
- {
-  "input": "They were then asked, how many women who test positive actually have breast cancer?",
-  "translatedText": "On leur a ensuite demandé combien de femmes dont le test était positif avaient réellement un cancer du sein?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 294.14,
-  "end": 298.42
- },
- {
-  "input": "What is the best answer?",
-  "translatedText": "Quelle est la meilleure réponse?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 298.62,
-  "end": 299.74
- },
- {
-  "input": "And they were presented with these four choices.",
-  "translatedText": "Et on leur a présenté ces quatre choix.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 299.9,
-  "end": 301.68
- },
- {
-  "input": "In one of the sessions, over half the doctors present said that the correct answer was 9 in 10, which is way off.",
-  "translatedText": "Lors d'une des séances, plus de la moitié des médecins présents ont déclaré que la bonne réponse était 9 sur 10, ce qui est loin d'être le cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 301.68,
-  "end": 309.3
- },
- {
-  "input": "Only a fifth of them gave the correct answer, which is worse than what it would have been if everybody had randomly guessed.",
-  "translatedText": "Seulement un cinquième d’entre eux ont donné la bonne réponse, ce qui est pire que ce qui aurait été si tout le monde avait deviné au hasard.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 310.02,
-  "end": 315.38
- },
- {
-  "input": "It might seem a little extreme to be calling this a paradox.",
-  "translatedText": "Il peut sembler un peu extrême de qualifier cela de paradoxe.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 316.66,
-  "end": 319.28
- },
- {
-  "input": "I mean, it's just a fact.",
-  "translatedText": "Je veux dire, c'est juste un fait.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 319.76,
-  "end": 321.14
- },
- {
-  "input": "It's not something intrinsically self-contradictory.",
-  "translatedText": "Ce n’est pas quelque chose de intrinsèquement contradictoire.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 321.26,
-  "end": 323.5
- },
- {
-  "input": "But, as these seminars with Gigerenzer show, people, including doctors, definitely find it counterintuitive that a test with high accuracy can give you such a low predictive value.",
-  "translatedText": "Mais comme le montrent ces séminaires avec Gigerenzer, les gens, y compris les médecins, trouvent certainement contre-intuitif qu’un test d’une grande précision puisse donner une valeur prédictive aussi faible.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 324.2,
-  "end": 334.24
- },
- {
-  "input": "We might call this a veridical paradox, which refers to facts that are provably true, but which nevertheless can feel false when phrased a certain way.",
-  "translatedText": "Nous pourrions appeler cela un paradoxe véridique, qui fait référence à des faits dont la vérité est prouvée, mais qui peuvent néanmoins sembler faux lorsqu’ils sont formulés d’une certaine manière.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 335.2,
-  "end": 343.8
- },
- {
-  "input": "It's sort of the softest form of a paradox, saying more about human psychology than about logic.",
-  "translatedText": "C’est en quelque sorte la forme la plus douce d’un paradoxe, qui en dit plus sur la psychologie humaine que sur la logique.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 344.3,
-  "end": 348.72
- },
- {
-  "input": "The question is how we can combat this.",
-  "translatedText": "La question est de savoir comment lutter contre cela.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 349.58,
-  "end": 351.98
- },
- {
-  "input": "Where we're going with this, by the way, is that I want you to be able to look at numbers like this and quickly estimate in your head that it means the predictive value of a positive test should be around 1 in 11.",
-  "translatedText": "En passant, je veux que vous puissiez examiner des chiffres comme celui-ci et estimer rapidement dans votre tête que cela signifie que la valeur prédictive d'un test positif devrait être d'environ 1 sur 11.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 353.8,
-  "end": 364.14
- },
- {
-  "input": "Or, if I changed things and asked, what if it was 10% of the population who had breast cancer?",
-  "translatedText": "Ou, si je changeais les choses et demandais : et si 10 % de la population souffrait d’un cancer du sein?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 364.76,
-  "end": 369.72
- },
- {
-  "input": "You should be able to quickly turn around and say that the final answer would be a little over 50%.",
-  "translatedText": "Vous devriez pouvoir rapidement vous retourner et dire que la réponse finale serait d'un peu plus de 50 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 370.12,
-  "end": 374.98
- },
- {
-  "input": "Or, if I said imagine a really low prevalence, something like 0.1% of patients having cancer, you should again quickly estimate that the predictive value of the test is around 1 in 100,",
-  "translatedText": "Ou, si je disais, imaginez une prévalence très faible, quelque chose comme 0.1% des patients ayant un cancer, il faut là encore rapidement estimer que la valeur prédictive du test est d'environ 1 sur 100.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 375.92,
-  "end": 386.14
- },
- {
-  "input": "that 1 in 100 of those with positive test results in that case would have cancer.",
-  "translatedText": "Dans ce cas, 1 personne sur 100 ayant des résultats de test positifs aurait un cancer.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 386.76,
-  "end": 390.6
- },
- {
-  "input": "Or, let's say we go back to the 1% prevalence, but I make the test more accurate.",
-  "translatedText": "Ou disons que nous revenons à la prévalence de 1 %, mais je rends le test plus précis.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 391.58,
-  "end": 395.24
- },
- {
-  "input": "I tell you to imagine the specificity is 99%.",
-  "translatedText": "Je vous dis d'imaginer que la spécificité est de 99 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 395.44,
-  "end": 398.4
- },
- {
-  "input": "There, you should be able to relatively quickly estimate that the answer is a little less than 50%.",
-  "translatedText": "Là, vous devriez pouvoir estimer assez rapidement que la réponse est un peu inférieure à 50 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 398.4,
-  "end": 403.8
- },
- {
-  "input": "The hope is that you're doing all of this with minimal calculations in your head.",
-  "translatedText": "L'espoir est que vous fassiez tout cela avec un minimum de calculs dans votre tête.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 404.32,
-  "end": 407.74
- },
- {
-  "input": "Now, the goals of quick calculations might feel very different from the goals of addressing whatever misconception underlies this paradox, but they actually go hand in hand.",
-  "translatedText": "Les objectifs des calculs rapides peuvent sembler très différents de ceux visant à répondre aux idées fausses qui sous-tendent ce paradoxe, mais ils vont en réalité de pair.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 408.54,
-  "end": 416.5
- },
- {
-  "input": "Let me show you what I mean.",
-  "translatedText": "Laissez-moi vous montrer ce que je veux dire.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 416.9,
-  "end": 417.68
- },
- {
-  "input": "On the side of addressing misconceptions, what would you tell to the people in that seminar who answered 9 and 10?",
-  "translatedText": "En ce qui concerne la lutte contre les idées fausses, que diriez-vous aux personnes participant à ce séminaire qui ont répondu aux questions 9 et 10?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 418.46,
-  "end": 423.98
- },
- {
-  "input": "What fundamental misconception are they revealing?",
-  "translatedText": "Quelle idée fausse fondamentale révèlent-ils?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 424.48,
-  "end": 426.9
- },
- {
-  "input": "What I might tell them is that in much the same way that you shouldn't think of tests as telling you deterministically whether you have a disease, you shouldn't even think of them as telling you your chances of having a disease.",
-  "translatedText": "Ce que je pourrais leur dire, c'est que de la même manière que vous ne devriez pas considérer les tests comme vous indiquant de manière déterministe si vous avez une maladie, vous ne devriez même pas les considérer comme vous indiquant vos chances d'avoir une maladie.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 428.18,
-  "end": 438.6
- },
- {
-  "input": "Instead, the healthy view of what tests do is that they update your chances.",
-  "translatedText": "Au lieu de cela, la vision saine de ce que font les tests est qu’ils mettent à jour vos chances.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 439.56,
-  "end": 444.46
- },
- {
-  "input": "In our example, before taking the test, a patient's chances of having cancer were 1 in 100.",
-  "translatedText": "Dans notre exemple, avant de passer le test, le risque d’avoir un cancer était de 1 sur 100.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 446.04,
-  "end": 450.68
- },
- {
-  "input": "In Bayesian terms, we call this the prior probability.",
-  "translatedText": "En termes bayésiens, nous appelons cela la probabilité a priori.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 451.12,
-  "end": 453.64
- },
- {
-  "input": "The effect of this test was to update that prior by almost an order of magnitude, up to around 1 in 11.",
-  "translatedText": "L’effet de ce test a été de mettre à jour le précédent de près d’un ordre de grandeur, jusqu’à environ 1 sur 11.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 454.38,
-  "end": 460.36
- },
- {
-  "input": "The accuracy of a test is telling us about the strength of this updating.",
-  "translatedText": "La précision d’un test nous renseigne sur la force de cette mise à jour.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 461.02,
-  "end": 464.82
- },
- {
-  "input": "It's not telling us a final answer.",
-  "translatedText": "Cela ne nous donne pas de réponse définitive.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 465.12,
-  "end": 466.74
- },
- {
-  "input": "What does this have to do with quick approximations?",
-  "translatedText": "Qu’est-ce que cela a à voir avec des approximations rapides?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 467.9,
-  "end": 469.64
- },
- {
-  "input": "Well, a key number for those approximations is something called the Bayes factor, and the very act of defining this number serves to reinforce this central lesson about reframing what it is the tests do.",
-  "translatedText": "Eh bien, un nombre clé pour ces approximations est ce qu’on appelle le facteur Bayes, et le fait même de définir ce nombre sert à renforcer cette leçon centrale sur le recadrage de ce que font les tests.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 470.3,
-  "end": 481.4
- },
- {
-  "input": "You see, one of the things that makes test statistics so very confusing is that there are at least 4 numbers that you'll hear associated with them.",
-  "translatedText": "Vous voyez, l'une des choses qui rendent les statistiques de test si confuses est qu'il y a au moins 4 nombres que vous entendrez associés à celles-ci.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 482.42,
-  "end": 488.9
- },
- {
-  "input": "For those with the disease, there's the sensitivity and the false negative rate, and then for those without, there's the specificity and the false positive rate, and none of these numbers actually tell you the thing you want to know.",
-  "translatedText": "Pour ceux qui sont atteints de la maladie, il y a la sensibilité et le taux de faux négatifs, et pour ceux qui ne le sont pas, il y a la spécificité et le taux de faux positifs, et aucun de ces chiffres ne vous dit réellement ce que vous voulez savoir.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 488.9,
-  "end": 498.8
- },
- {
-  "input": "Luckily, if you want to interpret a positive test result, you can pull out just one number to focus on from all this.",
-  "translatedText": "Heureusement, si vous souhaitez interpréter un résultat de test positif, vous pouvez tirer un seul chiffre sur lequel vous concentrer.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 499.5,
-  "end": 505.62
- },
- {
-  "input": "Take the sensitivity divided by the false positive rate.",
-  "translatedText": "Prenez la sensibilité divisée par le taux de faux positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 506.04,
-  "end": 508.6
- },
- {
-  "input": "In other words, how much more likely are you to see the positive test result with cancer versus without?",
-  "translatedText": "En d’autres termes, dans quelle mesure avez-vous plus de chances de voir un résultat de test positif avec un cancer plutôt qu’avec un cancer?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 509.16,
-  "end": 514.74
- },
- {
-  "input": "In our example, this number is 10.",
-  "translatedText": "Dans notre exemple, ce nombre est 10.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 514.74,
-  "end": 517.14
- },
- {
-  "input": "This is the Bayes factor, also sometimes called the likelihood ratio.",
-  "translatedText": "Il s’agit du facteur Bayes, aussi parfois appelé rapport de vraisemblance.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 517.9,
-  "end": 521.72
- },
- {
-  "input": "A very handy rule of thumb is that to update a small prior, or at least to approximate the answer, you simply multiply it by the Bayes factor.",
-  "translatedText": "Une règle empirique très pratique est que pour mettre à jour un petit a priori, ou au moins pour approximer la réponse, il vous suffit de le multiplier par le facteur Bayes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 523.1,
-  "end": 530.02
- },
- {
-  "input": "So in our example, where the prior was 1 in 100, you would estimate that the final answer should be around 1 in 10, which is in fact slightly above the true correct answer.",
-  "translatedText": "Ainsi, dans notre exemple, où la réponse a priori était de 1 sur 100, vous estimeriez que la réponse finale devrait être d'environ 1 sur 10, ce qui est en fait légèrement supérieur à la vraie bonne réponse.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 530.76,
-  "end": 538.82
- },
- {
-  "input": "So based on this rule of thumb, if I asked you what would happen if the prior from our example was instead 1 in 1000, you could quickly estimate that the effect of the test should be to update those chances to around 1 in 100.",
-  "translatedText": "Donc, sur la base de cette règle empirique, si je vous demandais ce qui se passerait si le facteur a priori de notre exemple était plutôt de 1 sur 1000, vous pourriez rapidement estimer que l'effet du test devrait être de mettre à jour ces chances à environ 1 sur 100.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 539.4,
-  "end": 551.42
- },
- {
-  "input": "And in fact, take a moment to check yourself by thinking through a sample population.",
-  "translatedText": "Et en fait, prenez un moment pour vous vérifier en réfléchissant à un échantillon de population.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 552.36,
-  "end": 555.72
- },
- {
-  "input": "In this case, you might picture 10,000 patients where only 10 of them really have cancer.",
-  "translatedText": "Dans ce cas, vous pourriez imaginer 10 000 patients dont seulement 10 d’entre eux sont réellement atteints d’un cancer.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 556.7,
-  "end": 560.88
- },
- {
-  "input": "And then based on that 90% sensitivity, we would expect 9 of those cancer cases to give true positives.",
-  "translatedText": "Et puis, sur la base de cette sensibilité de 90 %, nous nous attendrions à ce que 9 de ces cas de cancer donnent de vrais positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 562.14,
-  "end": 567.9
- },
- {
-  "input": "And on the other side, a 91% specificity means that 9% of those without cancer are getting false positives.",
-  "translatedText": "Et d’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des faux positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 569.0,
-  "end": 575.76
- },
- {
-  "input": "So we'd expect 9% of the remaining patients, which is around 900, to give false positive results.",
-  "translatedText": "Nous nous attendons donc à ce que 9 % des patients restants, soit environ 900, donnent des résultats faussement positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 576.66,
-  "end": 581.86
- },
- {
-  "input": "Here, with such a low prevalence, the false positives really do dominate the true positives.",
-  "translatedText": "Ici, avec une prévalence aussi faible, les faux positifs dominent réellement les vrais positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 582.7,
-  "end": 587.82
- },
- {
-  "input": "So the probability that a randomly chosen positive case from this population actually has cancer is only around 1%, just like the rule of thumb predicted.",
-  "translatedText": "Ainsi, la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédit la règle empirique.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 587.9,
-  "end": 597.02
- },
- {
-  "input": "Now, this rule of thumb clearly cannot work for higher priors.",
-  "translatedText": "Or, cette règle empirique ne peut clairement pas fonctionner pour des priorités plus élevées.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 598.7,
-  "end": 601.92
- },
- {
-  "input": "For example, it would predict that a prior of 10% gets updated all the way to 100% certainty.",
-  "translatedText": "Par exemple, il prédirait qu'un a priori de 10 % est mis à jour jusqu'à une certitude de 100 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 602.42,
-  "end": 607.86
- },
- {
-  "input": "But that can't be right.",
-  "translatedText": "Mais cela ne peut pas être vrai.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 608.36,
-  "end": 609.32
- },
- {
-  "input": "In fact, take a moment to think through what the answer should be, again, using a sample population.",
-  "translatedText": "En fait, prenez un moment pour réfléchir à la réponse, toujours en utilisant un échantillon de population.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 610.02,
-  "end": 614.5
- },
- {
-  "input": "Maybe this time we picture 10 out of 100 having cancer.",
-  "translatedText": "Peut-être que cette fois, nous imaginons que 10 personnes sur 100 auront un cancer.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 615.06,
-  "end": 617.86
- },
- {
-  "input": "Again, based on the 90% sensitivity of the test, we'd expect 9 of those true cancer cases to get positive results.",
-  "translatedText": "Encore une fois, sur la base de la sensibilité de 90 % du test, nous nous attendons à ce que 9 de ces véritables cas de cancer obtiennent des résultats positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 618.54,
-  "end": 624.92
- },
- {
-  "input": "But what about the false positives?",
-  "translatedText": "Mais qu’en est-il des faux positifs?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 624.92,
-  "end": 626.6
- },
- {
-  "input": "How many do we expect there?",
-  "translatedText": "Combien en attend-on là-bas?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 626.98,
-  "end": 628.1
- },
- {
-  "input": "About 9% of the remaining 90. About 8.",
-  "translatedText": "Environ 9% des 90 restants, soit environ 8.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 629.88,
-  "end": 632.62
- },
- {
-  "input": "So, upon seeing a positive test result, it tells you that you're either one of these 9 true positives or one of the 8 false positives.",
-  "translatedText": "Ainsi, lorsque vous voyez un résultat de test positif, cela vous indique que vous êtes soit l'un de ces 9 vrais positifs, soit l'un des 8 faux positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 633.82,
-  "end": 641.14
- },
- {
-  "input": "So this means the chances are a little over 50%, roughly 9 out of 17, or 53%.",
-  "translatedText": "Cela signifie donc que les chances sont d'un peu plus de 50 %, soit environ 9 sur 17, soit 53 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 641.86,
-  "end": 646.92
- },
- {
-  "input": "At this point, having dared to dream that Bayesian updating could look as simple as multiplication, you might tear down your hopes and pragmatically acknowledge that sometimes life is just more complicated than that.",
-  "translatedText": "À ce stade, après avoir osé rêver que la mise à jour bayésienne puisse paraître aussi simple que la multiplication, vous pourriez détruire vos espoirs et reconnaître de manière pragmatique que parfois la vie est simplement plus compliquée que cela.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 648.02,
-  "end": 657.7
- },
- {
-  "input": "Except it's not.",
-  "translatedText": "Sauf que ce n'est pas le cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 659.92,
-  "end": 661.12
- },
- {
-  "input": "This rule of thumb turns into a precise mathematical fact as long as we shift away from talking about probabilities to instead talking about odds.",
-  "translatedText": "Cette règle empirique se transforme en un fait mathématique précis, à condition que l’on cesse de parler de probabilités pour parler de probabilités.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 661.62,
-  "end": 669.0
- },
- {
-  "input": "If you've ever heard someone talk about the chances of an event being 1 to 1 or 2 to 1, things like that, you already know about odds.",
-  "translatedText": "Si vous avez déjà entendu quelqu'un parler des chances qu'un événement soit de 1 contre 1 ou de 2 contre 1, des choses comme ça, vous connaissez déjà les probabilités.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 670.32,
-  "end": 677.06
- },
- {
-  "input": "With probability, we're taking the ratio of the number of positive cases out of all possible cases, right?",
-  "translatedText": "Avec probabilité, on prend le ratio du nombre de cas positifs sur tous les cas possibles, n'est-ce pas?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 677.06,
-  "end": 683.06
- },
- {
-  "input": "Things like 1 in 5 or 1 in 10.",
-  "translatedText": "Des choses comme 1 sur 5 ou 1 sur 10.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 683.4,
-  "end": 685.28
- },
- {
-  "input": "With odds, what you do is take the ratio of all positive cases to all negative cases.",
-  "translatedText": "Avec les probabilités, vous faites le rapport entre tous les cas positifs et tous les cas négatifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 685.88,
-  "end": 690.32
- },
- {
-  "input": "You commonly see odds written with a colon to emphasize the distinction, but it's still just a fraction, just a number.",
-  "translatedText": "Vous voyez généralement les cotes écrites avec deux points pour souligner la distinction, mais ce n'est toujours qu'une fraction, juste un nombre.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 691.54,
-  "end": 697.06
- },
- {
-  "input": "So an event with a 50% probability would be described as having 1 to 1 odds. A 10% probability is the same as 1 to 9 odds. An 80% probability is the same as 4 to 1 odds. You get the point.",
-  "translatedText": "Ainsi, un événement avec une probabilité de 50 % serait décrit comme ayant une cote de 1 contre 1, une probabilité de 10 % équivaut à une cote de 1 sur 9, une probabilité de 80 % équivaut à une cote de 4 contre 1, vous obtenez le point.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 697.94,
-  "end": 710.46
- },
- {
-  "input": "It's the same information. It still describes the chances of a random event, but it's presented a little differently, like a different unit system.",
-  "translatedText": "C'est la même information, elle décrit toujours les chances d'un événement aléatoire, mais elle est présentée un peu différemment, comme un système d'unités différent.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 711.48,
-  "end": 718.34
- },
- {
-  "input": "Probabilities are constrained between 0 and 1, with even chances sitting at 0.5.",
-  "translatedText": "Les probabilités sont contraintes entre 0 et 1, les chances paires étant égales à 0.5.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 719.32,
-  "end": 723.68
- },
- {
-  "input": "But odds range from 0 up to infinity, with even chances sitting at the number 1.",
-  "translatedText": "Mais les cotes vont de 0 à l’infini, les chances paires se situant au numéro 1.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 724.8,
-  "end": 729.54
- },
- {
-  "input": "The beauty here is that a completely accurate, not even approximating things way to frame Bayes' rule is to say, express your prior using odds, and then just multiply by the Bayes' factor.",
-  "translatedText": "La beauté ici est qu'une façon tout à fait précise, même pas approximative, de cadrer la règle de Bayes est de dire, d'exprimer votre a priori en utilisant les cotes, puis de simplement multiplier par le facteur de Bayes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 731.88,
-  "end": 742.36
- },
- {
-  "input": "Think about what the prior odds are really saying.",
-  "translatedText": "Pensez à ce que disent réellement les cotes antérieures.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 743.44,
-  "end": 745.22
- },
- {
-  "input": "It's the number of people with cancer divided by the number without it.",
-  "translatedText": "C'est le nombre de personnes atteintes de cancer divisé par le nombre de personnes qui n'en souffrent pas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 745.58,
-  "end": 749.26
- },
- {
-  "input": "Here, let's just write that down as a normal fraction for a moment so we can multiply it.",
-  "translatedText": "Ici, écrivons cela sous forme de fraction normale pendant un instant afin de pouvoir la multiplier.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 749.7,
-  "end": 753.36
- },
- {
-  "input": "When you filter down just to those with positive test results, the number of people with cancer gets scaled down, scaled down by the probability of seeing a positive test result given that someone has cancer.",
-  "translatedText": "Lorsque vous filtrez uniquement celles dont les résultats de test sont positifs, le nombre de personnes atteintes de cancer est réduit, réduit par la probabilité de voir un résultat de test positif étant donné que quelqu'un a un cancer.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 753.36,
-  "end": 764.42
- },
- {
-  "input": "And then similarly, the number of people without cancer also gets scaled down, this time by the probability of seeing a positive test result, but in that case.",
-  "translatedText": "Et de la même manière, le nombre de personnes sans cancer est également réduit, cette fois en fonction de la probabilité de voir un résultat de test positif, mais dans ce cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 765.12,
-  "end": 773.44
- },
- {
-  "input": "So the ratio between these two counts, the new odds upon seeing the test, looks just like the prior odds except multiplied by this term here, which is exactly the Bayes' factor.",
-  "translatedText": "Ainsi, le rapport entre ces deux comptes, la nouvelle cote à la vue du test, ressemble exactement à la cote précédente, sauf qu'il est multiplié par ce terme ici, ce qui est exactement le facteur de Bayes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 774.18,
-  "end": 784.76
- },
- {
-  "input": "Look back at our example, where the Bayes' factor was 10.",
-  "translatedText": "Revenons à notre exemple, où le facteur de Bayes était de 10.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 787.8,
-  "end": 790.5
- },
- {
-  "input": "And as a reminder, this came from the 90% sensitivity divided by the 9% false positive rate.",
-  "translatedText": "Et pour rappel, cela provenait de la sensibilité de 90 % divisée par le taux de faux positifs de 9 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 791.0,
-  "end": 796.56
- },
- {
-  "input": "How much more likely are you to see a positive result with cancer versus without?",
-  "translatedText": "Dans quelle mesure avez-vous plus de chances de voir un résultat positif avec un cancer plutôt que sans?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 796.88,
-  "end": 800.74
- },
- {
-  "input": "If the prior is 1%, expressed as odds, this looks like 1 to 99.",
-  "translatedText": "Si l'a priori est de 1 %, exprimé en probabilité, cela ressemble à 1 : 99.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 801.72,
-  "end": 805.94
- },
- {
-  "input": "So by our rule, this gets updated to 10 to 99, which if you want you could convert back to a probability.",
-  "translatedText": "Donc, selon notre règle, cela est mis à jour entre 10 et 99, ce qui, si vous le souhaitez, peut être reconverti en probabilité.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 806.9,
-  "end": 813.4
- },
- {
-  "input": "It would be 10 divided by 10 plus 99, or about 1 in 11.",
-  "translatedText": "Ce serait 10 divisé par 10 plus 99, soit environ 1 sur 11.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 813.66,
-  "end": 817.22
- },
- {
-  "input": "If instead, the prior was 10%, which was the example that tripped up our rule of thumb earlier, expressed as odds, this looks like 1 to 9.",
-  "translatedText": "Si, à la place, l'a priori était de 10 %, ce qui était l'exemple qui a fait trébucher notre règle empirique plus tôt, exprimée en cotes, cela ressemble à 1 : 9.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 818.2,
-  "end": 826.26
- },
- {
-  "input": "By our simple rule, this gets updated to 10 to 9, which you can already read off pretty intuitively.",
-  "translatedText": "Selon notre règle simple, cela est mis à jour de 10 à 9, que vous pouvez déjà lire de manière assez intuitive.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 826.94,
-  "end": 832.44
- },
- {
-  "input": "It's a little above even chances, a little above 1 to 1.",
-  "translatedText": "C'est un peu au-dessus des chances égales, un peu au-dessus de 1 pour 1.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 832.44,
-  "end": 835.66
- },
- {
-  "input": "If you prefer, you can convert it back to a probability.",
-  "translatedText": "Si vous préférez, vous pouvez la reconvertir en probabilité.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 836.34,
-  "end": 838.84
- },
- {
-  "input": "You would write it as 10 out of 19, or about 53%.",
-  "translatedText": "Vous l'écririez comme 10 sur 19, soit environ 53 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 839.18,
-  "end": 843.28
- },
- {
-  "input": "And indeed, that is what we already found by thinking things through with a sample population.",
-  "translatedText": "Et c’est d’ailleurs ce que nous avons déjà constaté en réfléchissant sur un échantillon de population.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 843.28,
-  "end": 847.22
- },
- {
-  "input": "Let's say we go back to the 1% prevalence, but I make the test more accurate.",
-  "translatedText": "Disons que l'on revient à la prévalence de 1 %, mais je rends le test plus précis.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 848.3,
-  "end": 851.7
- },
- {
-  "input": "Now what if I told you to imagine that the false positive rate was only 1% instead of 9%?",
-  "translatedText": "Et si je vous disais d’imaginer que le taux de faux positifs n’était que de 1 % au lieu de 9 %?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 852.06,
-  "end": 856.64
- },
- {
-  "input": "What that would mean is that our Bayes factor is 90 instead of 10.",
-  "translatedText": "Cela signifierait que notre facteur Bayesien est de 90 au lieu de 10.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 857.12,
-  "end": 860.52
- },
- {
-  "input": "The test is doing more work for us.",
-  "translatedText": "Le test fait plus de travail pour nous.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 860.84,
-  "end": 862.46
- },
- {
-  "input": "In this case, with the more accurate test, it gets updated to 90 to 99, which is a little less than even chances, something a little under 50%.",
-  "translatedText": "Dans ce cas, avec le test le plus précis, il est mis à jour entre 90 et 99, ce qui est un peu moins que les chances égales, soit un peu moins de 50 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 863.16,
-  "end": 871.58
- },
- {
-  "input": "To be more precise, you could make the conversion back to probability and work out that it's around 48%.",
-  "translatedText": "Pour être plus précis, vous pouvez revenir à la conversion en probabilité et déterminer qu'elle est d'environ 48 %.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 871.58,
-  "end": 877.56
- },
- {
-  "input": "But honestly, if you're just going for a gut feel, it's fine to stick with the odds.",
-  "translatedText": "Mais honnêtement, si vous vous contentez d’une intuition, c’est bien de s’en tenir aux probabilités.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 877.56,
-  "end": 881.4
- },
- {
-  "input": "Do you see what I mean about how just defining this number helps to combat potential misconceptions?",
-  "translatedText": "Voyez-vous ce que je veux dire sur la façon dont la simple définition de ce nombre aide à lutter contre d’éventuelles idées fausses?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 882.22,
-  "end": 887.44
- },
- {
-  "input": "For anybody who's a little hasty in connecting test accuracy directly to your probability of having a disease, it's worth emphasizing that you could administer the same test with the same accuracy to multiple different patients who all get the same exact result, but if they're coming from different contexts, that result can mean wildly different things.",
-  "translatedText": "Pour tous ceux qui s'empressent de relier directement l'exactitude du test à votre probabilité de contracter une maladie, il convient de souligner que vous pouvez administrer le même test avec la même précision à plusieurs patients différents qui obtiennent tous exactement le même résultat, mais s'ils sont venant de contextes différents, ce résultat peut signifier des choses très différentes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 888.24,
-  "end": 906.72
- },
- {
-  "input": "However, the one thing that does stay constant in every case is the factor by which each patient's prior odds get updated.",
-  "translatedText": "Cependant, la seule chose qui reste constante dans tous les cas est le facteur par lequel les probabilités antérieures de chaque patient sont mises à jour.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 906.72,
-  "end": 914.66
- },
- {
-  "input": "And by the way, this whole time we've been using the prevalence of the disease, which is the proportion of people in a population who have it, as a substitute for the prior, the probability of having it before you see a test.",
-  "translatedText": "Et d'ailleurs, pendant tout ce temps, nous avons utilisé la prévalence de la maladie, c'est-à-dire la proportion de personnes dans une population qui en sont atteintes, comme substitut à la probabilité antérieure, la probabilité d'en être atteinte avant de passer un test.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 916.3,
-  "end": 926.88
- },
- {
-  "input": "However, that's not necessarily the case.",
-  "translatedText": "Cependant, ce n'est pas nécessairement le cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 927.52,
-  "end": 929.46
- },
- {
-  "input": "If there are other known factors, things like symptoms, or in the case of a contagious disease, things like known contacts, those also factor into the prior, and they could potentially make a huge difference.",
-  "translatedText": "S'il existe d'autres facteurs connus, comme les symptômes, ou dans le cas d'une maladie contagieuse, des éléments comme les contacts connus, ceux-ci sont également pris en compte dans les antécédents et pourraient potentiellement faire une énorme différence.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 929.78,
-  "end": 939.86
- },
- {
-  "input": "As another side note, so far we've only talked about positive test results, but way more often you would be seeing a negative test result.",
-  "translatedText": "Par ailleurs, jusqu'à présent, nous n'avons parlé que de résultats de tests positifs, mais bien plus souvent, vous verriez un résultat de test négatif.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 940.76,
-  "end": 947.46
- },
- {
-  "input": "The logic there is completely the same, but the base factor that you compute is going to look different.",
-  "translatedText": "La logique est complètement la même, mais le facteur de base que vous calculez sera différent.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 948.1,
-  "end": 952.32
- },
- {
-  "input": "Instead, you look at the probability of seeing this negative test result with the disease versus without the disease.",
-  "translatedText": "Au lieu de cela, vous examinez la probabilité de voir ce résultat de test négatif avec la maladie ou sans la maladie.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 952.76,
-  "end": 958.64
- },
- {
-  "input": "So in our cancer example, this would have been the 10% false negative rate divided by the 91% specificity, or about 1 in 9.",
-  "translatedText": "Ainsi, dans notre exemple de cancer, cela aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 958.64,
-  "end": 967.04
- },
- {
-  "input": "In other words, seeing a negative test result in that example would reduce your prior odds by about an order of magnitude.",
-  "translatedText": "En d’autres termes, voir un résultat de test négatif dans cet exemple réduirait vos chances antérieures d’environ un ordre de grandeur.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 967.78,
-  "end": 974.46
- },
- {
-  "input": "When you write it all out as a formula, here's how it looks.",
-  "translatedText": "Lorsque vous écrivez le tout sous forme de formule, voici à quoi cela ressemble.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 975.9,
-  "end": 978.42
- },
- {
-  "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the base factor.",
-  "translatedText": "Il indique que vos chances d'avoir une maladie compte tenu du résultat d'un test sont égales à vos chances avant de passer le test, les chances antérieures, multipliées par le facteur de base.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 978.76,
-  "end": 986.96
- },
- {
-  "input": "Now let's contrast this with the usual way Bayes' rule is written, which is a bit more complicated.",
-  "translatedText": "Comparons maintenant cela avec la manière habituelle d'écrire la règle de Bayes, qui est un peu plus compliquée.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 986.96,
-  "end": 992.26
- },
- {
-  "input": "In case you haven't seen it before, it's essentially just what we were doing with sample populations, but you wrap it all up symbolically.",
-  "translatedText": "Au cas où vous ne l'auriez jamais vu auparavant, c'est essentiellement ce que nous faisions avec des échantillons de populations, mais vous résumez le tout symboliquement.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 993.06,
-  "end": 998.78
- },
- {
-  "input": "Remember how every time we were counting the number of true positives and then dividing it by the sum of the true positives and the false positives?",
-  "translatedText": "Rappelez-vous qu'à chaque fois, nous comptions le nombre de vrais positifs, puis le divisons par la somme des vrais positifs et des faux positifs?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 999.5,
-  "end": 1006.26
- },
- {
-  "input": "We do just that, except instead of talking about absolute amounts, we talk of each term as a proportion.",
-  "translatedText": "C’est exactement ce que nous faisons, sauf qu’au lieu de parler de montants absolus, nous parlons de chaque terme comme d’une proportion.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1006.8,
-  "end": 1012.26
- },
- {
-  "input": "So the proportion of true positives in the population comes from the prior probability of having the disease multiplied by the probability of seeing a positive test result in that case.",
-  "translatedText": "Ainsi, la proportion de vrais positifs dans la population provient de la probabilité préalable d’être atteint de la maladie multipliée par la probabilité de voir un résultat de test positif dans ce cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1012.26,
-  "end": 1022.26
- },
- {
-  "input": "Then we copy that term down again into the denominator, and then the proportion of false positives comes from the prior probability of not having the disease times the probability of a positive test in that case.",
-  "translatedText": "Ensuite, nous recopieons ce terme dans le dénominateur, puis la proportion de faux positifs provient de la probabilité préalable de ne pas avoir la maladie multipliée par la probabilité d'un test positif dans ce cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1023.0,
-  "end": 1034.1
- },
- {
-  "input": "If you want, you could also write this down with words instead of symbols, if terms like sensitivity and false positive rate are more comfortable.",
-  "translatedText": "Si vous le souhaitez, vous pouvez également écrire cela avec des mots au lieu de symboles, si des termes comme sensibilité et taux de faux positifs sont plus confortables.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1035.08,
-  "end": 1040.86
- },
- {
-  "input": "And this is one of those formulas where once you say it out loud it seems like a bit much, but it really is no different from what we were doing with sample populations.",
-  "translatedText": "Et c’est une de ces formules où, une fois prononcée à voix haute, cela semble un peu excessif, mais ce n’est vraiment pas différent de ce que nous faisions avec des échantillons de population.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1041.38,
-  "end": 1048.4
- },
- {
-  "input": "If you wanted to make the whole thing look simpler, you often see this entire denominator written just as the probability of seeing a positive test result, overall.",
-  "translatedText": "Si vous vouliez rendre le tout plus simple, vous voyez souvent ce dénominateur entier écrit comme la probabilité de voir un résultat de test positif, dans l'ensemble.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1049.22,
-  "end": 1057.0
- },
- {
-  "input": "While that does make for a really elegant little expression, if you intend to use this for calculations, it's a little disingenuous, because in practice, every single time you do this you need to break down that denominator into two separate parts, breaking down the cases.",
-  "translatedText": "Bien que cela constitue une petite expression vraiment élégante, si vous avez l'intention de l'utiliser pour des calculs, c'est un peu fallacieux, car en pratique, chaque fois que vous faites cela, vous devez décomposer ce dénominateur en deux parties distinctes, décomposant le cas.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1057.98,
-  "end": 1070.58
- },
- {
-  "input": "So taking this more honest representation of it, let's compare our two versions of Bayes' rule.",
-  "translatedText": "En prenant donc cette représentation plus honnête, comparons nos deux versions de la règle de Bayes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1071.7,
-  "end": 1076.02
- },
- {
-  "input": "And again, maybe it looks nicer if we use the words sensitivity and false positive rate.",
-  "translatedText": "Et encore une fois, cela semble peut-être plus joli si nous utilisons les mots sensibilité et taux de faux positifs.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1076.82,
-  "end": 1080.28
- },
- {
-  "input": "If nothing else, it helps emphasize which parts of the formula are coming from statistics about the test accuracy.",
-  "translatedText": "À tout le moins, cela permet de souligner quelles parties de la formule proviennent de statistiques sur la précision du test.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1080.66,
-  "end": 1085.64
- },
- {
-  "input": "I mean, this actually emphasizes one thing I really like about the framing with odds and a Bayes' factor, which is that it cleanly factors out the parts that have to do with the prior and the parts that have to do with the test accuracy.",
-  "translatedText": "Je veux dire, cela souligne en fait une chose que j'aime vraiment dans le cadrage avec les cotes et le facteur de Bayes, c'est-à-dire qu'il met clairement en évidence les parties qui ont à voir avec l'a priori et les parties qui ont à voir avec la précision du test.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1085.64,
-  "end": 1095.84
- },
- {
-  "input": "But over in the usual formula, all of those are very intermingled together.",
-  "translatedText": "Mais dans la formule habituelle, tous ces éléments sont très mélangés.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1096.66,
-  "end": 1100.2
- },
- {
-  "input": "And this has a very practical benefit.",
-  "translatedText": "Et cela présente un avantage très pratique.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1100.58,
-  "end": 1102.36
- },
- {
-  "input": "It's really nice if you want to swap out different priors and easily see their effects.",
-  "translatedText": "C'est vraiment bien si vous souhaitez échanger différents priorités et voir facilement leurs effets.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1102.48,
-  "end": 1106.26
- },
- {
-  "input": "This is what we were doing earlier.",
-  "translatedText": "C'est ce que nous faisions plus tôt.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1106.6,
-  "end": 1107.9
- },
- {
-  "input": "But with the other formula, to do that, you have to recompute everything each time.",
-  "translatedText": "Mais avec l’autre formule, pour faire ça, il faut tout recalculer à chaque fois.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1108.42,
-  "end": 1112.2
- },
- {
-  "input": "You can't leverage a precomputed Bayes' factor the same way.",
-  "translatedText": "Vous ne pouvez pas exploiter un facteur Bayes précalculé de la même manière.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1112.38,
-  "end": 1115.36
- },
- {
-  "input": "The odds framing also makes things really nice if you want to do multiple different Bayesian updates based on multiple pieces of evidence.",
-  "translatedText": "Le cadrage des cotes rend également les choses vraiment agréables si vous souhaitez effectuer plusieurs mises à jour bayésiennes différentes basées sur plusieurs éléments de preuve.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1115.96,
-  "end": 1122.12
- },
- {
-  "input": "For example, let's say you took not one test, but two.",
-  "translatedText": "Par exemple, disons que vous avez passé non pas un test, mais deux.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1122.74,
-  "end": 1124.86
- },
- {
-  "input": "Or you wanted to think about how the presence of symptoms plays into it.",
-  "translatedText": "Ou vous vouliez réfléchir à l’influence de la présence de symptômes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1125.36,
-  "end": 1128.54
- },
- {
-  "input": "For each piece of new evidence you see, you always ask the question, how much more likely would you be to see that with the disease versus without the disease?",
-  "translatedText": "Pour chaque nouvelle preuve que vous voyez, vous posez toujours la question : dans quelle mesure seriez-vous plus susceptible de voir cela avec la maladie ou sans la maladie?",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1129.12,
-  "end": 1136.62
- },
- {
-  "input": "Each answer to that question gives you a new Bayes' factor, a new thing that you multiply by your odds.",
-  "translatedText": "Chaque réponse à cette question vous donne un nouveau facteur de Bayes, une nouvelle chose que vous multipliez par vos chances.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1137.24,
-  "end": 1142.0
- },
- {
-  "input": "Beyond just making calculations easier, there's something I really like about attaching a number to test accuracy that doesn't even look like a probability.",
-  "translatedText": "Au-delà de simplement faciliter les calculs, il y a quelque chose que j'aime vraiment dans le fait d'attacher un nombre pour tester la précision qui ne ressemble même pas à une probabilité.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1142.88,
-  "end": 1149.92
- },
- {
-  "input": "I mean, if you hear that a test has, for example, a 9% false positive rate, that's just such a disastrously ambiguous phrase.",
-  "translatedText": "Je veux dire, si vous entendez dire qu’un test a, par exemple, un taux de faux positifs de 9 %, c’est une expression extrêmement ambiguë.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1150.74,
-  "end": 1157.34
- },
- {
-  "input": "It's so easy to misinterpret it to mean there's a 9% chance that your positive test result is false.",
-  "translatedText": "Il est si facile de mal interpréter cela, en voulant dire qu'il y a 9 % de chances que votre résultat positif soit faux.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1157.78,
-  "end": 1162.58
- },
- {
-  "input": "But imagine if instead the number that we heard tacked on to test results was that the Bayes' factor for a positive test result is, say, 10.",
-  "translatedText": "Mais imaginez si, au lieu de cela, le chiffre que nous avons entendu sur les résultats des tests était que le facteur Bayes pour un résultat de test positif était, disons, de 10.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1163.3,
-  "end": 1170.32
- },
- {
-  "input": "There's no room to confuse that for your probability of having a disease.",
-  "translatedText": "Il n’y a aucune possibilité de confondre cela avec votre probabilité d’être atteint d’une maladie.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1170.82,
-  "end": 1174.14
- },
- {
-  "input": "The entire framing of what a Bayes' factor is, is that it's something that acts on a prior.",
-  "translatedText": "L'ensemble de ce qu'est un facteur bayésien est que c'est quelque chose qui agit sur un a priori.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1174.64,
-  "end": 1179.04
- },
- {
-  "input": "It forces your hand to acknowledge the prior as something that's separate entirely, and highly necessary to drawing any conclusion.",
-  "translatedText": "Cela vous oblige à reconnaître le préalable comme quelque chose de entièrement distinct et hautement nécessaire pour tirer une conclusion.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1179.5,
-  "end": 1185.44
- },
- {
-  "input": "All that said, the usual formula is definitely not without its merits.",
-  "translatedText": "Cela dit, la formule habituelle n’est certainement pas sans mérite.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1187.26,
-  "end": 1190.74
- },
- {
-  "input": "If you view it not simply as something to plug numbers into, but as an encapsulation of the sample population idea that we've been using throughout, you could very easily argue that that's actually much better for your intuition.",
-  "translatedText": "Si vous ne le considérez pas simplement comme quelque chose auquel insérer des chiffres, mais comme une encapsulation de l'idée d'un échantillon de population que nous avons utilisée tout au long, vous pourriez très facilement affirmer que c'est en fait bien meilleur pour votre intuition.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1191.08,
-  "end": 1201.98
- },
- {
-  "input": "After all, it's what we were routinely falling back on in order to check ourselves that the Bayes' factor computation even made sense in the first place.",
-  "translatedText": "Après tout, c’est sur cela que nous nous appuyions régulièrement pour vérifier nous-mêmes que le calcul factoriel de Bayes avait du sens en premier lieu.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1202.56,
-  "end": 1209.18
- },
- {
-  "input": "Like any design decision, there is no clear-cut objective best here.",
-  "translatedText": "Comme toute décision de conception, il n’y a pas ici d’objectif clairement défini.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1211.6,
-  "end": 1215.38
- },
- {
-  "input": "But it's almost certainly the case that giving serious consideration to that question will lead you to a better understanding of Bayes' rule.",
-  "translatedText": "Mais il est presque certain que réfléchir sérieusement à cette question vous mènera à une meilleure compréhension de la règle de Bayes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1215.42,
-  "end": 1221.72
- },
- {
-  "input": "Also, since we're on the topic of kind of paradoxical things, a friend of mine, Matt Cook, recently wrote a book all about paradoxes.",
-  "translatedText": "De plus, puisque nous parlons de choses paradoxales, un de mes amis, Matt Cook, a récemment écrit un livre consacré aux paradoxes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1230.1,
-  "end": 1236.12
- },
- {
-  "input": "I actually contributed a small chapter to it with thoughts on the question of whether math is invented or discovered.",
-  "translatedText": "J'y ai en fait contribué dans un petit chapitre avec des réflexions sur la question de savoir si les mathématiques sont inventées ou découvertes.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1237.04,
-  "end": 1241.82
- },
- {
-  "input": "And the book as a whole is this really nice connection of thought-provoking paradoxical things ranging from philosophy to math and physics.",
-  "translatedText": "Et le livre dans son ensemble est cette connexion vraiment agréable de choses paradoxales qui suscitent la réflexion, allant de la philosophie aux mathématiques et à la physique.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1242.3,
-  "end": 1248.4
- },
- {
-  "input": "You can, of course, find all the details in the description. .",
-  "translatedText": "Vous pouvez bien entendu retrouver tous les détails dans la description.",
-  "model": "google_nmt",
-  "n_reviews": 0,
-  "start": 1248.82,
-  "end": 1251.04
- }
+  {
+    "input": "Some of you may have heard this paradoxical fact about medical tests.",
+    "translatedText": "Vous avez peut-être déjà entendu parler d’un paradoxe concernant les tests de dépistage.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 0,
+    "end": 3.14
+  },
+  {
+    "input": "It's very commonly used to introduce the topic of Bayes' rule in probability.",
+    "translatedText": "C'est un exemple couramment utilisé pour présenter le théorème de Bayes.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 3.58,
+    "end": 6.74
+  },
+  {
+    "input": "The paradox is that you could take a test which is highly accurate, in the sense that it gives correct results to a large majority of the people taking it.",
+    "translatedText": "Voici le paradoxe : il est possible qu’un test soit très précis, au sens où il fournit des résultats corrects pour la grande majorité des personnes testées.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 7.5,
+    "end": 15.66
+  },
+  {
+    "input": "And yet, under the right circumstances, when assessing the probability that your particular test result is correct, you can still land on a very low number, arbitrarily low, in fact.",
+    "translatedText": "Mais que, sous certaines conditions, le résultat de votre dépistage en particulier n’ait qu’une probabilité infime — voire arbitrairement faible — d’être correct.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 16.04,
+    "end": 26.3
+  },
+  {
+    "input": "In short, an accurate test is not necessarily a very predictive test.",
+    "translatedText": "En résumé, un test précis n’a pas forcément une grande valeur prédictive.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 26.78,
+    "end": 31.82
+  },
+  {
+    "input": "Now when people think about math and formulas, they don't often think of it as a design process.",
+    "translatedText": "Généralement, les gens ne voient pas vraiment les maths et les équations en tant que processus de conception.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 33.06,
+    "end": 37.44
+  },
+  {
+    "input": "I mean, maybe in the case of notation it's easy to see that different choices are possible, but when it comes to the structure of the formulas themselves and how we use them, that's something that people typically view as fixed.",
+    "translatedText": "Concernant les notations, on a évidemment le choix. Mais on pourrait avoir tendance à voir la structure des équations et la manière dont on les utilise comme quelque chose d’immuable.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 38.08,
+    "end": 49.68
+  },
+  {
+    "input": "In this video, you and I will dig into this paradox, but instead of using it to talk about the usual version of Bayes' rule, I'd like to motivate an alternate version, an alternate design choice.",
+    "translatedText": "Dans cette vidéo, nous allons expliciter ce paradoxe, mais au lieu de présenter le théorème de Bayes sous sa forme forme habituelle, j'aimerais en profiter pour proposer une formulation alternative, conçue différemment.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 50.68,
+    "end": 60.56
+  },
+  {
+    "input": "Now, what's up on the screen now is a little bit abstract, which makes it difficult to justify that there really is a substantive difference here, especially when I haven't explained either one yet.",
+    "translatedText": "Bon, pour l’instant, ce qui est à l'écran est un peu abstrait. Ce n’est pas évident de vous convaincre qu’il y a une différence notable, surtout que je n'ai expliqué aucune des formules.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 61.66,
+    "end": 70.54
+  },
+  {
+    "input": "To see what I'm talking about though, we should really start by spending some time a little more concretely, and just laying out what exactly this paradox is.",
+    "translatedText": "Pour bien comprendre de quoi je parle, prenons le temps de regarder concrètement en quoi consiste ce paradoxe.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 71.04,
+    "end": 78.1
+  },
+  {
+    "input": "Picture a thousand women and suppose that 1% of them have breast cancer.",
+    "translatedText": "Prenons 100 femmes, et supposons qu’1% d’entre elles aient un cancer du sein.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 84.02,
+    "end": 87.94
+  },
+  {
+    "input": "And let's say they all undergo a certain breast cancer screening, and that 9 of those with cancer correctly get positive results, and there's one false negative.",
+    "translatedText": "Imaginons qu’elles passent toutes un certain type de dépistage, et que pour les 10 femmes ayant un cancer, il y a 9 vrais positifs, et un faux négatif.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 88.68,
+    "end": 96.68
+  },
+  {
+    "input": "And then suppose that among the remainder without cancer, 89 get false positives, and 901 correctly get negative results.",
+    "translatedText": "Et supposons que pour les femmes restantes, 89 obtiennent des faux positifs et 901 obtiennent des vrais négatifs.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 97.48,
+    "end": 104.92
+  },
+  {
+    "input": "So if all you know about a woman is that she does the screening and she gets a positive result, you don't have information about symptoms or anything like that, you know that she's either one of these 9 true positives or one of these 89 false positives.",
+    "translatedText": "Donc, si une femme effectue ce dépistage et obtient un résultat positif, si vous n'avez aucune information complémentaire comme ses symptômes, vous savez qu'elle fait soit partie des 9 vrais positifs, soit des 89 faux positifs.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 105.72,
+    "end": 118.26
+  },
+  {
+    "input": "So the probability that she's in the cancer group given the test result is 9 divided by 9 plus 89, which is approximately 1 in 11.",
+    "translatedText": "La probabilité qu’elle fasse partie du groupe des personnes ayant un cancer, étant donné le résultat du test, est de 9 divisé par 9 plus 89, soit environ 1 sur 11.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 119.36,
+    "end": 128.14
+  },
+  {
+    "input": "In medical parlance, you would call this the positive predictive value of the test, or PPV, the number of true positives divided by the total number of positive test results.",
+    "translatedText": "Dans la terminologie médicale, on nomme ça la valeur prédictive positive du test (PPV en anglais), le nombre de vrais positifs divisé par le nombre total de résultats de test positifs.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 129.08,
+    "end": 138.62
+  },
+  {
+    "input": "You can see where the name comes from.",
+    "translatedText": "On comprend d'où vient le nom :",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 138.62,
+    "end": 140.44
+  },
+  {
+    "input": "To what extent does a positive test result actually predict that you have the disease?",
+    "translatedText": "Dans quelle mesure un résultat de test positif prédit-il réellement que vous souffrez de la maladie?",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 140.74,
+    "end": 145.36
+  },
+  {
+    "input": "Now, hopefully, as I've presented it this way where we're thinking concretely about a sample population, all of this makes perfect sense.",
+    "translatedText": "J'espère qu’en utilisant cet exemple concret d’un échantillon de 100 personnes, tout ça est parfaitement clair.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 146.82,
+    "end": 153.46
+  },
+  {
+    "input": "But where it comes across as counterintuitive is if you just look at the accuracy of the test, present it to people as a statistic, and then ask them to make judgments about their test result.",
+    "translatedText": "Mais ça devient contre-intuitif lorsque vous prenez la performance du test, que vous la présentez aux gens sous forme de statistique, et que vous leur demandez de se prononcer sur le résultat de leur test.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 153.96,
+    "end": 163.2
+  },
+  {
+    "input": "Test accuracy is not actually one number, but two.",
+    "translatedText": "La performance d’un test se mesure en fait avec deux chiffres.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 164.02,
+    "end": 166.26
+  },
+  {
+    "input": "First, you ask how often is the test correct on those with the disease.",
+    "translatedText": "D’abord, on veut savoir pour quelle proportion des personnes atteintes de la maladie le test est positif.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 166.26,
+    "end": 171.12
+  },
+  {
+    "input": "This is known as the test sensitivity, as in how sensitive is it to detecting the presence of the disease.",
+    "translatedText": "C’est ce qu’on appelle la sensibilité du test, c’est-à-dire : quelle est sa sensibilité pour détecter la présence de la maladie ?",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 171.7,
+    "end": 177.44
+  },
+  {
+    "input": "In our example, test sensitivity is 9 in 10, or 90%.",
+    "translatedText": "Dans notre exemple, la sensibilité du test est de 9 sur 10, soit 90 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 178.26,
+    "end": 181.26
+  },
+  {
+    "input": "And another way to say the same fact would be to say the false negative rate is 10%.",
+    "translatedText": "Et une autre façon de dire la même chose serait de dire que le taux de faux négatifs est de 10 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 182.02,
+    "end": 186.68
+  },
+  {
+    "input": "And then a separate, not necessarily related number is how often it's correct for those without the disease, which is known as the test specificity, as in are positive results caused specifically by the disease, or are there confounding triggers giving false positives.",
+    "translatedText": "Un autre chiffre, pas nécessairement lié, est la fréquence à laquelle le test est correct pour les personnes non atteintes de la maladie. C’est ce que l'on appelle la spécificité du test : les résultats positifs sont-ils causés spécifiquement par la maladie, ou y a-t-il des facteurs de confusion entraînant des faux positifs ?",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 186.68,
+    "end": 202.06
+  },
+  {
+    "input": "In our example, the specificity is about 91%.",
+    "translatedText": "Dans notre exemple, la spécificité est d'environ 91 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 203.08,
+    "end": 206.58
+  },
+  {
+    "input": "Or another way to say the same fact would be to say the false positive rate is 9%.",
+    "translatedText": "Ici, une autre manière de le dire est que le taux de faux positifs est de 9 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 206.58,
+    "end": 211.66
+  },
+  {
+    "input": "So the paradox here is that in one sense, the test is over 90% accurate.",
+    "translatedText": "Le paradoxe ici est donc que, dans un sens, le test est précis à plus de 90 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 211.66,
+    "end": 216.76
+  },
+  {
+    "input": "It gives correct results to over 90% of the patients who take it.",
+    "translatedText": "Il donne des résultats corrects à plus de 90 % des patients qui se font dépister.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 217.02,
+    "end": 220.66
+  },
+  {
+    "input": "And yet, if you learn that someone gets a positive result without any added information, there's actually only a 1 in 11 chance that that particular result is accurate.",
+    "translatedText": "Mais pourtant, si vous apprenez qu’une personne obtient un résultat positif sans détenir aucune information supplémentaire, il n’y a en réalité qu’une chance sur 11 pour que ce résultat particulier soit exact.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 220.66,
+    "end": 229.6
+  },
+  {
+    "input": "This is a bit of a problem, because of all of the places for math to be counterintuitive, medical tests are one area where it matters a lot.",
+    "translatedText": "C'est embêtant, car cela peut particulièrement impacter la lecture des résultats des dépistages.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 230.62,
+    "end": 237.18
+  },
+  {
+    "input": "In 2006 and 2007, the psychologist Gerd Gigerenzer gave a series of statistics seminars to practicing gynecologists, and he opened with the following example.",
+    "translatedText": "En 2006 et 2007, le psychologue Gerd Gigerenzer a donné une série de conférences de statistiques à des gynécologues en exercice, qu’il commençait par l'exemple suivant.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 237.94,
+    "end": 246.8
+  },
+  {
+    "input": "A 50-year-old woman, no symptoms, participates in a routine mammography screening.",
+    "translatedText": "Une femme de 50 ans, sans symptômes, participe à un dépistage de routine par mammographie.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 246.8,
+    "end": 251.74
+  },
+  {
+    "input": "She tests positive, is alarmed, and wants to know from you whether she has breast cancer for certain or what her chances are.",
+    "translatedText": "Son test est positif. Elle est inquiète et veut savoir s'il est est certain qu’elle a un cancer du sein, ou le risque que ce soit effectivement le cas.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 252.28,
+    "end": 258.38
+  },
+  {
+    "input": "Apart from the screening result, you know nothing else about this woman.",
+    "translatedText": "Hormis le résultat du dépistage, vous ne savez rien d’autre sur cette femme.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 258.88,
+    "end": 261.74
+  },
+  {
+    "input": "In that seminar, the doctors were then told that the prevalence of breast cancer for women of this age is about 1%, and then to suppose that the test sensitivity is 90% and that its specificity was 91%.",
+    "translatedText": "Les informations suivantes ont ensuite été données à l’audience : la prévalence du cancer du sein chez les femmes de cet âge est d'environ 1 %, et vous pouvez supposer que la sensibilité du test est de 90 % et que sa spécificité est de 91 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 262.58,
+    "end": 274.18
+  },
+  {
+    "input": "You might notice these are exactly the same numbers from the example that you and I just looked at.",
+    "translatedText": "Vous aurez peut-être remarqué que ce sont exactement les mêmes chiffres que précédemment.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 274.18,
+    "end": 278.18
+  },
+  {
+    "input": "This is where I got them.",
+    "translatedText": "C'est de là que je les tiens.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 278.36,
+    "end": 279.44
+  },
+  {
+    "input": "So, having already thought it through, you and I know the answer.",
+    "translatedText": "Vu qu’on y a déjà réfléchi, vous et moi on connaissons déjà la réponse.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 279.76,
+    "end": 282.6
+  },
+  {
+    "input": "It's about 1 in 11.",
+    "translatedText": "C'est environ 1 sur 11.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 282.88,
+    "end": 283.84
+  },
+  {
+    "input": "However, the doctors in this session were not primed with the suggestion to picture a concrete sample of a thousand individuals, the way that you and I had.",
+    "translatedText": "En revanche, les médecins présents lors de ces conférences n’ont pas eu la suggestion d’imaginer un échantillon concret comme nous l’avons fait.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 284.6,
+    "end": 291.54
+  },
+  {
+    "input": "All they saw were these numbers.",
+    "translatedText": "Tout ce qu’ils ont vu, c’était des chiffres.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 292.04,
+    "end": 293.34
+  },
+  {
+    "input": "They were then asked, how many women who test positive actually have breast cancer?",
+    "translatedText": "On leur a ensuite demandé combien de femmes dont le test était positif avaient réellement un cancer du sein ?",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 294.14,
+    "end": 298.42
+  },
+  {
+    "input": "What is the best answer?",
+    "translatedText": "Quelle est la meilleure réponse?",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 298.62,
+    "end": 299.74
+  },
+  {
+    "input": "And they were presented with these four choices.",
+    "translatedText": "Parmi ces quatre réponses.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 299.9,
+    "end": 301.68
+  },
+  {
+    "input": "In one of the sessions, over half the doctors present said that the correct answer was 9 in 10, which is way off.",
+    "translatedText": "Au cours d'une des conférences, plus de la moitié des médecins pensaient que la réponse était 9 sur 10, ce qui est très loin de la bonne réponse.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 301.68,
+    "end": 309.3
+  },
+  {
+    "input": "Only a fifth of them gave the correct answer, which is worse than what it would have been if everybody had randomly guessed.",
+    "translatedText": "Seul un cinquième d’entre eux ont donné la bonne réponse, ce qui est pire que si tout le monde avait voté au hasard.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 310.02,
+    "end": 315.38
+  },
+  {
+    "input": "It might seem a little extreme to be calling this a paradox.",
+    "translatedText": "Ça peut sembler un peu extrême d’appeler ça un paradoxe.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 316.66,
+    "end": 319.28
+  },
+  {
+    "input": "I mean, it's just a fact.",
+    "translatedText": "En réalité, c'est juste un fait.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 319.76,
+    "end": 321.14
+  },
+  {
+    "input": "It's not something intrinsically self-contradictory.",
+    "translatedText": "Ce n’est pas intrinsèquement contradictoire.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 321.26,
+    "end": 323.5
+  },
+  {
+    "input": "But, as these seminars with Gigerenzer show, people, including doctors, definitely find it counterintuitive that a test with high accuracy can give you such a low predictive value.",
+    "translatedText": "Mais comme le montrent ces conférences de Gigerenzer, les gens, y compris les médecins, trouvent clairement contre-intuitif qu’un test d’une grande performance puisse donner une valeur prédictive aussi faible.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 324.2,
+    "end": 334.24
+  },
+  {
+    "input": "We might call this a veridical paradox, which refers to facts that are provably true, but which nevertheless can feel false when phrased a certain way.",
+    "translatedText": "Nous pourrions appeler cela un paradoxe véridique, qui fait référence à des faits dont la vérité est prouvée, mais qui peuvent néanmoins sembler faux lorsqu’ils sont formulés d’une certaine manière.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 335.2,
+    "end": 343.8
+  },
+  {
+    "input": "It's sort of the softest form of a paradox, saying more about human psychology than about logic.",
+    "translatedText": "C’est un peu comme une version attenué d’un paradoxe, qui en dit plus sur la psychologie humaine que sur la logique.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 344.3,
+    "end": 348.72
+  },
+  {
+    "input": "The question is how we can combat this.",
+    "translatedText": "La question est de savoir comment lutter contre ça.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 349.58,
+    "end": 351.98
+  },
+  {
+    "input": "Where we're going with this, by the way, is that I want you to be able to look at numbers like this and quickly estimate in your head that it means the predictive value of a positive test should be around 1 in 11.",
+    "translatedText": "Dans l’idée, j’aimerais que vous puissiez regarder ce genre de chiffres et rapidement estimer de tête que la valeur prédictive associée pour un test positif est d'à-peu-près 1 sur 11.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 353.8,
+    "end": 364.14
+  },
+  {
+    "input": "Or, if I changed things and asked, what if it was 10% of the population who had breast cancer?",
+    "translatedText": "Et si je modifie les valeurs, et vous demande ce qu’il en serait si la prévalence du cancer du sein était de 10%",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 364.76,
+    "end": 369.72
+  },
+  {
+    "input": "You should be able to quickly turn around and say that the final answer would be a little over 50%.",
+    "translatedText": "Vous devriez pouvoir rapidement adapter votre réponse et me dire que la valeur prédictive serait d'un peu plus que 50 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 370.12,
+    "end": 374.98
+  },
+  {
+    "input": "Or, if I said imagine a really low prevalence, something like 0.1% of patients having cancer, you should again quickly estimate that the predictive value of the test is around 1 in 100,",
+    "translatedText": "Ou, disons que je vous donne une prévalence très faible, comme 0.1% de patients atteints de cancer, vous devriez là encore pouvoir estimer rapidement que la valeur prédictive du test est d'environ 1 sur 100.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 375.92,
+    "end": 386.14
+  },
+  {
+    "input": "that 1 in 100 of those with positive test results in that case would have cancer.",
+    "translatedText": "c’est-à-dire qu’une personne sur 100 avec des résultats positifs aurait un cancer.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 386.76,
+    "end": 390.6
+  },
+  {
+    "input": "Or, let's say we go back to the 1% prevalence, but I make the test more accurate.",
+    "translatedText": "Ou, en revenant à une prévalence de 1 %, mais en rendant le test plus précis.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 391.58,
+    "end": 395.24
+  },
+  {
+    "input": "I tell you to imagine the specificity is 99%.",
+    "translatedText": "Imaginons que la spécificité soit de 99 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 395.44,
+    "end": 398.4
+  },
+  {
+    "input": "There, you should be able to relatively quickly estimate that the answer is a little less than 50%.",
+    "translatedText": "Là, vous devriez pouvoir estimer assez rapidement que la réponse est un peu inférieure à 50 %.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 398.4,
+    "end": 403.8
+  },
+  {
+    "input": "The hope is that you're doing all of this with minimal calculations in your head.",
+    "translatedText": "Le but est que vous puissiez faire tout ça avec un minimum de calculs dans votre tête.",
+    "model": "google_nmt",
+    "n_reviews": 1,
+    "start": 404.32,
+    "end": 407.74
+  },
+  {
+    "input": "Now, the goals of quick calculations might feel very different from the goals of addressing whatever misconception underlies this paradox, but they actually go hand in hand.",
+    "translatedText": "Les objectifs des calculs rapides peuvent sembler très différents de ceux visant à répondre aux idées fausses qui sous-tendent ce paradoxe, mais ils vont en réalité de pair.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 408.54,
+    "end": 416.5
+  },
+  {
+    "input": "Let me show you what I mean.",
+    "translatedText": "Laissez-moi vous montrer ce que je veux dire.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 416.9,
+    "end": 417.68
+  },
+  {
+    "input": "On the side of addressing misconceptions, what would you tell to the people in that seminar who answered 9 and 10?",
+    "translatedText": "En ce qui concerne la lutte contre les idées fausses, que diriez-vous aux personnes participant à ce séminaire qui ont répondu aux questions 9 et 10?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 418.46,
+    "end": 423.98
+  },
+  {
+    "input": "What fundamental misconception are they revealing?",
+    "translatedText": "Quelle idée fausse fondamentale révèlent-ils?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 424.48,
+    "end": 426.9
+  },
+  {
+    "input": "What I might tell them is that in much the same way that you shouldn't think of tests as telling you deterministically whether you have a disease, you shouldn't even think of them as telling you your chances of having a disease.",
+    "translatedText": "Ce que je pourrais leur dire, c'est que de la même manière que vous ne devriez pas considérer les tests comme vous indiquant de manière déterministe si vous avez une maladie, vous ne devriez même pas les considérer comme vous indiquant vos chances d'avoir une maladie.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 428.18,
+    "end": 438.6
+  },
+  {
+    "input": "Instead, the healthy view of what tests do is that they update your chances.",
+    "translatedText": "Au lieu de cela, la vision saine de ce que font les tests est qu’ils mettent à jour vos chances.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 439.56,
+    "end": 444.46
+  },
+  {
+    "input": "In our example, before taking the test, a patient's chances of having cancer were 1 in 100.",
+    "translatedText": "Dans notre exemple, avant de passer le test, le risque d’avoir un cancer était de 1 sur 100.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 446.04,
+    "end": 450.68
+  },
+  {
+    "input": "In Bayesian terms, we call this the prior probability.",
+    "translatedText": "En termes bayésiens, nous appelons cela la probabilité a priori.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 451.12,
+    "end": 453.64
+  },
+  {
+    "input": "The effect of this test was to update that prior by almost an order of magnitude, up to around 1 in 11.",
+    "translatedText": "L’effet de ce test a été de mettre à jour le précédent de près d’un ordre de grandeur, jusqu’à environ 1 sur 11.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 454.38,
+    "end": 460.36
+  },
+  {
+    "input": "The accuracy of a test is telling us about the strength of this updating.",
+    "translatedText": "La précision d’un test nous renseigne sur la force de cette mise à jour.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 461.02,
+    "end": 464.82
+  },
+  {
+    "input": "It's not telling us a final answer.",
+    "translatedText": "Cela ne nous donne pas de réponse définitive.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 465.12,
+    "end": 466.74
+  },
+  {
+    "input": "What does this have to do with quick approximations?",
+    "translatedText": "Qu’est-ce que cela a à voir avec des approximations rapides?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 467.9,
+    "end": 469.64
+  },
+  {
+    "input": "Well, a key number for those approximations is something called the Bayes factor, and the very act of defining this number serves to reinforce this central lesson about reframing what it is the tests do.",
+    "translatedText": "Eh bien, un nombre clé pour ces approximations est ce qu’on appelle le facteur Bayes, et le fait même de définir ce nombre sert à renforcer cette leçon centrale sur le recadrage de ce que font les tests.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 470.3,
+    "end": 481.4
+  },
+  {
+    "input": "You see, one of the things that makes test statistics so very confusing is that there are at least 4 numbers that you'll hear associated with them.",
+    "translatedText": "Vous voyez, l'une des choses qui rendent les statistiques de test si confuses est qu'il y a au moins 4 nombres que vous entendrez associés à celles-ci.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 482.42,
+    "end": 488.9
+  },
+  {
+    "input": "For those with the disease, there's the sensitivity and the false negative rate, and then for those without, there's the specificity and the false positive rate, and none of these numbers actually tell you the thing you want to know.",
+    "translatedText": "Pour ceux qui sont atteints de la maladie, il y a la sensibilité et le taux de faux négatifs, et pour ceux qui ne le sont pas, il y a la spécificité et le taux de faux positifs, et aucun de ces chiffres ne vous dit réellement ce que vous voulez savoir.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 488.9,
+    "end": 498.8
+  },
+  {
+    "input": "Luckily, if you want to interpret a positive test result, you can pull out just one number to focus on from all this.",
+    "translatedText": "Heureusement, si vous souhaitez interpréter un résultat de test positif, vous pouvez tirer un seul chiffre sur lequel vous concentrer.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 499.5,
+    "end": 505.62
+  },
+  {
+    "input": "Take the sensitivity divided by the false positive rate.",
+    "translatedText": "Prenez la sensibilité divisée par le taux de faux positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 506.04,
+    "end": 508.6
+  },
+  {
+    "input": "In other words, how much more likely are you to see the positive test result with cancer versus without?",
+    "translatedText": "En d’autres termes, dans quelle mesure avez-vous plus de chances de voir un résultat de test positif avec un cancer plutôt qu’avec un cancer?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 509.16,
+    "end": 514.74
+  },
+  {
+    "input": "In our example, this number is 10.",
+    "translatedText": "Dans notre exemple, ce nombre est 10.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 514.74,
+    "end": 517.14
+  },
+  {
+    "input": "This is the Bayes factor, also sometimes called the likelihood ratio.",
+    "translatedText": "Il s’agit du facteur Bayes, aussi parfois appelé rapport de vraisemblance.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 517.9,
+    "end": 521.72
+  },
+  {
+    "input": "A very handy rule of thumb is that to update a small prior, or at least to approximate the answer, you simply multiply it by the Bayes factor.",
+    "translatedText": "Une règle empirique très pratique est que pour mettre à jour un petit a priori, ou au moins pour approximer la réponse, il vous suffit de le multiplier par le facteur Bayes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 523.1,
+    "end": 530.02
+  },
+  {
+    "input": "So in our example, where the prior was 1 in 100, you would estimate that the final answer should be around 1 in 10, which is in fact slightly above the true correct answer.",
+    "translatedText": "Ainsi, dans notre exemple, où la réponse a priori était de 1 sur 100, vous estimeriez que la réponse finale devrait être d'environ 1 sur 10, ce qui est en fait légèrement supérieur à la vraie bonne réponse.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 530.76,
+    "end": 538.82
+  },
+  {
+    "input": "So based on this rule of thumb, if I asked you what would happen if the prior from our example was instead 1 in 1000, you could quickly estimate that the effect of the test should be to update those chances to around 1 in 100.",
+    "translatedText": "Donc, sur la base de cette règle empirique, si je vous demandais ce qui se passerait si le facteur a priori de notre exemple était plutôt de 1 sur 1000, vous pourriez rapidement estimer que l'effet du test devrait être de mettre à jour ces chances à environ 1 sur 100.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 539.4,
+    "end": 551.42
+  },
+  {
+    "input": "And in fact, take a moment to check yourself by thinking through a sample population.",
+    "translatedText": "Et en fait, prenez un moment pour vous vérifier en réfléchissant à un échantillon de population.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 552.36,
+    "end": 555.72
+  },
+  {
+    "input": "In this case, you might picture 10,000 patients where only 10 of them really have cancer.",
+    "translatedText": "Dans ce cas, vous pourriez imaginer 10 000 patients dont seulement 10 d’entre eux sont réellement atteints d’un cancer.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 556.7,
+    "end": 560.88
+  },
+  {
+    "input": "And then based on that 90% sensitivity, we would expect 9 of those cancer cases to give true positives.",
+    "translatedText": "Et puis, sur la base de cette sensibilité de 90 %, nous nous attendrions à ce que 9 de ces cas de cancer donnent de vrais positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 562.14,
+    "end": 567.9
+  },
+  {
+    "input": "And on the other side, a 91% specificity means that 9% of those without cancer are getting false positives.",
+    "translatedText": "Et d’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des faux positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 569,
+    "end": 575.76
+  },
+  {
+    "input": "So we'd expect 9% of the remaining patients, which is around 900, to give false positive results.",
+    "translatedText": "Nous nous attendons donc à ce que 9 % des patients restants, soit environ 900, donnent des résultats faussement positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 576.66,
+    "end": 581.86
+  },
+  {
+    "input": "Here, with such a low prevalence, the false positives really do dominate the true positives.",
+    "translatedText": "Ici, avec une prévalence aussi faible, les faux positifs dominent réellement les vrais positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 582.7,
+    "end": 587.82
+  },
+  {
+    "input": "So the probability that a randomly chosen positive case from this population actually has cancer is only around 1%, just like the rule of thumb predicted.",
+    "translatedText": "Ainsi, la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédit la règle empirique.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 587.9,
+    "end": 597.02
+  },
+  {
+    "input": "Now, this rule of thumb clearly cannot work for higher priors.",
+    "translatedText": "Or, cette règle empirique ne peut clairement pas fonctionner pour des priorités plus élevées.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 598.7,
+    "end": 601.92
+  },
+  {
+    "input": "For example, it would predict that a prior of 10% gets updated all the way to 100% certainty.",
+    "translatedText": "Par exemple, il prédirait qu'un a priori de 10 % est mis à jour jusqu'à une certitude de 100 %.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 602.42,
+    "end": 607.86
+  },
+  {
+    "input": "But that can't be right.",
+    "translatedText": "Mais cela ne peut pas être vrai.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 608.36,
+    "end": 609.32
+  },
+  {
+    "input": "In fact, take a moment to think through what the answer should be, again, using a sample population.",
+    "translatedText": "En fait, prenez un moment pour réfléchir à la réponse, toujours en utilisant un échantillon de population.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 610.02,
+    "end": 614.5
+  },
+  {
+    "input": "Maybe this time we picture 10 out of 100 having cancer.",
+    "translatedText": "Peut-être que cette fois, nous imaginons que 10 personnes sur 100 auront un cancer.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 615.06,
+    "end": 617.86
+  },
+  {
+    "input": "Again, based on the 90% sensitivity of the test, we'd expect 9 of those true cancer cases to get positive results.",
+    "translatedText": "Encore une fois, sur la base de la sensibilité de 90 % du test, nous nous attendons à ce que 9 de ces véritables cas de cancer obtiennent des résultats positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 618.54,
+    "end": 624.92
+  },
+  {
+    "input": "But what about the false positives?",
+    "translatedText": "Mais qu’en est-il des faux positifs?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 624.92,
+    "end": 626.6
+  },
+  {
+    "input": "How many do we expect there?",
+    "translatedText": "Combien en attend-on là-bas?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 626.98,
+    "end": 628.1
+  },
+  {
+    "input": "About 9% of the remaining 90. About 8.",
+    "translatedText": "Environ 9% des 90 restants, soit environ 8.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 629.88,
+    "end": 632.62
+  },
+  {
+    "input": "So, upon seeing a positive test result, it tells you that you're either one of these 9 true positives or one of the 8 false positives.",
+    "translatedText": "Ainsi, lorsque vous voyez un résultat de test positif, cela vous indique que vous êtes soit l'un de ces 9 vrais positifs, soit l'un des 8 faux positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 633.82,
+    "end": 641.14
+  },
+  {
+    "input": "So this means the chances are a little over 50%, roughly 9 out of 17, or 53%.",
+    "translatedText": "Cela signifie donc que les chances sont d'un peu plus de 50 %, soit environ 9 sur 17, soit 53 %.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 641.86,
+    "end": 646.92
+  },
+  {
+    "input": "At this point, having dared to dream that Bayesian updating could look as simple as multiplication, you might tear down your hopes and pragmatically acknowledge that sometimes life is just more complicated than that.",
+    "translatedText": "À ce stade, après avoir osé rêver que la mise à jour bayésienne puisse paraître aussi simple que la multiplication, vous pourriez détruire vos espoirs et reconnaître de manière pragmatique que parfois la vie est simplement plus compliquée que cela.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 648.02,
+    "end": 657.7
+  },
+  {
+    "input": "Except it's not.",
+    "translatedText": "Sauf que ce n'est pas le cas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 659.92,
+    "end": 661.12
+  },
+  {
+    "input": "This rule of thumb turns into a precise mathematical fact as long as we shift away from talking about probabilities to instead talking about odds.",
+    "translatedText": "Cette règle empirique se transforme en un fait mathématique précis, à condition que l’on cesse de parler de probabilités pour parler de probabilités.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 661.62,
+    "end": 669
+  },
+  {
+    "input": "If you've ever heard someone talk about the chances of an event being 1 to 1 or 2 to 1, things like that, you already know about odds.",
+    "translatedText": "Si vous avez déjà entendu quelqu'un parler des chances qu'un événement soit de 1 contre 1 ou de 2 contre 1, des choses comme ça, vous connaissez déjà les probabilités.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 670.32,
+    "end": 677.06
+  },
+  {
+    "input": "With probability, we're taking the ratio of the number of positive cases out of all possible cases, right?",
+    "translatedText": "Avec probabilité, on prend le ratio du nombre de cas positifs sur tous les cas possibles, n'est-ce pas?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 677.06,
+    "end": 683.06
+  },
+  {
+    "input": "Things like 1 in 5 or 1 in 10.",
+    "translatedText": "Des choses comme 1 sur 5 ou 1 sur 10.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 683.4,
+    "end": 685.28
+  },
+  {
+    "input": "With odds, what you do is take the ratio of all positive cases to all negative cases.",
+    "translatedText": "Avec les probabilités, vous faites le rapport entre tous les cas positifs et tous les cas négatifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 685.88,
+    "end": 690.32
+  },
+  {
+    "input": "You commonly see odds written with a colon to emphasize the distinction, but it's still just a fraction, just a number.",
+    "translatedText": "Vous voyez généralement les cotes écrites avec deux points pour souligner la distinction, mais ce n'est toujours qu'une fraction, juste un nombre.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 691.54,
+    "end": 697.06
+  },
+  {
+    "input": "So an event with a 50% probability would be described as having 1 to 1 odds. A 10% probability is the same as 1 to 9 odds. An 80% probability is the same as 4 to 1 odds. You get the point.",
+    "translatedText": "Ainsi, un événement avec une probabilité de 50 % serait décrit comme ayant une cote de 1 contre 1, une probabilité de 10 % équivaut à une cote de 1 sur 9, une probabilité de 80 % équivaut à une cote de 4 contre 1, vous obtenez le point.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 697.94,
+    "end": 710.46
+  },
+  {
+    "input": "It's the same information. It still describes the chances of a random event, but it's presented a little differently, like a different unit system.",
+    "translatedText": "C'est la même information, elle décrit toujours les chances d'un événement aléatoire, mais elle est présentée un peu différemment, comme un système d'unités différent.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 711.48,
+    "end": 718.34
+  },
+  {
+    "input": "Probabilities are constrained between 0 and 1, with even chances sitting at 0.5.",
+    "translatedText": "Les probabilités sont contraintes entre 0 et 1, les chances paires étant égales à 0.5.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 719.32,
+    "end": 723.68
+  },
+  {
+    "input": "But odds range from 0 up to infinity, with even chances sitting at the number 1.",
+    "translatedText": "Mais les cotes vont de 0 à l’infini, les chances paires se situant au numéro 1.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 724.8,
+    "end": 729.54
+  },
+  {
+    "input": "The beauty here is that a completely accurate, not even approximating things way to frame Bayes' rule is to say, express your prior using odds, and then just multiply by the Bayes' factor.",
+    "translatedText": "La beauté ici est qu'une façon tout à fait précise, même pas approximative, de cadrer la règle de Bayes est de dire, d'exprimer votre a priori en utilisant les cotes, puis de simplement multiplier par le facteur de Bayes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 731.88,
+    "end": 742.36
+  },
+  {
+    "input": "Think about what the prior odds are really saying.",
+    "translatedText": "Pensez à ce que disent réellement les cotes antérieures.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 743.44,
+    "end": 745.22
+  },
+  {
+    "input": "It's the number of people with cancer divided by the number without it.",
+    "translatedText": "C'est le nombre de personnes atteintes de cancer divisé par le nombre de personnes qui n'en souffrent pas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 745.58,
+    "end": 749.26
+  },
+  {
+    "input": "Here, let's just write that down as a normal fraction for a moment so we can multiply it.",
+    "translatedText": "Ici, écrivons cela sous forme de fraction normale pendant un instant afin de pouvoir la multiplier.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 749.7,
+    "end": 753.36
+  },
+  {
+    "input": "When you filter down just to those with positive test results, the number of people with cancer gets scaled down, scaled down by the probability of seeing a positive test result given that someone has cancer.",
+    "translatedText": "Lorsque vous filtrez uniquement celles dont les résultats de test sont positifs, le nombre de personnes atteintes de cancer est réduit, réduit par la probabilité de voir un résultat de test positif étant donné que quelqu'un a un cancer.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 753.36,
+    "end": 764.42
+  },
+  {
+    "input": "And then similarly, the number of people without cancer also gets scaled down, this time by the probability of seeing a positive test result, but in that case.",
+    "translatedText": "Et de la même manière, le nombre de personnes sans cancer est également réduit, cette fois en fonction de la probabilité de voir un résultat de test positif, mais dans ce cas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 765.12,
+    "end": 773.44
+  },
+  {
+    "input": "So the ratio between these two counts, the new odds upon seeing the test, looks just like the prior odds except multiplied by this term here, which is exactly the Bayes' factor.",
+    "translatedText": "Ainsi, le rapport entre ces deux comptes, la nouvelle cote à la vue du test, ressemble exactement à la cote précédente, sauf qu'il est multiplié par ce terme ici, ce qui est exactement le facteur de Bayes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 774.18,
+    "end": 784.76
+  },
+  {
+    "input": "Look back at our example, where the Bayes' factor was 10.",
+    "translatedText": "Revenons à notre exemple, où le facteur de Bayes était de 10.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 787.8,
+    "end": 790.5
+  },
+  {
+    "input": "And as a reminder, this came from the 90% sensitivity divided by the 9% false positive rate.",
+    "translatedText": "Et pour rappel, cela provenait de la sensibilité de 90 % divisée par le taux de faux positifs de 9 %.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 791,
+    "end": 796.56
+  },
+  {
+    "input": "How much more likely are you to see a positive result with cancer versus without?",
+    "translatedText": "Dans quelle mesure avez-vous plus de chances de voir un résultat positif avec un cancer plutôt que sans?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 796.88,
+    "end": 800.74
+  },
+  {
+    "input": "If the prior is 1%, expressed as odds, this looks like 1 to 99.",
+    "translatedText": "Si l'a priori est de 1 %, exprimé en probabilité, cela ressemble à 1 : 99.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 801.72,
+    "end": 805.94
+  },
+  {
+    "input": "So by our rule, this gets updated to 10 to 99, which if you want you could convert back to a probability.",
+    "translatedText": "Donc, selon notre règle, cela est mis à jour entre 10 et 99, ce qui, si vous le souhaitez, peut être reconverti en probabilité.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 806.9,
+    "end": 813.4
+  },
+  {
+    "input": "It would be 10 divided by 10 plus 99, or about 1 in 11.",
+    "translatedText": "Ce serait 10 divisé par 10 plus 99, soit environ 1 sur 11.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 813.66,
+    "end": 817.22
+  },
+  {
+    "input": "If instead, the prior was 10%, which was the example that tripped up our rule of thumb earlier, expressed as odds, this looks like 1 to 9.",
+    "translatedText": "Si, à la place, l'a priori était de 10 %, ce qui était l'exemple qui a fait trébucher notre règle empirique plus tôt, exprimée en cotes, cela ressemble à 1 : 9.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 818.2,
+    "end": 826.26
+  },
+  {
+    "input": "By our simple rule, this gets updated to 10 to 9, which you can already read off pretty intuitively.",
+    "translatedText": "Selon notre règle simple, cela est mis à jour de 10 à 9, que vous pouvez déjà lire de manière assez intuitive.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 826.94,
+    "end": 832.44
+  },
+  {
+    "input": "It's a little above even chances, a little above 1 to 1.",
+    "translatedText": "C'est un peu au-dessus des chances égales, un peu au-dessus de 1 pour 1.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 832.44,
+    "end": 835.66
+  },
+  {
+    "input": "If you prefer, you can convert it back to a probability.",
+    "translatedText": "Si vous préférez, vous pouvez la reconvertir en probabilité.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 836.34,
+    "end": 838.84
+  },
+  {
+    "input": "You would write it as 10 out of 19, or about 53%.",
+    "translatedText": "Vous l'écririez comme 10 sur 19, soit environ 53 %.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 839.18,
+    "end": 843.28
+  },
+  {
+    "input": "And indeed, that is what we already found by thinking things through with a sample population.",
+    "translatedText": "Et c’est d’ailleurs ce que nous avons déjà constaté en réfléchissant sur un échantillon de population.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 843.28,
+    "end": 847.22
+  },
+  {
+    "input": "Let's say we go back to the 1% prevalence, but I make the test more accurate.",
+    "translatedText": "Disons que l'on revient à la prévalence de 1 %, mais je rends le test plus précis.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 848.3,
+    "end": 851.7
+  },
+  {
+    "input": "Now what if I told you to imagine that the false positive rate was only 1% instead of 9%?",
+    "translatedText": "Et si je vous disais d’imaginer que le taux de faux positifs n’était que de 1 % au lieu de 9 %?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 852.06,
+    "end": 856.64
+  },
+  {
+    "input": "What that would mean is that our Bayes factor is 90 instead of 10.",
+    "translatedText": "Cela signifierait que notre facteur Bayesien est de 90 au lieu de 10.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 857.12,
+    "end": 860.52
+  },
+  {
+    "input": "The test is doing more work for us.",
+    "translatedText": "Le test fait plus de travail pour nous.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 860.84,
+    "end": 862.46
+  },
+  {
+    "input": "In this case, with the more accurate test, it gets updated to 90 to 99, which is a little less than even chances, something a little under 50%.",
+    "translatedText": "Dans ce cas, avec le test le plus précis, il est mis à jour entre 90 et 99, ce qui est un peu moins que les chances égales, soit un peu moins de 50 %.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 863.16,
+    "end": 871.58
+  },
+  {
+    "input": "To be more precise, you could make the conversion back to probability and work out that it's around 48%.",
+    "translatedText": "Pour être plus précis, vous pouvez revenir à la conversion en probabilité et déterminer qu'elle est d'environ 48 %.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 871.58,
+    "end": 877.56
+  },
+  {
+    "input": "But honestly, if you're just going for a gut feel, it's fine to stick with the odds.",
+    "translatedText": "Mais honnêtement, si vous vous contentez d’une intuition, c’est bien de s’en tenir aux probabilités.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 877.56,
+    "end": 881.4
+  },
+  {
+    "input": "Do you see what I mean about how just defining this number helps to combat potential misconceptions?",
+    "translatedText": "Voyez-vous ce que je veux dire sur la façon dont la simple définition de ce nombre aide à lutter contre d’éventuelles idées fausses?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 882.22,
+    "end": 887.44
+  },
+  {
+    "input": "For anybody who's a little hasty in connecting test accuracy directly to your probability of having a disease, it's worth emphasizing that you could administer the same test with the same accuracy to multiple different patients who all get the same exact result, but if they're coming from different contexts, that result can mean wildly different things.",
+    "translatedText": "Pour tous ceux qui s'empressent de relier directement l'exactitude du test à votre probabilité de contracter une maladie, il convient de souligner que vous pouvez administrer le même test avec la même précision à plusieurs patients différents qui obtiennent tous exactement le même résultat, mais s'ils sont venant de contextes différents, ce résultat peut signifier des choses très différentes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 888.24,
+    "end": 906.72
+  },
+  {
+    "input": "However, the one thing that does stay constant in every case is the factor by which each patient's prior odds get updated.",
+    "translatedText": "Cependant, la seule chose qui reste constante dans tous les cas est le facteur par lequel les probabilités antérieures de chaque patient sont mises à jour.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 906.72,
+    "end": 914.66
+  },
+  {
+    "input": "And by the way, this whole time we've been using the prevalence of the disease, which is the proportion of people in a population who have it, as a substitute for the prior, the probability of having it before you see a test.",
+    "translatedText": "Et d'ailleurs, pendant tout ce temps, nous avons utilisé la prévalence de la maladie, c'est-à-dire la proportion de personnes dans une population qui en sont atteintes, comme substitut à la probabilité antérieure, la probabilité d'en être atteinte avant de passer un test.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 916.3,
+    "end": 926.88
+  },
+  {
+    "input": "However, that's not necessarily the case.",
+    "translatedText": "Cependant, ce n'est pas nécessairement le cas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 927.52,
+    "end": 929.46
+  },
+  {
+    "input": "If there are other known factors, things like symptoms, or in the case of a contagious disease, things like known contacts, those also factor into the prior, and they could potentially make a huge difference.",
+    "translatedText": "S'il existe d'autres facteurs connus, comme les symptômes, ou dans le cas d'une maladie contagieuse, des éléments comme les contacts connus, ceux-ci sont également pris en compte dans les antécédents et pourraient potentiellement faire une énorme différence.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 929.78,
+    "end": 939.86
+  },
+  {
+    "input": "As another side note, so far we've only talked about positive test results, but way more often you would be seeing a negative test result.",
+    "translatedText": "Par ailleurs, jusqu'à présent, nous n'avons parlé que de résultats de tests positifs, mais bien plus souvent, vous verriez un résultat de test négatif.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 940.76,
+    "end": 947.46
+  },
+  {
+    "input": "The logic there is completely the same, but the base factor that you compute is going to look different.",
+    "translatedText": "La logique est complètement la même, mais le facteur de base que vous calculez sera différent.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 948.1,
+    "end": 952.32
+  },
+  {
+    "input": "Instead, you look at the probability of seeing this negative test result with the disease versus without the disease.",
+    "translatedText": "Au lieu de cela, vous examinez la probabilité de voir ce résultat de test négatif avec la maladie ou sans la maladie.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 952.76,
+    "end": 958.64
+  },
+  {
+    "input": "So in our cancer example, this would have been the 10% false negative rate divided by the 91% specificity, or about 1 in 9.",
+    "translatedText": "Ainsi, dans notre exemple de cancer, cela aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 958.64,
+    "end": 967.04
+  },
+  {
+    "input": "In other words, seeing a negative test result in that example would reduce your prior odds by about an order of magnitude.",
+    "translatedText": "En d’autres termes, voir un résultat de test négatif dans cet exemple réduirait vos chances antérieures d’environ un ordre de grandeur.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 967.78,
+    "end": 974.46
+  },
+  {
+    "input": "When you write it all out as a formula, here's how it looks.",
+    "translatedText": "Lorsque vous écrivez le tout sous forme de formule, voici à quoi cela ressemble.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 975.9,
+    "end": 978.42
+  },
+  {
+    "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the base factor.",
+    "translatedText": "Il indique que vos chances d'avoir une maladie compte tenu du résultat d'un test sont égales à vos chances avant de passer le test, les chances antérieures, multipliées par le facteur de base.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 978.76,
+    "end": 986.96
+  },
+  {
+    "input": "Now let's contrast this with the usual way Bayes' rule is written, which is a bit more complicated.",
+    "translatedText": "Comparons maintenant cela avec la manière habituelle d'écrire la règle de Bayes, qui est un peu plus compliquée.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 986.96,
+    "end": 992.26
+  },
+  {
+    "input": "In case you haven't seen it before, it's essentially just what we were doing with sample populations, but you wrap it all up symbolically.",
+    "translatedText": "Au cas où vous ne l'auriez jamais vu auparavant, c'est essentiellement ce que nous faisions avec des échantillons de populations, mais vous résumez le tout symboliquement.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 993.06,
+    "end": 998.78
+  },
+  {
+    "input": "Remember how every time we were counting the number of true positives and then dividing it by the sum of the true positives and the false positives?",
+    "translatedText": "Rappelez-vous qu'à chaque fois, nous comptions le nombre de vrais positifs, puis le divisons par la somme des vrais positifs et des faux positifs?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 999.5,
+    "end": 1006.26
+  },
+  {
+    "input": "We do just that, except instead of talking about absolute amounts, we talk of each term as a proportion.",
+    "translatedText": "C’est exactement ce que nous faisons, sauf qu’au lieu de parler de montants absolus, nous parlons de chaque terme comme d’une proportion.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1006.8,
+    "end": 1012.26
+  },
+  {
+    "input": "So the proportion of true positives in the population comes from the prior probability of having the disease multiplied by the probability of seeing a positive test result in that case.",
+    "translatedText": "Ainsi, la proportion de vrais positifs dans la population provient de la probabilité préalable d’être atteint de la maladie multipliée par la probabilité de voir un résultat de test positif dans ce cas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1012.26,
+    "end": 1022.26
+  },
+  {
+    "input": "Then we copy that term down again into the denominator, and then the proportion of false positives comes from the prior probability of not having the disease times the probability of a positive test in that case.",
+    "translatedText": "Ensuite, nous recopieons ce terme dans le dénominateur, puis la proportion de faux positifs provient de la probabilité préalable de ne pas avoir la maladie multipliée par la probabilité d'un test positif dans ce cas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1023,
+    "end": 1034.1
+  },
+  {
+    "input": "If you want, you could also write this down with words instead of symbols, if terms like sensitivity and false positive rate are more comfortable.",
+    "translatedText": "Si vous le souhaitez, vous pouvez également écrire cela avec des mots au lieu de symboles, si des termes comme sensibilité et taux de faux positifs sont plus confortables.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1035.08,
+    "end": 1040.86
+  },
+  {
+    "input": "And this is one of those formulas where once you say it out loud it seems like a bit much, but it really is no different from what we were doing with sample populations.",
+    "translatedText": "Et c’est une de ces formules où, une fois prononcée à voix haute, cela semble un peu excessif, mais ce n’est vraiment pas différent de ce que nous faisions avec des échantillons de population.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1041.38,
+    "end": 1048.4
+  },
+  {
+    "input": "If you wanted to make the whole thing look simpler, you often see this entire denominator written just as the probability of seeing a positive test result, overall.",
+    "translatedText": "Si vous vouliez rendre le tout plus simple, vous voyez souvent ce dénominateur entier écrit comme la probabilité de voir un résultat de test positif, dans l'ensemble.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1049.22,
+    "end": 1057
+  },
+  {
+    "input": "While that does make for a really elegant little expression, if you intend to use this for calculations, it's a little disingenuous, because in practice, every single time you do this you need to break down that denominator into two separate parts, breaking down the cases.",
+    "translatedText": "Bien que cela constitue une petite expression vraiment élégante, si vous avez l'intention de l'utiliser pour des calculs, c'est un peu fallacieux, car en pratique, chaque fois que vous faites cela, vous devez décomposer ce dénominateur en deux parties distinctes, décomposant le cas.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1057.98,
+    "end": 1070.58
+  },
+  {
+    "input": "So taking this more honest representation of it, let's compare our two versions of Bayes' rule.",
+    "translatedText": "En prenant donc cette représentation plus honnête, comparons nos deux versions de la règle de Bayes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1071.7,
+    "end": 1076.02
+  },
+  {
+    "input": "And again, maybe it looks nicer if we use the words sensitivity and false positive rate.",
+    "translatedText": "Et encore une fois, cela semble peut-être plus joli si nous utilisons les mots sensibilité et taux de faux positifs.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1076.82,
+    "end": 1080.28
+  },
+  {
+    "input": "If nothing else, it helps emphasize which parts of the formula are coming from statistics about the test accuracy.",
+    "translatedText": "À tout le moins, cela permet de souligner quelles parties de la formule proviennent de statistiques sur la précision du test.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1080.66,
+    "end": 1085.64
+  },
+  {
+    "input": "I mean, this actually emphasizes one thing I really like about the framing with odds and a Bayes' factor, which is that it cleanly factors out the parts that have to do with the prior and the parts that have to do with the test accuracy.",
+    "translatedText": "Je veux dire, cela souligne en fait une chose que j'aime vraiment dans le cadrage avec les cotes et le facteur de Bayes, c'est-à-dire qu'il met clairement en évidence les parties qui ont à voir avec l'a priori et les parties qui ont à voir avec la précision du test.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1085.64,
+    "end": 1095.84
+  },
+  {
+    "input": "But over in the usual formula, all of those are very intermingled together.",
+    "translatedText": "Mais dans la formule habituelle, tous ces éléments sont très mélangés.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1096.66,
+    "end": 1100.2
+  },
+  {
+    "input": "And this has a very practical benefit.",
+    "translatedText": "Et cela présente un avantage très pratique.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1100.58,
+    "end": 1102.36
+  },
+  {
+    "input": "It's really nice if you want to swap out different priors and easily see their effects.",
+    "translatedText": "C'est vraiment bien si vous souhaitez échanger différents priorités et voir facilement leurs effets.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1102.48,
+    "end": 1106.26
+  },
+  {
+    "input": "This is what we were doing earlier.",
+    "translatedText": "C'est ce que nous faisions plus tôt.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1106.6,
+    "end": 1107.9
+  },
+  {
+    "input": "But with the other formula, to do that, you have to recompute everything each time.",
+    "translatedText": "Mais avec l’autre formule, pour faire ça, il faut tout recalculer à chaque fois.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1108.42,
+    "end": 1112.2
+  },
+  {
+    "input": "You can't leverage a precomputed Bayes' factor the same way.",
+    "translatedText": "Vous ne pouvez pas exploiter un facteur Bayes précalculé de la même manière.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1112.38,
+    "end": 1115.36
+  },
+  {
+    "input": "The odds framing also makes things really nice if you want to do multiple different Bayesian updates based on multiple pieces of evidence.",
+    "translatedText": "Le cadrage des cotes rend également les choses vraiment agréables si vous souhaitez effectuer plusieurs mises à jour bayésiennes différentes basées sur plusieurs éléments de preuve.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1115.96,
+    "end": 1122.12
+  },
+  {
+    "input": "For example, let's say you took not one test, but two.",
+    "translatedText": "Par exemple, disons que vous avez passé non pas un test, mais deux.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1122.74,
+    "end": 1124.86
+  },
+  {
+    "input": "Or you wanted to think about how the presence of symptoms plays into it.",
+    "translatedText": "Ou vous vouliez réfléchir à l’influence de la présence de symptômes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1125.36,
+    "end": 1128.54
+  },
+  {
+    "input": "For each piece of new evidence you see, you always ask the question, how much more likely would you be to see that with the disease versus without the disease?",
+    "translatedText": "Pour chaque nouvelle preuve que vous voyez, vous posez toujours la question : dans quelle mesure seriez-vous plus susceptible de voir cela avec la maladie ou sans la maladie?",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1129.12,
+    "end": 1136.62
+  },
+  {
+    "input": "Each answer to that question gives you a new Bayes' factor, a new thing that you multiply by your odds.",
+    "translatedText": "Chaque réponse à cette question vous donne un nouveau facteur de Bayes, une nouvelle chose que vous multipliez par vos chances.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1137.24,
+    "end": 1142
+  },
+  {
+    "input": "Beyond just making calculations easier, there's something I really like about attaching a number to test accuracy that doesn't even look like a probability.",
+    "translatedText": "Au-delà de simplement faciliter les calculs, il y a quelque chose que j'aime vraiment dans le fait d'attacher un nombre pour tester la précision qui ne ressemble même pas à une probabilité.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1142.88,
+    "end": 1149.92
+  },
+  {
+    "input": "I mean, if you hear that a test has, for example, a 9% false positive rate, that's just such a disastrously ambiguous phrase.",
+    "translatedText": "Je veux dire, si vous entendez dire qu’un test a, par exemple, un taux de faux positifs de 9 %, c’est une expression extrêmement ambiguë.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1150.74,
+    "end": 1157.34
+  },
+  {
+    "input": "It's so easy to misinterpret it to mean there's a 9% chance that your positive test result is false.",
+    "translatedText": "Il est si facile de mal interpréter cela, en voulant dire qu'il y a 9 % de chances que votre résultat positif soit faux.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1157.78,
+    "end": 1162.58
+  },
+  {
+    "input": "But imagine if instead the number that we heard tacked on to test results was that the Bayes' factor for a positive test result is, say, 10.",
+    "translatedText": "Mais imaginez si, au lieu de cela, le chiffre que nous avons entendu sur les résultats des tests était que le facteur Bayes pour un résultat de test positif était, disons, de 10.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1163.3,
+    "end": 1170.32
+  },
+  {
+    "input": "There's no room to confuse that for your probability of having a disease.",
+    "translatedText": "Il n’y a aucune possibilité de confondre cela avec votre probabilité d’être atteint d’une maladie.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1170.82,
+    "end": 1174.14
+  },
+  {
+    "input": "The entire framing of what a Bayes' factor is, is that it's something that acts on a prior.",
+    "translatedText": "L'ensemble de ce qu'est un facteur bayésien est que c'est quelque chose qui agit sur un a priori.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1174.64,
+    "end": 1179.04
+  },
+  {
+    "input": "It forces your hand to acknowledge the prior as something that's separate entirely, and highly necessary to drawing any conclusion.",
+    "translatedText": "Cela vous oblige à reconnaître le préalable comme quelque chose de entièrement distinct et hautement nécessaire pour tirer une conclusion.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1179.5,
+    "end": 1185.44
+  },
+  {
+    "input": "All that said, the usual formula is definitely not without its merits.",
+    "translatedText": "Cela dit, la formule habituelle n’est certainement pas sans mérite.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1187.26,
+    "end": 1190.74
+  },
+  {
+    "input": "If you view it not simply as something to plug numbers into, but as an encapsulation of the sample population idea that we've been using throughout, you could very easily argue that that's actually much better for your intuition.",
+    "translatedText": "Si vous ne le considérez pas simplement comme quelque chose auquel insérer des chiffres, mais comme une encapsulation de l'idée d'un échantillon de population que nous avons utilisée tout au long, vous pourriez très facilement affirmer que c'est en fait bien meilleur pour votre intuition.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1191.08,
+    "end": 1201.98
+  },
+  {
+    "input": "After all, it's what we were routinely falling back on in order to check ourselves that the Bayes' factor computation even made sense in the first place.",
+    "translatedText": "Après tout, c’est sur cela que nous nous appuyions régulièrement pour vérifier nous-mêmes que le calcul factoriel de Bayes avait du sens en premier lieu.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1202.56,
+    "end": 1209.18
+  },
+  {
+    "input": "Like any design decision, there is no clear-cut objective best here.",
+    "translatedText": "Comme toute décision de conception, il n’y a pas ici d’objectif clairement défini.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1211.6,
+    "end": 1215.38
+  },
+  {
+    "input": "But it's almost certainly the case that giving serious consideration to that question will lead you to a better understanding of Bayes' rule.",
+    "translatedText": "Mais il est presque certain que réfléchir sérieusement à cette question vous mènera à une meilleure compréhension de la règle de Bayes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1215.42,
+    "end": 1221.72
+  },
+  {
+    "input": "Also, since we're on the topic of kind of paradoxical things, a friend of mine, Matt Cook, recently wrote a book all about paradoxes.",
+    "translatedText": "De plus, puisque nous parlons de choses paradoxales, un de mes amis, Matt Cook, a récemment écrit un livre consacré aux paradoxes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1230.1,
+    "end": 1236.12
+  },
+  {
+    "input": "I actually contributed a small chapter to it with thoughts on the question of whether math is invented or discovered.",
+    "translatedText": "J'y ai en fait contribué dans un petit chapitre avec des réflexions sur la question de savoir si les mathématiques sont inventées ou découvertes.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1237.04,
+    "end": 1241.82
+  },
+  {
+    "input": "And the book as a whole is this really nice connection of thought-provoking paradoxical things ranging from philosophy to math and physics.",
+    "translatedText": "Et le livre dans son ensemble est cette connexion vraiment agréable de choses paradoxales qui suscitent la réflexion, allant de la philosophie aux mathématiques et à la physique.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1242.3,
+    "end": 1248.4
+  },
+  {
+    "input": "You can, of course, find all the details in the description. .",
+    "translatedText": "Vous pouvez bien entendu retrouver tous les détails dans la description.",
+    "model": "google_nmt",
+    "n_reviews": 0,
+    "start": 1248.82,
+    "end": 1251.04
+  }
 ]

--- a/2020/better-bayes/french/sentence_translations.json
+++ b/2020/better-bayes/french/sentence_translations.json
@@ -969,609 +969,609 @@
   },
   {
     "input": "When you filter down just to those with positive test results, the number of people with cancer gets scaled down, scaled down by the probability of seeing a positive test result given that someone has cancer.",
-    "translatedText": "Lorsque vous filtrez uniquement celles dont les résultats de test sont positifs, le nombre de personnes atteintes de cancer est réduit, réduit par la probabilité de voir un résultat de test positif étant donné que quelqu'un a un cancer.",
+    "translatedText": "Si on ne regarde que les personnes ayant un test positif, l’ensemble de celles qui ont un cancer a diminué, par rapport au groupe initial, d’un facteur égal à la probabilité d’obtenir un test positif sur une personne malade.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 753.36,
     "end": 764.42
   },
   {
     "input": "And then similarly, the number of people without cancer also gets scaled down, this time by the probability of seeing a positive test result, but in that case.",
-    "translatedText": "Et de la même manière, le nombre de personnes sans cancer est également réduit, cette fois en fonction de la probabilité de voir un résultat de test positif, mais dans ce cas.",
+    "translatedText": "De la même manière, l’ensemble des personnes saines a également diminué, mais cette fois par un facteur égal à la probabilité qu’une personne saine obtienne un résultat positif.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 765.12,
     "end": 773.44
   },
   {
     "input": "So the ratio between these two counts, the new odds upon seeing the test, looks just like the prior odds except multiplied by this term here, which is exactly the Bayes' factor.",
-    "translatedText": "Ainsi, le rapport entre ces deux comptes, la nouvelle cote à la vue du test, ressemble exactement à la cote précédente, sauf qu'il est multiplié par ce terme ici, ce qui est exactement le facteur de Bayes.",
+    "translatedText": "Le rapport des effectifs de ces groupes, qui est la nouvelle cote post-tests, a la même forme que la cote pre-tests, mais multipliée par ce terme, qui est précisément le facteur de Bayes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 774.18,
     "end": 784.76
   },
   {
     "input": "Look back at our example, where the Bayes' factor was 10.",
-    "translatedText": "Revenons à notre exemple, où le facteur de Bayes était de 10.",
+    "translatedText": "Reprenons notre exemple, où le facteur de Bayes était de 10.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 787.8,
     "end": 790.5
   },
   {
     "input": "And as a reminder, this came from the 90% sensitivity divided by the 9% false positive rate.",
-    "translatedText": "Et pour rappel, cela provenait de la sensibilité de 90 % divisée par le taux de faux positifs de 9 %.",
+    "translatedText": "Qu’on peut calculer, pour rappel, comme le rapport d’une sensibilité de 90 % sur un taux de faux positifs de 9 %.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 791,
     "end": 796.56
   },
   {
     "input": "How much more likely are you to see a positive result with cancer versus without?",
-    "translatedText": "Dans quelle mesure avez-vous plus de chances de voir un résultat positif avec un cancer plutôt que sans?",
+    "translatedText": "Quand avez-vous plus de chances d’avoir un résultat positif pour une personne malade plutôt que saine ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 796.88,
     "end": 800.74
   },
   {
     "input": "If the prior is 1%, expressed as odds, this looks like 1 to 99.",
-    "translatedText": "Si l'a priori est de 1 %, exprimé en probabilité, cela ressemble à 1 : 99.",
+    "translatedText": "Si l'a priori est de 1 %, ça nous donne une cote de 1 pour 99.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 801.72,
     "end": 805.94
   },
   {
     "input": "So by our rule, this gets updated to 10 to 99, which if you want you could convert back to a probability.",
-    "translatedText": "Donc, selon notre règle, cela est mis à jour entre 10 et 99, ce qui, si vous le souhaitez, peut être reconverti en probabilité.",
+    "translatedText": "Donc, d’après notre règle, la cote est mise à jour à 10 pour 99. Et vous pouvez la reconvertir en probabilité si besoin.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 806.9,
     "end": 813.4
   },
   {
     "input": "It would be 10 divided by 10 plus 99, or about 1 in 11.",
-    "translatedText": "Ce serait 10 divisé par 10 plus 99, soit environ 1 sur 11.",
+    "translatedText": "Ça nous donnerait 10 divisé par 10 plus 99, soit environ 1 sur 11.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 813.66,
     "end": 817.22
   },
   {
     "input": "If instead, the prior was 10%, which was the example that tripped up our rule of thumb earlier, expressed as odds, this looks like 1 to 9.",
-    "translatedText": "Si, à la place, l'a priori était de 10 %, ce qui était l'exemple qui a fait trébucher notre règle empirique plus tôt, exprimée en cotes, cela ressemble à 1 : 9.",
+    "translatedText": "Si l'a priori était plutôt de 10 %, comme dans l’exemple qui mettait notre approximation en défaut un peu plus tôt, on aurait une cote de 1 pour 9.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 818.2,
     "end": 826.26
   },
   {
     "input": "By our simple rule, this gets updated to 10 to 9, which you can already read off pretty intuitively.",
-    "translatedText": "Selon notre règle simple, cela est mis à jour de 10 à 9, que vous pouvez déjà lire de manière assez intuitive.",
+    "translatedText": "D’après notre règle, cette cote passe à 10 pour 9, que vous pouvez déjà interpréter de manière assez intuitive.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 826.94,
     "end": 832.44
   },
   {
     "input": "It's a little above even chances, a little above 1 to 1.",
-    "translatedText": "C'est un peu au-dessus des chances égales, un peu au-dessus de 1 pour 1.",
+    "translatedText": "C'est un peu au-dessus d’un partage équitable des chances, un peu au-dessus de 1 pour 1.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 832.44,
     "end": 835.66
   },
   {
     "input": "If you prefer, you can convert it back to a probability.",
-    "translatedText": "Si vous préférez, vous pouvez la reconvertir en probabilité.",
+    "translatedText": "Si vous préférez, on peut reconvertir cette cote en probabilité.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 836.34,
     "end": 838.84
   },
   {
     "input": "You would write it as 10 out of 19, or about 53%.",
-    "translatedText": "Vous l'écririez comme 10 sur 19, soit environ 53 %.",
+    "translatedText": "Ça donnerait 10 sur 19, soit environ 53 %.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 839.18,
     "end": 843.28
   },
   {
     "input": "And indeed, that is what we already found by thinking things through with a sample population.",
-    "translatedText": "Et c’est d’ailleurs ce que nous avons déjà constaté en réfléchissant sur un échantillon de population.",
+    "translatedText": "Et c’est d’ailleurs ce qu’on avait déjà trouvé en réfléchissant à notre population fictive.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 843.28,
     "end": 847.22
   },
   {
     "input": "Let's say we go back to the 1% prevalence, but I make the test more accurate.",
-    "translatedText": "Disons que l'on revient à la prévalence de 1 %, mais je rends le test plus précis.",
+    "translatedText": "Disons qu’on reprend une prévalence de 1 %, mais que le test est plus précis.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 848.3,
     "end": 851.7
   },
   {
     "input": "Now what if I told you to imagine that the false positive rate was only 1% instead of 9%?",
-    "translatedText": "Et si je vous disais d’imaginer que le taux de faux positifs n’était que de 1 % au lieu de 9 %?",
+    "translatedText": "Imaginons maintenant que le taux de faux positifs n’est que de 1 %, plutôt que 9 %",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 852.06,
     "end": 856.64
   },
   {
     "input": "What that would mean is that our Bayes factor is 90 instead of 10.",
-    "translatedText": "Cela signifierait que notre facteur Bayesien est de 90 au lieu de 10.",
+    "translatedText": "Ça voudrait dire que notre facteur de Bayes est de 90 au lieu de 10.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 857.12,
     "end": 860.52
   },
   {
     "input": "The test is doing more work for us.",
-    "translatedText": "Le test fait plus de travail pour nous.",
+    "translatedText": "Le test joue davantage en notre faveur.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 860.84,
     "end": 862.46
   },
   {
     "input": "In this case, with the more accurate test, it gets updated to 90 to 99, which is a little less than even chances, something a little under 50%.",
-    "translatedText": "Dans ce cas, avec le test le plus précis, il est mis à jour entre 90 et 99, ce qui est un peu moins que les chances égales, soit un peu moins de 50 %.",
+    "translatedText": "Dans ce cas, avec un test plus précis, la cote se déplace à 90 pour 99, ce qui est un peu moins que 50 % de chances.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 863.16,
     "end": 871.58
   },
   {
     "input": "To be more precise, you could make the conversion back to probability and work out that it's around 48%.",
-    "translatedText": "Pour être plus précis, vous pouvez revenir à la conversion en probabilité et déterminer qu'elle est d'environ 48 %.",
+    "translatedText": "Plus précisément, on peut la convertir en probabilité et trouver qu'elle est à peu près égale à 48 %.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 871.58,
     "end": 877.56
   },
   {
     "input": "But honestly, if you're just going for a gut feel, it's fine to stick with the odds.",
-    "translatedText": "Mais honnêtement, si vous vous contentez d’une intuition, c’est bien de s’en tenir aux probabilités.",
+    "translatedText": "Mais honnêtement, si vous voulez juste vous faire une idée, les cotes sont largement suffisantes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 877.56,
     "end": 881.4
   },
   {
     "input": "Do you see what I mean about how just defining this number helps to combat potential misconceptions?",
-    "translatedText": "Voyez-vous ce que je veux dire sur la façon dont la simple définition de ce nombre aide à lutter contre d’éventuelles idées fausses?",
+    "translatedText": "Est-ce que vous voyez le rapport entre la simple définition de ce facteur et le fait d’éviter d’éventuelles confusions ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 882.22,
     "end": 887.44
   },
   {
     "input": "For anybody who's a little hasty in connecting test accuracy directly to your probability of having a disease, it's worth emphasizing that you could administer the same test with the same accuracy to multiple different patients who all get the same exact result, but if they're coming from different contexts, that result can mean wildly different things.",
-    "translatedText": "Pour tous ceux qui s'empressent de relier directement l'exactitude du test à votre probabilité de contracter une maladie, il convient de souligner que vous pouvez administrer le même test avec la même précision à plusieurs patients différents qui obtiennent tous exactement le même résultat, mais s'ils sont venant de contextes différents, ce résultat peut signifier des choses très différentes.",
+    "translatedText": "Si une personne a envie d’associer un peu trop vite le résultat d’un test à la probabilité d’avoir une maladie, on peut lui rappeler qu’il est possible de faire passer exactement le même test, avec la même précision, à plusieurs patients différents et que ces patients obtiennent tous exactement le même résultat. Pourtant, en fonction du contexte, ces résultats peuvent signifier des choses incroyablement différentes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 888.24,
     "end": 906.72
   },
   {
     "input": "However, the one thing that does stay constant in every case is the factor by which each patient's prior odds get updated.",
-    "translatedText": "Cependant, la seule chose qui reste constante dans tous les cas est le facteur par lequel les probabilités antérieures de chaque patient sont mises à jour.",
+    "translatedText": "Par contre, la seule chose qui ne change pas entre tous ces cas, c'est le facteur par lequel les cotes a priori de chaque patient sont mises à jour.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 906.72,
     "end": 914.66
   },
   {
     "input": "And by the way, this whole time we've been using the prevalence of the disease, which is the proportion of people in a population who have it, as a substitute for the prior, the probability of having it before you see a test.",
-    "translatedText": "Et d'ailleurs, pendant tout ce temps, nous avons utilisé la prévalence de la maladie, c'est-à-dire la proportion de personnes dans une population qui en sont atteintes, comme substitut à la probabilité antérieure, la probabilité d'en être atteinte avant de passer un test.",
+    "translatedText": "Et d'ailleurs, on a choisi comme probabilité a priori la prévalence de la maladie depuis tout à l’heure. C'est-à-dire la proportion de personnes malades au sein de la population.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 916.3,
     "end": 926.88
   },
   {
     "input": "However, that's not necessarily the case.",
-    "translatedText": "Cependant, ce n'est pas nécessairement le cas.",
+    "translatedText": "Mais ce n’est pas forcément toujours le cas.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 927.52,
     "end": 929.46
   },
   {
     "input": "If there are other known factors, things like symptoms, or in the case of a contagious disease, things like known contacts, those also factor into the prior, and they could potentially make a huge difference.",
-    "translatedText": "S'il existe d'autres facteurs connus, comme les symptômes, ou dans le cas d'une maladie contagieuse, des éléments comme les contacts connus, ceux-ci sont également pris en compte dans les antécédents et pourraient potentiellement faire une énorme différence.",
+    "translatedText": "Si on connaît d’autres éléments, comme par exemple les symptômes, ou, dans le cas d'une maladie contagieuse, les personnes contact, ceux-ci sont pris en compte dans l’a priori et peuvent potentiellement faire une énorme différence.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 929.78,
     "end": 939.86
   },
   {
     "input": "As another side note, so far we've only talked about positive test results, but way more often you would be seeing a negative test result.",
-    "translatedText": "Par ailleurs, jusqu'à présent, nous n'avons parlé que de résultats de tests positifs, mais bien plus souvent, vous verriez un résultat de test négatif.",
+    "translatedText": "Par ailleurs, jusqu'ici, on n’a parlé que de résultats de tests positifs, mais on voit bien plus de résultats  négatif en pratique.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 940.76,
     "end": 947.46
   },
   {
-    "input": "The logic there is completely the same, but the base factor that you compute is going to look different.",
-    "translatedText": "La logique est complètement la même, mais le facteur de base que vous calculez sera différent.",
+    "input": "The logic there is completely the same, but the Bayes factor that you compute is going to look different.",
+    "translatedText": "La logique est exactement la même, mais le facteur de Bayes que vous calculez aura une allure différente.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 948.1,
     "end": 952.32
   },
   {
     "input": "Instead, you look at the probability of seeing this negative test result with the disease versus without the disease.",
-    "translatedText": "Au lieu de cela, vous examinez la probabilité de voir ce résultat de test négatif avec la maladie ou sans la maladie.",
+    "translatedText": "À la place on regardera la probabilité d’obtenir un résultat de test négatif en présence de la maladie, et au contraire, en son absence.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 952.76,
     "end": 958.64
   },
   {
     "input": "So in our cancer example, this would have been the 10% false negative rate divided by the 91% specificity, or about 1 in 9.",
-    "translatedText": "Ainsi, dans notre exemple de cancer, cela aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
+    "translatedText": "Du coup, dans notre exemple sur le cancer, cela aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 958.64,
     "end": 967.04
   },
   {
     "input": "In other words, seeing a negative test result in that example would reduce your prior odds by about an order of magnitude.",
-    "translatedText": "En d’autres termes, voir un résultat de test négatif dans cet exemple réduirait vos chances antérieures d’environ un ordre de grandeur.",
+    "translatedText": "Autrement dit, observer un résultat de test négatif dans cet exemple réduirait la cote a priori d’environ un ordre de grandeur.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 967.78,
     "end": 974.46
   },
   {
     "input": "When you write it all out as a formula, here's how it looks.",
-    "translatedText": "Lorsque vous écrivez le tout sous forme de formule, voici à quoi cela ressemble.",
+    "translatedText": "Si on l’exprime sous la forme d’une équation, voilà à quoi ça ressemble.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 975.9,
     "end": 978.42
   },
   {
-    "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the base factor.",
-    "translatedText": "Il indique que vos chances d'avoir une maladie compte tenu du résultat d'un test sont égales à vos chances avant de passer le test, les chances antérieures, multipliées par le facteur de base.",
+    "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the Bayes factor.",
+    "translatedText": "Elle vous dit que le risque d'avoir une maladie compte tenu du résultat d'un test est égal au risque estimé avant de passer le test, la cote a priori, multiplié par le facteur de Bayes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 978.76,
     "end": 986.96
   },
   {
     "input": "Now let's contrast this with the usual way Bayes' rule is written, which is a bit more complicated.",
-    "translatedText": "Comparons maintenant cela avec la manière habituelle d'écrire la règle de Bayes, qui est un peu plus compliquée.",
+    "translatedText": "On peut comparer ça avec la manière dont on présente habituellement le théorème de Bayes, qui est un peu plus compliquée.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 986.96,
     "end": 992.26
   },
   {
     "input": "In case you haven't seen it before, it's essentially just what we were doing with sample populations, but you wrap it all up symbolically.",
-    "translatedText": "Au cas où vous ne l'auriez jamais vu auparavant, c'est essentiellement ce que nous faisions avec des échantillons de populations, mais vous résumez le tout symboliquement.",
+    "translatedText": "Si vous ne l’avez jamais vu, ça revient essentiellement à ce qu’on a fait avec nos populations fictives, mais exprimé de manière symbolique.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 993.06,
     "end": 998.78
   },
   {
     "input": "Remember how every time we were counting the number of true positives and then dividing it by the sum of the true positives and the false positives?",
-    "translatedText": "Rappelez-vous qu'à chaque fois, nous comptions le nombre de vrais positifs, puis le divisons par la somme des vrais positifs et des faux positifs?",
+    "translatedText": "Vous vous souvenez qu’à chaque fois on prenait le nombre de vrais positifs et qu’on le divisait par la somme des vrais positifs et des faux positifs ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 999.5,
     "end": 1006.26
   },
   {
     "input": "We do just that, except instead of talking about absolute amounts, we talk of each term as a proportion.",
-    "translatedText": "C’est exactement ce que nous faisons, sauf qu’au lieu de parler de montants absolus, nous parlons de chaque terme comme d’une proportion.",
+    "translatedText": "On va refaire la même chose, sauf qu’au lieu de parler de tailles d’échantillons, chaque terme désignera une proportion.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1006.8,
     "end": 1012.26
   },
   {
     "input": "So the proportion of true positives in the population comes from the prior probability of having the disease multiplied by the probability of seeing a positive test result in that case.",
-    "translatedText": "Ainsi, la proportion de vrais positifs dans la population provient de la probabilité préalable d’être atteint de la maladie multipliée par la probabilité de voir un résultat de test positif dans ce cas.",
+    "translatedText": "La proportion de vrais positifs dans la population est égale à la probabilité a priori d’être atteint de la maladie multipliée par la probabilité d’observer un résultat de test positif dans ce cas-là.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1012.26,
     "end": 1022.26
   },
   {
     "input": "Then we copy that term down again into the denominator, and then the proportion of false positives comes from the prior probability of not having the disease times the probability of a positive test in that case.",
-    "translatedText": "Ensuite, nous recopieons ce terme dans le dénominateur, puis la proportion de faux positifs provient de la probabilité préalable de ne pas avoir la maladie multipliée par la probabilité d'un test positif dans ce cas.",
+    "translatedText": "On recopie ce terme au dénominateur, et on calcule la proportion de faux positifs comme la probabilité a priori de ne pas avoir la maladie multipliée par la probabilité d'un test positif dans ce cas-là.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1023,
     "end": 1034.1
   },
   {
     "input": "If you want, you could also write this down with words instead of symbols, if terms like sensitivity and false positive rate are more comfortable.",
-    "translatedText": "Si vous le souhaitez, vous pouvez également écrire cela avec des mots au lieu de symboles, si des termes comme sensibilité et taux de faux positifs sont plus confortables.",
+    "translatedText": "Vous pouvez aussi l'écrire en toutes lettres si les termes de sensibilité et de taux de faux positifs vous parlent plus.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1035.08,
     "end": 1040.86
   },
   {
     "input": "And this is one of those formulas where once you say it out loud it seems like a bit much, but it really is no different from what we were doing with sample populations.",
-    "translatedText": "Et c’est une de ces formules où, une fois prononcée à voix haute, cela semble un peu excessif, mais ce n’est vraiment pas différent de ce que nous faisions avec des échantillons de population.",
+    "translatedText": "Et c’est vrai que la formule a l’air un peu costaud, vue comme ça, mais ça correspond simplement à ce qu’on a vu tout à l’heure avec nos populations fictives.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1041.38,
     "end": 1048.4
   },
   {
     "input": "If you wanted to make the whole thing look simpler, you often see this entire denominator written just as the probability of seeing a positive test result, overall.",
-    "translatedText": "Si vous vouliez rendre le tout plus simple, vous voyez souvent ce dénominateur entier écrit comme la probabilité de voir un résultat de test positif, dans l'ensemble.",
+    "translatedText": "On peut rendre ça plus concis en décrivant le dénominateur comme la probabilité d’observer un résultat de test positif au global.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1049.22,
     "end": 1057
   },
   {
     "input": "While that does make for a really elegant little expression, if you intend to use this for calculations, it's a little disingenuous, because in practice, every single time you do this you need to break down that denominator into two separate parts, breaking down the cases.",
-    "translatedText": "Bien que cela constitue une petite expression vraiment élégante, si vous avez l'intention de l'utiliser pour des calculs, c'est un peu fallacieux, car en pratique, chaque fois que vous faites cela, vous devez décomposer ce dénominateur en deux parties distinctes, décomposant le cas.",
+    "translatedText": "Et même si ça nous donne une expression très élégante, c’est un peu trompeur, car dès qu’on voudra l’utiliser en pratique, il faudra décomposer le dénominateur en deux parties distinctes, qui décrivent chacune des situations.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1057.98,
     "end": 1070.58
   },
   {
     "input": "So taking this more honest representation of it, let's compare our two versions of Bayes' rule.",
-    "translatedText": "En prenant donc cette représentation plus honnête, comparons nos deux versions de la règle de Bayes.",
+    "translatedText": "Gardons donc cette représentation un peu plus honnête et comparons les deux versions du théorème de Bayes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1071.7,
     "end": 1076.02
   },
   {
     "input": "And again, maybe it looks nicer if we use the words sensitivity and false positive rate.",
-    "translatedText": "Et encore une fois, cela semble peut-être plus joli si nous utilisons les mots sensibilité et taux de faux positifs.",
+    "translatedText": "Et de nouveau, utilisons les termes de sensibilité et taux de faux positifs.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1076.82,
     "end": 1080.28
   },
   {
     "input": "If nothing else, it helps emphasize which parts of the formula are coming from statistics about the test accuracy.",
-    "translatedText": "À tout le moins, cela permet de souligner quelles parties de la formule proviennent de statistiques sur la précision du test.",
+    "translatedText": "Ça permet au minimum de souligner quels éléments dans les formules proviennent des mesures sur la performance du test.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1080.66,
     "end": 1085.64
   },
   {
     "input": "I mean, this actually emphasizes one thing I really like about the framing with odds and a Bayes' factor, which is that it cleanly factors out the parts that have to do with the prior and the parts that have to do with the test accuracy.",
-    "translatedText": "Je veux dire, cela souligne en fait une chose que j'aime vraiment dans le cadrage avec les cotes et le facteur de Bayes, c'est-à-dire qu'il met clairement en évidence les parties qui ont à voir avec l'a priori et les parties qui ont à voir avec la précision du test.",
+    "translatedText": "Ce que j’apprécie dans cette manière de présenter à travers les cotes et le facteur de Bayes, c’est qu’elle sépare clairement ce qui a à voir avec l'a priori et ce qui a à voir avec la performance du test.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1085.64,
     "end": 1095.84
   },
   {
     "input": "But over in the usual formula, all of those are very intermingled together.",
-    "translatedText": "Mais dans la formule habituelle, tous ces éléments sont très mélangés.",
+    "translatedText": "Alors que dans la formulation habituelle, tous ces éléments sont vraiment mélangés.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1096.66,
     "end": 1100.2
   },
   {
     "input": "And this has a very practical benefit.",
-    "translatedText": "Et cela présente un avantage très pratique.",
+    "translatedText": "Et ça a une conséquence très immédiate.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1100.58,
     "end": 1102.36
   },
   {
     "input": "It's really nice if you want to swap out different priors and easily see their effects.",
-    "translatedText": "C'est vraiment bien si vous souhaitez échanger différents priorités et voir facilement leurs effets.",
+    "translatedText": "C'est vraiment pratique pour changer la valeur de l’a priori et observer l’effet que ça produit.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1102.48,
     "end": 1106.26
   },
   {
     "input": "This is what we were doing earlier.",
-    "translatedText": "C'est ce que nous faisions plus tôt.",
+    "translatedText": "C'est ce qu’on faisait plus tôt.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1106.6,
     "end": 1107.9
   },
   {
     "input": "But with the other formula, to do that, you have to recompute everything each time.",
-    "translatedText": "Mais avec l’autre formule, pour faire ça, il faut tout recalculer à chaque fois.",
+    "translatedText": "Mais avec l’autre formule, pour pouvoir faire ça, il faudrait tout recalculer à chaque fois.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1108.42,
     "end": 1112.2
   },
   {
     "input": "You can't leverage a precomputed Bayes' factor the same way.",
-    "translatedText": "Vous ne pouvez pas exploiter un facteur Bayes précalculé de la même manière.",
+    "translatedText": "On ne peut pas utiliser un facteur de Bayes pré-calculé de la même manière.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1112.38,
     "end": 1115.36
   },
   {
     "input": "The odds framing also makes things really nice if you want to do multiple different Bayesian updates based on multiple pieces of evidence.",
-    "translatedText": "Le cadrage des cotes rend également les choses vraiment agréables si vous souhaitez effectuer plusieurs mises à jour bayésiennes différentes basées sur plusieurs éléments de preuve.",
+    "translatedText": "La formulation avec cotes est aussi très pratique lorsqu’on veut effectuer des mises à jour bayésiennes en série basées sur plusieurs observations.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1115.96,
     "end": 1122.12
   },
   {
     "input": "For example, let's say you took not one test, but two.",
-    "translatedText": "Par exemple, disons que vous avez passé non pas un test, mais deux.",
+    "translatedText": "Par exemple, disons que vous n’avez pas passé un test, mais deux.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1122.74,
     "end": 1124.86
   },
   {
     "input": "Or you wanted to think about how the presence of symptoms plays into it.",
-    "translatedText": "Ou vous vouliez réfléchir à l’influence de la présence de symptômes.",
+    "translatedText": "Ou que vous vouliez inclure une information concernant la présence de certains symptômes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1125.36,
     "end": 1128.54
   },
   {
     "input": "For each piece of new evidence you see, you always ask the question, how much more likely would you be to see that with the disease versus without the disease?",
-    "translatedText": "Pour chaque nouvelle preuve que vous voyez, vous posez toujours la question : dans quelle mesure seriez-vous plus susceptible de voir cela avec la maladie ou sans la maladie?",
+    "translatedText": "Dès qu’on obtient une nouvelle information, on va toujours se demander : dans quel cas est-ce qu’il est plus probable d’observer cette information, avec ou sans la maladie ?",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1129.12,
     "end": 1136.62
   },
   {
     "input": "Each answer to that question gives you a new Bayes' factor, a new thing that you multiply by your odds.",
-    "translatedText": "Chaque réponse à cette question vous donne un nouveau facteur de Bayes, une nouvelle chose que vous multipliez par vos chances.",
+    "translatedText": "Chaque réponse successive nous donne un nouveau facteur de Bayes, par lequel on va pouvoir multiplier notre cote précédente.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1137.24,
     "end": 1142
   },
   {
     "input": "Beyond just making calculations easier, there's something I really like about attaching a number to test accuracy that doesn't even look like a probability.",
-    "translatedText": "Au-delà de simplement faciliter les calculs, il y a quelque chose que j'aime vraiment dans le fait d'attacher un nombre pour tester la précision qui ne ressemble même pas à une probabilité.",
+    "translatedText": "Au-delà de simplifier les calculs, il y a quelque chose que j'aime vraiment dans le fait d’utiliser un nombre qui n’est pas une probabilité pour mesurer la performance d’un test.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1142.88,
     "end": 1149.92
   },
   {
     "input": "I mean, if you hear that a test has, for example, a 9% false positive rate, that's just such a disastrously ambiguous phrase.",
-    "translatedText": "Je veux dire, si vous entendez dire qu’un test a, par exemple, un taux de faux positifs de 9 %, c’est une expression extrêmement ambiguë.",
+    "translatedText": "Par exemple, si on nous dit qu’un test A, a un taux de faux positifs de 9 %, c’est une assertion incroyablement ambiguë.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1150.74,
     "end": 1157.34
   },
   {
     "input": "It's so easy to misinterpret it to mean there's a 9% chance that your positive test result is false.",
-    "translatedText": "Il est si facile de mal interpréter cela, en voulant dire qu'il y a 9 % de chances que votre résultat positif soit faux.",
+    "translatedText": "C’est très facile de se méprendre et croire qu'il y a 9 % de chances que votre résultat positif soit faux.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1157.78,
     "end": 1162.58
   },
   {
     "input": "But imagine if instead the number that we heard tacked on to test results was that the Bayes' factor for a positive test result is, say, 10.",
-    "translatedText": "Mais imaginez si, au lieu de cela, le chiffre que nous avons entendu sur les résultats des tests était que le facteur Bayes pour un résultat de test positif était, disons, de 10.",
+    "translatedText": "Mais imaginons qu’à la place, on nous dise à propos du test que son facteur de Bayes pour un résultat positif est, par exemple, de 10.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1163.3,
     "end": 1170.32
   },
   {
     "input": "There's no room to confuse that for your probability of having a disease.",
-    "translatedText": "Il n’y a aucune possibilité de confondre cela avec votre probabilité d’être atteint d’une maladie.",
+    "translatedText": "Là, on ne peut plus interpréter ça à tort comme la probabilité d’être atteint d’une maladie.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1170.82,
     "end": 1174.14
   },
   {
     "input": "The entire framing of what a Bayes' factor is, is that it's something that acts on a prior.",
-    "translatedText": "L'ensemble de ce qu'est un facteur bayésien est que c'est quelque chose qui agit sur un a priori.",
+    "translatedText": "L’idée au cœur de la définition du facteur de Bayes, c'est qu’il prend et agit sur un a priori.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1174.64,
     "end": 1179.04
   },
   {
     "input": "It forces your hand to acknowledge the prior as something that's separate entirely, and highly necessary to drawing any conclusion.",
-    "translatedText": "Cela vous oblige à reconnaître le préalable comme quelque chose de entièrement distinct et hautement nécessaire pour tirer une conclusion.",
+    "translatedText": "Et ça oblige à considérer cet priori comme quelque chose de complètement distinct, et d’obligatoire pour pouvoir tirer une quelconque conclusion.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1179.5,
     "end": 1185.44
   },
   {
     "input": "All that said, the usual formula is definitely not without its merits.",
-    "translatedText": "Cela dit, la formule habituelle n’est certainement pas sans mérite.",
+    "translatedText": "Cela dit, la forme habituelle a clairement des avantages.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1187.26,
     "end": 1190.74
   },
   {
     "input": "If you view it not simply as something to plug numbers into, but as an encapsulation of the sample population idea that we've been using throughout, you could very easily argue that that's actually much better for your intuition.",
-    "translatedText": "Si vous ne le considérez pas simplement comme quelque chose auquel insérer des chiffres, mais comme une encapsulation de l'idée d'un échantillon de population que nous avons utilisée tout au long, vous pourriez très facilement affirmer que c'est en fait bien meilleur pour votre intuition.",
+    "translatedText": "Si on ne la voit pas juste comme une formule à évaluer avec des valeurs données, mais comme portant cette idée de population fictive qu’on a utilisée tout du long, on pourrait se dire qu’elle est en fait bien meilleure pour notre intuition.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1191.08,
     "end": 1201.98
   },
   {
     "input": "After all, it's what we were routinely falling back on in order to check ourselves that the Bayes' factor computation even made sense in the first place.",
-    "translatedText": "Après tout, c’est sur cela que nous nous appuyions régulièrement pour vérifier nous-mêmes que le calcul factoriel de Bayes avait du sens en premier lieu.",
+    "translatedText": "Après tout, c’est sur cette formule qu’on se basait à chaque fois pour vérifier que nos calculs incluant le facteur Bayes avaient bien du sens.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1202.56,
     "end": 1209.18
   },
   {
     "input": "Like any design decision, there is no clear-cut objective best here.",
-    "translatedText": "Comme toute décision de conception, il n’y a pas ici d’objectif clairement défini.",
+    "translatedText": "Comme dans tout processus de conception, on n’a pas une solution clairement meilleure que l’autre.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1211.6,
     "end": 1215.38
   },
   {
     "input": "But it's almost certainly the case that giving serious consideration to that question will lead you to a better understanding of Bayes' rule.",
-    "translatedText": "Mais il est presque certain que réfléchir sérieusement à cette question vous mènera à une meilleure compréhension de la règle de Bayes.",
+    "translatedText": "Mais il est à peu sûr que le fait de réfléchir sérieusement à cette question vous permettra de mieux comprendre le sens du théorème de Bayes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1215.42,
     "end": 1221.72
   },
   {
     "input": "Also, since we're on the topic of kind of paradoxical things, a friend of mine, Matt Cook, recently wrote a book all about paradoxes.",
-    "translatedText": "De plus, puisque nous parlons de choses paradoxales, un de mes amis, Matt Cook, a récemment écrit un livre consacré aux paradoxes.",
+    "translatedText": "Et puisqu’on parle de choses un peu paradoxales ; Matt Cook, un ami à moi, a récemment écrit un livre qui traite beaucoup de paradoxes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1230.1,
     "end": 1236.12
   },
   {
     "input": "I actually contributed a small chapter to it with thoughts on the question of whether math is invented or discovered.",
-    "translatedText": "J'y ai en fait contribué dans un petit chapitre avec des réflexions sur la question de savoir si les mathématiques sont inventées ou découvertes.",
+    "translatedText": "Et j’y ai d’ailleurs écrit un petit chapitre sur la question d’est-ce que les maths ont été plutôt inventées ou découvertes.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1237.04,
     "end": 1241.82
   },
   {
     "input": "And the book as a whole is this really nice connection of thought-provoking paradoxical things ranging from philosophy to math and physics.",
-    "translatedText": "Et le livre dans son ensemble est cette connexion vraiment agréable de choses paradoxales qui suscitent la réflexion, allant de la philosophie aux mathématiques et à la physique.",
+    "translatedText": "Et le livre tisse un lien entre différents concepts paradoxaux qui vous feront réfléchir, en passant par la philosophie, les maths et ou la physique.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1242.3,
     "end": 1248.4
   },
   {
-    "input": "You can, of course, find all the details in the description. .",
-    "translatedText": "Vous pouvez bien entendu retrouver tous les détails dans la description.",
+    "input": "You can, of course, find all the details in the description.",
+    "translatedText": "Vous pouvez retrouver tous les détails dans la description.",
     "model": "google_nmt",
-    "n_reviews": 0,
+    "n_reviews": 1,
     "start": 1248.82,
     "end": 1251.04
   }

--- a/2020/better-bayes/french/sentence_translations.json
+++ b/2020/better-bayes/french/sentence_translations.json
@@ -1,1578 +1,1578 @@
 [
-  {
-    "input": "Some of you may have heard this paradoxical fact about medical tests.",
-    "translatedText": "Vous avez peut-être déjà entendu parler d’un paradoxe concernant les tests de dépistage.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 0,
-    "end": 3.14
-  },
-  {
-    "input": "It's very commonly used to introduce the topic of Bayes' rule in probability.",
-    "translatedText": "C'est un exemple couramment utilisé pour présenter le théorème de Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 3.58,
-    "end": 6.74
-  },
-  {
-    "input": "The paradox is that you could take a test which is highly accurate, in the sense that it gives correct results to a large majority of the people taking it.",
-    "translatedText": "Voici le paradoxe : il est possible qu’un test soit très précis, au sens où il fournit des résultats corrects pour la grande majorité des personnes testées.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 7.5,
-    "end": 15.66
-  },
-  {
-    "input": "And yet, under the right circumstances, when assessing the probability that your particular test result is correct, you can still land on a very low number, arbitrarily low, in fact.",
-    "translatedText": "Mais que, sous certaines conditions, le résultat de votre dépistage en particulier n’ait qu’une probabilité infime — voire arbitrairement faible — d’être correct.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 16.04,
-    "end": 26.3
-  },
-  {
-    "input": "In short, an accurate test is not necessarily a very predictive test.",
-    "translatedText": "En résumé, un test précis n’a pas forcément une grande valeur prédictive.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 26.78,
-    "end": 31.82
-  },
-  {
-    "input": "Now when people think about math and formulas, they don't often think of it as a design process.",
-    "translatedText": "Généralement, les gens ne voient pas vraiment les maths et les équations en tant que processus de conception.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 33.06,
-    "end": 37.44
-  },
-  {
-    "input": "I mean, maybe in the case of notation it's easy to see that different choices are possible, but when it comes to the structure of the formulas themselves and how we use them, that's something that people typically view as fixed.",
-    "translatedText": "Concernant les notations, on a évidemment le choix. Mais on pourrait avoir tendance à voir la structure des équations et la manière dont on les utilise comme quelque chose d’immuable.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 38.08,
-    "end": 49.68
-  },
-  {
-    "input": "In this video, you and I will dig into this paradox, but instead of using it to talk about the usual version of Bayes' rule, I'd like to motivate an alternate version, an alternate design choice.",
-    "translatedText": "Dans cette vidéo, nous allons expliciter ce paradoxe, mais au lieu de présenter le théorème de Bayes sous sa forme forme habituelle, j'aimerais en profiter pour proposer une formulation alternative, conçue différemment.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 50.68,
-    "end": 60.56
-  },
-  {
-    "input": "Now, what's up on the screen now is a little bit abstract, which makes it difficult to justify that there really is a substantive difference here, especially when I haven't explained either one yet.",
-    "translatedText": "Bon, pour l’instant, ce qui est à l'écran est un peu abstrait. Ce n’est pas évident de vous convaincre qu’il y a une différence notable, surtout que je n'ai pas encore expliqué les formules.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 61.66,
-    "end": 70.54
-  },
-  {
-    "input": "To see what I'm talking about though, we should really start by spending some time a little more concretely, and just laying out what exactly this paradox is.",
-    "translatedText": "Pour bien comprendre de quoi je parle, prenons le temps de regarder concrètement en quoi consiste le paradoxe.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 71.04,
-    "end": 78.1
-  },
-  {
-    "input": "Picture a thousand women and suppose that 1% of them have breast cancer.",
-    "translatedText": "Prenons 100 femmes, et supposons qu’1 % d’entre elles aient un cancer du sein.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 84.02,
-    "end": 87.94
-  },
-  {
-    "input": "And let's say they all undergo a certain breast cancer screening, and that 9 of those with cancer correctly get positive results, and there's one false negative.",
-    "translatedText": "Imaginons qu’elles passent toutes un certain type de dépistage, et que pour les 10 femmes ayant un cancer, 9 test sont des vrais positifs, et un faux négatif.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 88.68,
-    "end": 96.68
-  },
-  {
-    "input": "And then suppose that among the remainder without cancer, 89 get false positives, and 901 correctly get negative results.",
-    "translatedText": "Et supposons que pour les femmes restantes, 89 obtiennent des faux positifs et 901 obtiennent des vrais négatifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 97.48,
-    "end": 104.92
-  },
-  {
-    "input": "So if all you know about a woman is that she does the screening and she gets a positive result, you don't have information about symptoms or anything like that, you know that she's either one of these 9 true positives or one of these 89 false positives.",
-    "translatedText": "Donc, si une femme effectue ce dépistage et obtient un résultat positif, en l’absence d’information complémentaire comme des symptômes, vous savez qu'elle fait soit partie des 9 vrais positifs, soit des 89 faux positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 105.72,
-    "end": 118.26
-  },
-  {
-    "input": "So the probability that she's in the cancer group given the test result is 9 divided by 9 plus 89, which is approximately 1 in 11.",
-    "translatedText": "La probabilité qu’elle fasse partie du groupe des personnes ayant un cancer, étant donné le résultat du test, est de 9 divisé par 9 plus 89, soit environ 1 sur 11.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 119.36,
-    "end": 128.14
-  },
-  {
-    "input": "In medical parlance, you would call this the positive predictive value of the test, or PPV, the number of true positives divided by the total number of positive test results.",
-    "translatedText": "Dans la terminologie médicale, on appelle ça la valeur prédictive positive du test (PPV), le nombre de vrais positifs divisé par le nombre total de résultats de test positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 129.08,
-    "end": 138.62
-  },
-  {
-    "input": "You can see where the name comes from.",
-    "translatedText": "On comprend d'où vient le nom :",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 138.62,
-    "end": 140.44
-  },
-  {
-    "input": "To what extent does a positive test result actually predict that you have the disease?",
-    "translatedText": "Dans quelle mesure un résultat de test positif prédit-il réellement que vous souffrez de la maladie?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 140.74,
-    "end": 145.36
-  },
-  {
-    "input": "Now, hopefully, as I've presented it this way where we're thinking concretely about a sample population, all of this makes perfect sense.",
-    "translatedText": "J'espère qu’en utilisant cet exemple concret d’un échantillon de 100 personnes, tout ça est clair.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 146.82,
-    "end": 153.46
-  },
-  {
-    "input": "But where it comes across as counterintuitive is if you just look at the accuracy of the test, present it to people as a statistic, and then ask them to make judgments about their test result.",
-    "translatedText": "Mais là où ça devient contre-intuitif, c’est que si vous prenez la performance du test, que vous la présentez aux gens sous forme de chiffre, et que vous leur demandez de réagir au résultat de leur test.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 153.96,
-    "end": 163.2
-  },
-  {
-    "input": "Test accuracy is not actually one number, but two.",
-    "translatedText": "La performance d’un test se mesure en fait avec deux chiffres.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 164.02,
-    "end": 166.26
-  },
-  {
-    "input": "First, you ask how often is the test correct on those with the disease.",
-    "translatedText": "D’abord, on veut savoir pour quelle proportion des personnes atteintes de la maladie le test est positif.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 166.26,
-    "end": 171.12
-  },
-  {
-    "input": "This is known as the test sensitivity, as in how sensitive is it to detecting the presence of the disease.",
-    "translatedText": "C’est ce qu’on appelle la sensibilité du test, c’est-à-dire : quelle est sa sensibilité pour détecter la présence de la maladie ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 171.7,
-    "end": 177.44
-  },
-  {
-    "input": "In our example, test sensitivity is 9 in 10, or 90%.",
-    "translatedText": "Dans notre exemple, la sensibilité du test est de 9 sur 10, soit 90 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 178.26,
-    "end": 181.26
-  },
-  {
-    "input": "And another way to say the same fact would be to say the false negative rate is 10 %.",
-    "translatedText": "Et une autre façon de dire la même chose serait de dire que le taux de faux négatifs est de 10 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 182.02,
-    "end": 186.68
-  },
-  {
-    "input": "And then a separate, not necessarily related number is how often it's correct for those without the disease, which is known as the test specificity, as in are positive results caused specifically by the disease, or are there confounding triggers giving false positives.",
-    "translatedText": "Un autre chiffre, pas nécessairement lié, est la fréquence à laquelle le test est correct pour les personnes non atteintes de la maladie. C’est ce que l'on appelle la spécificité du test : les résultats positifs sont-ils causés spécifiquement par la maladie, ou y a-t-il des facteurs de confusion entraînant des faux positifs ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 186.68,
-    "end": 202.06
-  },
-  {
-    "input": "In our example, the specificity is about 91%.",
-    "translatedText": "Dans notre exemple, la spécificité est d'environ 91 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 203.08,
-    "end": 206.58
-  },
-  {
-    "input": "Or another way to say the same fact would be to say the false positive rate is 9%.",
-    "translatedText": "Une autre manière de le dire est que le taux de faux positifs est de 9 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 206.58,
-    "end": 211.66
-  },
-  {
-    "input": "So the paradox here is that in one sense, the test is over 90% accurate.",
-    "translatedText": "Le paradoxe ici est donc que, d’un côté, le test est précis à plus de 90 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 211.66,
-    "end": 216.76
-  },
-  {
-    "input": "It gives correct results to over 90% of the patients who take it.",
-    "translatedText": "Il donne des résultats corrects à plus de 90 % des patients qui se font dépister.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 217.02,
-    "end": 220.66
-  },
-  {
-    "input": "And yet, if you learn that someone gets a positive result without any added information, there's actually only a 1 in 11 chance that that particular result is accurate.",
-    "translatedText": "Mais pourtant, si vous apprenez qu’une personne obtient un résultat positif sans détenir aucune information supplémentaire, il n’y a en réalité qu’une chance sur 11 pour que ce résultat particulier soit exact.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 220.66,
-    "end": 229.6
-  },
-  {
-    "input": "This is a bit of a problem, because of all of the places for math to be counterintuitive, medical tests are one area where it matters a lot.",
-    "translatedText": "C'est embêtant, car cela peut particulièrement impacter la lecture des résultats des dépistages.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 230.62,
-    "end": 237.18
-  },
-  {
-    "input": "In 2006 and 2007, the psychologist Gerd Gigerenzer gave a series of statistics seminars to practicing gynecologists, and he opened with the following example.",
-    "translatedText": "Entre 2006 et 2007, le psychologue Gerd Gigerenzer a donné une série de séminaires de statistiques à des gynécologues en activité, qu’il commençait avec l'exemple suivant :",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 237.94,
-    "end": 246.8
-  },
-  {
-    "input": "A 50-year-old woman, no symptoms, participates in a routine mammography screening.",
-    "translatedText": "Une femme de 50 ans, sans symptômes, effectue un dépistage de routine par mammographie.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 246.8,
-    "end": 251.74
-  },
-  {
-    "input": "She tests positive, is alarmed, and wants to know from you whether she has breast cancer for certain or what her chances are.",
-    "translatedText": "Son test est positif. Elle est inquiète et veut savoir s'il est certain qu’elle a un cancer du sein, ou quel est le risque que ce soit le cas.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 252.28,
-    "end": 258.38
-  },
-  {
-    "input": "Apart from the screening result, you know nothing else about this woman.",
-    "translatedText": "Hormis le résultat du dépistage, vous ne savez rien d’autre sur cette femme.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 258.88,
-    "end": 261.74
-  },
-  {
-    "input": "In that seminar, the doctors were then told that the prevalence of breast cancer for women of this age is about 1%, and then to suppose that the test sensitivity is 90% and that its specificity was 91%.",
-    "translatedText": "Les informations suivantes ont ensuite été données à l’audience : la prévalence du cancer du sein chez les femmes de cet âge est d'environ 1 %, et vous pouvez supposer que la sensibilité du test est de 90 % et que sa spécificité est de 91 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 262.58,
-    "end": 274.18
-  },
-  {
-    "input": "You might notice these are exactly the same numbers from the example that you and I just looked at.",
-    "translatedText": "Vous aurez peut-être remarqué que ce sont exactement les mêmes chiffres que précédemment.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 274.18,
-    "end": 278.18
-  },
-  {
-    "input": "This is where I got them.",
-    "translatedText": "C'est de là que je les tiens.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 278.36,
-    "end": 279.44
-  },
-  {
-    "input": "So, having already thought it through, you and I know the answer.",
-    "translatedText": "Vu qu’on vient juste d’y réfléchir, on connaît déjà la réponse.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 279.76,
-    "end": 282.6
-  },
-  {
-    "input": "It's about 1 in 11.",
-    "translatedText": "C'est environ 1 sur 11.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 282.88,
-    "end": 283.84
-  },
-  {
-    "input": "However, the doctors in this session were not primed with the suggestion to picture a concrete sample of a thousand individuals, the way that you and I had.",
-    "translatedText": "En revanche, on n’a pas proposé aux médecins présents lors de ces séminaires d’imaginer un échantillon de population concret comme on l’a fait ici.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 284.6,
-    "end": 291.54
-  },
-  {
-    "input": "All they saw were these numbers.",
-    "translatedText": "Tout ce qu’ils voyaient, c’était des chiffres.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 292.04,
-    "end": 293.34
-  },
-  {
-    "input": "They were then asked, how many women who test positive actually have breast cancer?",
-    "translatedText": "On leur a ensuite demandé combien de femmes dont le test était positif avaient réellement un cancer du sein ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 294.14,
-    "end": 298.42
-  },
-  {
-    "input": "What is the best answer?",
-    "translatedText": "Quelle est la meilleure réponse ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 298.62,
-    "end": 299.74
-  },
-  {
-    "input": "And they were presented with these four choices.",
-    "translatedText": "Parmi ces quatre propositions.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 299.9,
-    "end": 301.68
-  },
-  {
-    "input": "In one of the sessions, over half the doctors present said that the correct answer was 9 in 10, which is way off.",
-    "translatedText": "Au cours d’un des séminaires, plus de la moitié des médecins on proposé la réponse « 9 sur 10 », ce qui est très loin de la bonne réponse.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 301.68,
-    "end": 309.3
-  },
-  {
-    "input": "Only a fifth of them gave the correct answer, which is worse than what it would have been if everybody had randomly guessed.",
-    "translatedText": "Seul un cinquième d’entre eux ont donné la bonne réponse, ce qui est pire que si tout le monde avait voté au hasard.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 310.02,
-    "end": 315.38
-  },
-  {
-    "input": "It might seem a little extreme to be calling this a paradox.",
-    "translatedText": "Ça peut sembler un peu exagéré d’appeler ça un paradoxe.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 316.66,
-    "end": 319.28
-  },
-  {
-    "input": "I mean, it's just a fact.",
-    "translatedText": "En réalité, c'est juste un fait.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 319.76,
-    "end": 321.14
-  },
-  {
-    "input": "It's not something intrinsically self-contradictory.",
-    "translatedText": "Ce n’est pas intrinsèquement contradictoire.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 321.26,
-    "end": 323.5
-  },
-  {
-    "input": "But, as these seminars with Gigerenzer show, people, including doctors, definitely find it counterintuitive that a test with high accuracy can give you such a low predictive value.",
-    "translatedText": "Mais comme le montrent les séminaires de Gigerenzer, les gens, y compris les médecins, trouvent clairement contre-intuitif qu’un test d’une grande performance puisse fournir une valeur prédictive aussi faible.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 324.2,
-    "end": 334.24
-  },
-  {
-    "input": "We might call this a veridical paradox, which refers to facts that are provably true, but which nevertheless can feel false when phrased a certain way.",
-    "translatedText": "Nous pourrions appeler ça un « paradoxe véridique », qui fait référence à des faits dont la vérité est avérée, mais qui peuvent néanmoins sembler faux lorsqu’ils sont formulés d’une certaine manière.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 335.2,
-    "end": 343.8
-  },
-  {
-    "input": "It's sort of the softest form of a paradox, saying more about human psychology than about logic.",
-    "translatedText": "C’est un peu comme une version attenué d’un paradoxe, qui en dit plus sur la psychologie humaine que sur la logique.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 344.3,
-    "end": 348.72
-  },
-  {
-    "input": "The question is how we can combat this.",
-    "translatedText": "La question c’est : comment lutter contre ça ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 349.58,
-    "end": 351.98
-  },
-  {
-    "input": "Where we're going with this, by the way, is that I want you to be able to look at numbers like this and quickly estimate in your head that it means the predictive value of a positive test should be around 1 in 11.",
-    "translatedText": "Dans l’idée, j’aimerais que vous puissiez regarder ce genre de chiffres et rapidement estimer de tête que la valeur prédictive associée pour un test positif est d'à-peu-près 1 sur 11.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 353.8,
-    "end": 364.14
-  },
-  {
-    "input": "Or, if I changed things and asked, what if it was 10% of the population who had breast cancer?",
-    "translatedText": "Et si je modifie les valeurs, et vous demande ce qu’il en serait si la prévalence du cancer du sein était de 10 %",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 364.76,
-    "end": 369.72
-  },
-  {
-    "input": "You should be able to quickly turn around and say that the final answer would be a little over 50%.",
-    "translatedText": "Vous devriez pouvoir rapidement modifier votre réponse et me dire que la valeur prédictive serait d'un peu plus que 50 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 370.12,
-    "end": 374.98
-  },
-  {
-    "input": "Or, if I said imagine a really low prevalence, something like 0.1% of patients having cancer, you should again quickly estimate that the predictive value of the test is around 1 in 100,",
-    "translatedText": "Ou, disons que je vous donne une prévalence très faible, comme 0,1 % de patients atteints de cancer, vous devriez là encore pouvoir estimer rapidement que la valeur prédictive du test est d'environ 1 sur 100.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 375.92,
-    "end": 386.14
-  },
-  {
-    "input": "that 1 in 100 of those with positive test results in that case would have cancer.",
-    "translatedText": "C’est-à-dire qu’une personne sur 100 avec des résultats positifs aurait un cancer.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 386.76,
-    "end": 390.6
-  },
-  {
-    "input": "Or, let's say we go back to the 1% prevalence, but I make the test more accurate.",
-    "translatedText": "Ou, en revenant à une prévalence de 1 %, mais en rendant le test plus précis.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 391.58,
-    "end": 395.24
-  },
-  {
-    "input": "I tell you to imagine the specificity is 99%.",
-    "translatedText": "Imaginons que la spécificité soit de 99 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 395.44,
-    "end": 398.4
-  },
-  {
-    "input": "There, you should be able to relatively quickly estimate that the answer is a little less than 50%.",
-    "translatedText": "Là, vous devriez pouvoir estimer assez rapidement que la réponse est un peu inférieure à 50 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 398.4,
-    "end": 403.8
-  },
-  {
-    "input": "The hope is that you're doing all of this with minimal calculations in your head.",
-    "translatedText": "Le but est que vous puissiez faire tout ça de tête, avec un minimum de calculs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 404.32,
-    "end": 407.74
-  },
-  {
-    "input": "Now, the goals of quick calculations might feel very different from the goals of addressing whatever misconception underlies this paradox, but they actually go hand in hand.",
-    "translatedText": "L’objectif de ces estimations rapides pourrait sembler très différent du fait de corriger les idées qui sous-tendent ce paradoxe, mais les deux sont liés.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 408.54,
-    "end": 416.5
-  },
-  {
-    "input": "Let me show you what I mean.",
-    "translatedText": "Regardons ça plus en détail.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 416.9,
-    "end": 417.68
-  },
-  {
-    "input": "On the side of addressing misconceptions, what would you tell to the people in that seminar who answered 9 and 10?",
-    "translatedText": "Du côté des idées erronnées, qu’auriez-vous envie de dire aux médecins qui ont répondu « 9 sur 10 » lors de la conférence ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 418.46,
-    "end": 423.98
-  },
-  {
-    "input": "What fundamental misconception are they revealing?",
-    "translatedText": "En quoi leur raisonnement est-il fondamentalement faux ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 424.48,
-    "end": 426.9
-  },
-  {
-    "input": "What I might tell them is that in much the same way that you shouldn't think of tests as telling you deterministically whether you have a disease, you shouldn't even think of them as telling you your chances of having a disease.",
-    "translatedText": "On pourrait leur dire que, de la même manière qu’on ne devrait pas considérer que les tests peuvent déterminer si quelqu’un est malade ou pas, on ne devrait même pas considérer qu’ils nous donnent le risque que cette personne soit malade.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 428.18,
-    "end": 438.6
-  },
-  {
-    "input": "Instead, the healthy view of what tests do is that they update your chances.",
-    "translatedText": "Une description plus exacte est que les test nous permettent de mettre à jour nos estimations.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 439.56,
-    "end": 444.46
-  },
-  {
-    "input": "In our example, before taking the test, a patient's chances of having cancer were 1 in 100.",
-    "translatedText": "Dans notre exemple, avant de passer le test, le risque d’avoir un cancer était de 1 sur 100.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 446.04,
-    "end": 450.68
-  },
-  {
-    "input": "In Bayesian terms, we call this the prior probability.",
-    "translatedText": "En termes bayésiens, on appelle ça la probabilité a priori.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 451.12,
-    "end": 453.64
-  },
-  {
-    "input": "The effect of this test was to update that prior by almost an order of magnitude, up to around 1 in 11.",
-    "translatedText": "L’effet de ce test a été de mettre à jour cet a priori par quasiment un facteur 10, à 1 sur 11.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 454.38,
-    "end": 460.36
-  },
-  {
-    "input": "The accuracy of a test is telling us about the strength of this updating.",
-    "translatedText": "La performance d’un test se traduit dans la taille de cette mise à jour.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 461.02,
-    "end": 464.82
-  },
-  {
-    "input": "It's not telling us a final answer.",
-    "translatedText": "Elle ne nous donne pas de réponse définitive.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 465.12,
-    "end": 466.74
-  },
-  {
-    "input": "What does this have to do with quick approximations?",
-    "translatedText": "Du coup, quel rapport avec nos estimations rapides ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 467.9,
-    "end": 469.64
-  },
-  {
-    "input": "Well, a key number for those approximations is something called the Bayes factor, and the very act of defining this number serves to reinforce this central lesson about reframing what it is the tests do.",
-    "translatedText": "Eh bien, un élément clé pour ces estimations est ce qu’on appelle le facteur de Bayes. Et le fait même de définir ce nombre vient consolider notre compréhension de ce que disent réellement les tests.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 470.3,
-    "end": 481.4
-  },
-  {
-    "input": "You see, one of the things that makes test statistics so very confusing is that there are at least 4 numbers that you'll hear associated with them.",
-    "translatedText": "Une des choses qui génère de la confusion concernant la performance des tests est qu’on parle généralement d’au moins 4 chiffres différents. ",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 482.42,
-    "end": 488.9
-  },
-  {
-    "input": "For those with the disease, there's the sensitivity and the false negative rate, and then for those without, there's the specificity and the false positive rate, and none of these numbers actually tell you the thing you want to know.",
-    "translatedText": "La sensibilité et le taux de faux négatifs pour les personnes atteintes de la maladie ; la spécificité et le taux de faux positifs pour celles qui ne le sont pas. Mais aucun de ces chiffres ne nous dit vraiment ce qu’on veut savoir.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 488.9,
-    "end": 498.8
-  },
-  {
-    "input": "Luckily, if you want to interpret a positive test result, you can pull out just one number to focus on from all this.",
-    "translatedText": "Heureusement, si on veut interpréter un résultat de test positif, il y a un chiffre sur lequel on peut se concentrer.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 499.5,
-    "end": 505.62
-  },
-  {
-    "input": "Take the sensitivity divided by the false positive rate.",
-    "translatedText": "Prenez la sensibilité divisée par le taux de faux positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 506.04,
-    "end": 508.6
-  },
-  {
-    "input": "In other words, how much more likely are you to see the positive test result with cancer versus without?",
-    "translatedText": "Autrement dit, dans quelle mesure a-t-on plus de chances de voir un résultat de test positif entre un cas ayant un cancer et un cas sans ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 509.16,
-    "end": 514.74
-  },
-  {
-    "input": "In our example, this number is 10.",
-    "translatedText": "Dans notre exemple, ce nombre est égal à 10.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 514.74,
-    "end": 517.14
-  },
-  {
-    "input": "This is the Bayes factor, also sometimes called the likelihood ratio.",
-    "translatedText": "Il s’agit du facteur de Bayes, aussi parfois appelé rapport de vraisemblance.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 517.9,
-    "end": 521.72
-  },
-  {
-    "input": "A very handy rule of thumb is that to update a small prior, or at least to approximate the answer, you simply multiply it by the Bayes factor.",
-    "translatedText": "Voici une approximation très pratique pour mettre à jour une probabilité a priori lorsqu’elle est faible : il vous suffit de la multiplier par le facteur Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 523.1,
-    "end": 530.02
-  },
-  {
-    "input": "So in our example, where the prior was 1 in 100, you would estimate that the final answer should be around 1 in 10, which is in fact slightly above the true correct answer.",
-    "translatedText": "Avec une probabilité a priori de 1 sur 100, vous pouvez donc estimer que la probabilité a posteriori sera d'environ 1 sur 10, ce qui est effectivement légèrement au-dessus de la valeur réelle.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 530.76,
-    "end": 538.82
-  },
-  {
-    "input": "So based on this rule of thumb, if I asked you what would happen if the prior from our example was instead 1 in 1000, you could quickly estimate that the effect of the test should be to update those chances to around 1 in 100.",
-    "translatedText": "Donc, si je vous demande ce qui se passerait si la probabilité a priori de notre exemple était plutôt de 1 sur 1000, vous devriez pouvoir estimer rapidement que le résultat du test a pour conséquence de mettre à jour cette probabilité à environ 1 sur 100.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 539.4,
-    "end": 551.42
-  },
-  {
-    "input": "And in fact, take a moment to check yourself by thinking through a sample population.",
-    "translatedText": "Prenez donc un moment pour vérifier que vous avez bien compris en imaginant une population.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 552.36,
-    "end": 555.72
-  },
-  {
-    "input": "In this case, you might picture 10,000 patients where only 10 of them really have cancer.",
-    "translatedText": "Vous pourriez imaginer 10000 patients, parmi lesquels 10 d’entre eux sont atteints d’un cancer.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 556.7,
-    "end": 560.88
-  },
-  {
-    "input": "And then based on that 90% sensitivity, we would expect 9 of those cancer cases to give true positives.",
-    "translatedText": "Et, en partant sur une sensibilité de 90 %, on s’attend à ce que sur les 10 cas de cancer, 9 résultats de tests soient des vrais positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 562.14,
-    "end": 567.9
-  },
-  {
-    "input": "And on the other side, a 91% specificity means that 9% of those without cancer are getting false positives.",
-    "translatedText": "D’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des résultats faux positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 569,
-    "end": 575.76
-  },
-  {
-    "input": "So we'd expect 9% of the remaining patients, which is around 900, to give false positive results.",
-    "translatedText": "On s’attend donc à ce que 9 % des patients restants, soit environ 900, aient des résultats faussement positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 576.66,
-    "end": 581.86
-  },
-  {
-    "input": "Here, with such a low prevalence, the false positives really do dominate the true positives.",
-    "translatedText": "Ici, avec une prévalence aussi faible, les faux positifs dominent vraiment les vrais positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 582.7,
-    "end": 587.82
-  },
-  {
-    "input": "So the probability that a randomly chosen positive case from this population actually has cancer is only around 1%, just like the rule of thumb predicted.",
-    "translatedText": "Donc, la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédisait l’approximation.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 587.9,
-    "end": 597.02
-  },
-  {
-    "input": "Now, this rule of thumb clearly cannot work for higher priors.",
-    "translatedText": "Or, cette approximation ne fonctionne clairement pas pour des valeurs d’a priori plus élevées.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 598.7,
-    "end": 601.92
-  },
-  {
-    "input": "For example, it would predict that a prior of 10% gets updated all the way to 100% certainty.",
-    "translatedText": "Par exemple, elle prédirait qu'un a priori de 10 % serait mis à jour vers une valeur de 100 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 602.42,
-    "end": 607.86
-  },
-  {
-    "input": "But that can't be right.",
-    "translatedText": "Mais ça n’a pas de sens.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 608.36,
-    "end": 609.32
-  },
-  {
-    "input": "In fact, take a moment to think through what the answer should be, again, using a sample population.",
-    "translatedText": "Prenons un moment pour réfléchir à ce que devrait être la vraie valeur, en utilisant toujours une population fictive.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 610.02,
-    "end": 614.5
-  },
-  {
-    "input": "Maybe this time we picture 10 out of 100 having cancer.",
-    "translatedText": "Cette fois, imaginons que 10 personnes sur 100 ont un cancer.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 615.06,
-    "end": 617.86
-  },
-  {
-    "input": "Again, based on the 90% sensitivity of the test, we'd expect 9 of those true cancer cases to get positive results.",
-    "translatedText": "De nouveau, en prenant une sensibilité de 90 % du test, nous nous attendons à ce que 9 des véritables cas de cancer fournissent des résultats positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 618.54,
-    "end": 624.92
-  },
-  {
-    "input": "But what about the false positives?",
-    "translatedText": "Mais concernant les faux positifs,",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 624.92,
-    "end": 626.6
-  },
-  {
-    "input": "How many do we expect there?",
-    "translatedText": "Combien va-t-on en trouver ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 626.98,
-    "end": 628.1
-  },
-  {
-    "input": "About 9% of the remaining 90. About 8.",
-    "translatedText": "Environ 9 % des 90 restants, soit environ 8.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 629.88,
-    "end": 632.62
-  },
-  {
-    "input": "So, upon seeing a positive test result, it tells you that you're either one of these 9 true positives or one of the 8 false positives.",
-    "translatedText": "Donc, quand vous voyez un résultat de test positif, vous avez devant vous soit l'un des 9 vrais positifs, soit l'un des 8 faux positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 633.82,
-    "end": 641.14
-  },
-  {
-    "input": "So this means the chances are a little over 50%, roughly 9 out of 17, or 53%.",
-    "translatedText": "On a donc un peu plus d’une chance sur deux. 9 sur 17, soit à peu près 53 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 641.86,
-    "end": 646.92
-  },
-  {
-    "input": "At this point, having dared to dream that Bayesian updating could look as simple as multiplication, you might tear down your hopes and pragmatically acknowledge that sometimes life is just more complicated than that.",
-    "translatedText": "À ce stade, tout espoir que cette mise à jour bayésienne puisse être aussi simple qu’une multiplication à l’air perdu, et on se dit que parfois ce n’est pas aussi simple qu’on aimerait.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 648.02,
-    "end": 657.7
-  },
-  {
-    "input": "Except it's not.",
-    "translatedText": "Sauf que ce n'est pas le cas !",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 659.92,
-    "end": 661.12
-  },
-  {
-    "input": "This rule of thumb turns into a precise mathematical fact as long as we shift away from talking about probabilities to instead talking about odds.",
-    "translatedText": "Cette approximation peut devenir exacte, à condition que l’on ne considère plus des probabilités, mais des cotes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 661.62,
-    "end": 669
-  },
-  {
-    "input": "If you've ever heard someone talk about the chances of an event being 1 to 1 or 2 to 1, things like that, you already know about odds.",
-    "translatedText": "Si vous avez déjà entendu quelqu'un dire quelque chose comme : « 1 pour 1 », ou « à 2 contre 1 », vous savez déjà ce que c’est qu’une cote.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 670.32,
-    "end": 677.06
-  },
-  {
-    "input": "With probability, we're taking the ratio of the number of positive cases out of all possible cases, right?",
-    "translatedText": "Pour une probabilité, on prend le rapport entre le nombre de cas positifs et l’ensemble des cas.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 677.06,
-    "end": 683.06
-  },
-  {
-    "input": "Things like 1 in 5 or 1 in 10.",
-    "translatedText": "Par exemple 1 sur 5, ou 1 sur 10.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 683.4,
-    "end": 685.28
-  },
-  {
-    "input": "With odds, what you do is take the ratio of all positive cases to all negative cases.",
-    "translatedText": "Avec les cotes, on fait le rapport entre tous les cas positifs et tous les cas négatifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 685.88,
-    "end": 690.32
-  },
-  {
-    "input": "You commonly see odds written with a colon to emphasize the distinction, but it's still just a fraction, just a number.",
-    "translatedText": "Généralement, on note les cotes en utilisant deux points pour les distinguer d’une probabilité, mais ça reste bien une fraction, un nombre.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 691.54,
-    "end": 697.06
-  },
-  {
-    "input": "So an event with a 50% probability would be described as having 1 to 1 odds. A 10% probability is the same as 1 to 9 odds. An 80% probability is the same as 4 to 1 odds. You get the point.",
-    "translatedText": "Du coup, un événement avec une probabilité de 50 % a une cote de 1 pour 1, une probabilité de 10 % équivaut à une cote de 1 pour 9, une probabilité de 80 %, une cote de 4 pour 1. Vous voyez l’idée.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 697.94,
-    "end": 710.46
-  },
-  {
-    "input": "It's the same information. It still describes the chances of a random event, but it's presented a little differently, like a different unit system.",
-    "translatedText": "C'est la même information : on décrit toujours les chances qu'un événement aléatoire se produise, mais avec une échelle un peu différente.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 711.48,
-    "end": 718.34
-  },
-  {
-    "input": "Probabilities are constrained between 0 and 1, with even chances sitting at 0.5.",
-    "translatedText": "Une probabilité est un nombre entre 0 et 1. On a autant de chances d’avoir un résultat que l’autre à 0,5.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 719.32,
-    "end": 723.68
-  },
-  {
-    "input": "But odds range from 0 up to infinity, with even chances sitting at the number 1.",
-    "translatedText": "Mais une cote va de 0 à l’infini, et un partage équitable des chances se situe alors à 1.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 724.8,
-    "end": 729.54
-  },
-  {
-    "input": "The beauty here is that a completely accurate, not even approximating things way to frame Bayes' rule is to say, express your prior using odds, and then just multiply by the Bayes' factor.",
-    "translatedText": "Ce qui est beau ici, c’est que cette description du théorème de Bayes est tout à fait exacte : écrivez votre a priori comme une cote, et multipliez le simplement par le facteur de Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 731.88,
-    "end": 742.36
-  },
-  {
-    "input": "Think about what the prior odds are really saying.",
-    "translatedText": "Réfléchissez à ce que veut vraiment dire une cote a priori.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 743.44,
-    "end": 745.22
-  },
-  {
-    "input": "It's the number of people with cancer divided by the number without it.",
-    "translatedText": "C'est le nombre de personnes malades divisé par le nombre de personnes saines.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 745.58,
-    "end": 749.26
-  },
-  {
-    "input": "Here, let's just write that down as a normal fraction for a moment so we can multiply it.",
-    "translatedText": "Mettons-le sous forme de fraction pour pouvoir le multiplier.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 749.7,
-    "end": 753.36
-  },
-  {
-    "input": "When you filter down just to those with positive test results, the number of people with cancer gets scaled down, scaled down by the probability of seeing a positive test result given that someone has cancer.",
-    "translatedText": "Si on ne regarde que les personnes ayant un test positif, l’ensemble de celles qui ont un cancer a diminué par rapport au groupe initial d’un facteur égal à la probabilité d’obtenir un test positif pour une personne malade.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 753.36,
-    "end": 764.42
-  },
-  {
-    "input": "And then similarly, the number of people without cancer also gets scaled down, this time by the probability of seeing a positive test result, but in that case.",
-    "translatedText": "De la même manière, l’ensemble des personnes saines a également diminué, mais cette fois par un facteur égal à la probabilité qu’une personne saine obtienne un résultat positif.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 765.12,
-    "end": 773.44
-  },
-  {
-    "input": "So the ratio between these two counts, the new odds upon seeing the test, looks just like the prior odds except multiplied by this term here, which is exactly the Bayes' factor.",
-    "translatedText": "Le rapport des effectifs de ces groupes, qui est la nouvelle cote a posteriori, a la même forme que la cote pre-tests, mais multipliée par ce terme, qui est précisément le facteur de Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 774.18,
-    "end": 784.76
-  },
-  {
-    "input": "Look back at our example, where the Bayes' factor was 10.",
-    "translatedText": "Reprenons notre exemple, où le facteur de Bayes était de 10.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 787.8,
-    "end": 790.5
-  },
-  {
-    "input": "And as a reminder, this came from the 90% sensitivity divided by the 9% false positive rate.",
-    "translatedText": "Qu’on peut calculer, pour rappel, comme le rapport d’une sensibilité de 90 % sur un taux de faux positifs de 9 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 791,
-    "end": 796.56
-  },
-  {
-    "input": "How much more likely are you to see a positive result with cancer versus without?",
-    "translatedText": "Quand est-ce plus probable d’avoir un résultat positif pour une personne malade plutôt que saine ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 796.88,
-    "end": 800.74
-  },
-  {
-    "input": "If the prior is 1%, expressed as odds, this looks like 1 to 99.",
-    "translatedText": "Si l'a priori est de 1 %, ça nous donne une cote de 1 pour 99.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 801.72,
-    "end": 805.94
-  },
-  {
-    "input": "So by our rule, this gets updated to 10 to 99, which if you want you could convert back to a probability.",
-    "translatedText": "Donc, d’après notre règle, la cote est mise à jour à 10 pour 99. Et vous pouvez la reconvertir en probabilité au besoin.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 806.9,
-    "end": 813.4
-  },
-  {
-    "input": "It would be 10 divided by 10 plus 99, or about 1 in 11.",
-    "translatedText": "Ça nous donnerait 10 divisé par 10 plus 99, soit environ 1 sur 11.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 813.66,
-    "end": 817.22
-  },
-  {
-    "input": "If instead, the prior was 10%, which was the example that tripped up our rule of thumb earlier, expressed as odds, this looks like 1 to 9.",
-    "translatedText": "Si l'a priori était plutôt de 10 %, comme dans l’exemple qui faisait dérailler notre approximation tout à l’heure, on aurait une cote de 1 pour 9.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 818.2,
-    "end": 826.26
-  },
-  {
-    "input": "By our simple rule, this gets updated to 10 to 9, which you can already read off pretty intuitively.",
-    "translatedText": "D’après notre règle, cette cote passe à 10 pour 9, que vous pouvez déjà interpréter de manière assez intuitive.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 826.94,
-    "end": 832.44
-  },
-  {
-    "input": "It's a little above even chances, a little above 1 to 1.",
-    "translatedText": "C'est un peu au-dessus d’un partage équitable des chances, un peu au-dessus de 1 pour 1.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 832.44,
-    "end": 835.66
-  },
-  {
-    "input": "If you prefer, you can convert it back to a probability.",
-    "translatedText": "Si vous préférez, on peut reconvertir cette cote en probabilité.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 836.34,
-    "end": 838.84
-  },
-  {
-    "input": "You would write it as 10 out of 19, or about 53%.",
-    "translatedText": "Ça nous donnerait 10 sur 19, soit environ 53 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 839.18,
-    "end": 843.28
-  },
-  {
-    "input": "And indeed, that is what we already found by thinking things through with a sample population.",
-    "translatedText": "Et c’est d’ailleurs ce qu’on avait déjà trouvé en réfléchissant à notre population fictive.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 843.28,
-    "end": 847.22
-  },
-  {
-    "input": "Let's say we go back to the 1% prevalence, but I make the test more accurate.",
-    "translatedText": "Disons qu’on reprend une prévalence de 1 %, mais que le test est plus précis.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 848.3,
-    "end": 851.7
-  },
-  {
-    "input": "Now what if I told you to imagine that the false positive rate was only 1% instead of 9%?",
-    "translatedText": "Imaginons maintenant que le taux de faux positifs n’est que de 1 %, plutôt que 9 %",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 852.06,
-    "end": 856.64
-  },
-  {
-    "input": "What that would mean is that our Bayes factor is 90 instead of 10.",
-    "translatedText": "Ça voudrait dire que notre facteur de Bayes est de 90 au lieu de 10.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 857.12,
-    "end": 860.52
-  },
-  {
-    "input": "The test is doing more work for us.",
-    "translatedText": "Le test nous aide plus.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 860.84,
-    "end": 862.46
-  },
-  {
-    "input": "In this case, with the more accurate test, it gets updated to 90 to 99, which is a little less than even chances, something a little under 50%.",
-    "translatedText": "Dans ce cas, avec un test plus précis, la cote se déplace à 90 pour 99, ce qui est un peu moins que 50 % de chances.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 863.16,
-    "end": 871.58
-  },
-  {
-    "input": "To be more precise, you could make the conversion back to probability and work out that it's around 48%.",
-    "translatedText": "Plus précisément, on peut la convertir en probabilité et trouver qu'elle est à peu près égale à 48 %.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 871.58,
-    "end": 877.56
-  },
-  {
-    "input": "But honestly, if you're just going for a gut feel, it's fine to stick with the odds.",
-    "translatedText": "Mais honnêtement, si vous voulez juste vous faire une idée, une cote est amplement suffisante.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 877.56,
-    "end": 881.4
-  },
-  {
-    "input": "Do you see what I mean about how just defining this number helps to combat potential misconceptions?",
-    "translatedText": "Est-ce que vous voyez le rapport entre la simple définition de ce facteur et le fait d’éviter d’éventuelles confusions ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 882.22,
-    "end": 887.44
-  },
-  {
-    "input": "For anybody who's a little hasty in connecting test accuracy directly to your probability of having a disease, it's worth emphasizing that you could administer the same test with the same accuracy to multiple different patients who all get the same exact result, but if they're coming from different contexts, that result can mean wildly different things.",
-    "translatedText": "Si une personne est tentée d’associer un peu trop vite le résultat d’un test à la probabilité d’avoir une maladie, on peut lui montrer qu’il est possible de faire passer exactement le même test, avec la même précision, à plusieurs patients différents, que ces patients obtiennent tous exactement le même résultat. Pourtant, en fonction du contexte, ces résultats peuvent signifier des choses incroyablement différentes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 888.24,
-    "end": 906.72
-  },
-  {
-    "input": "However, the one thing that does stay constant in every case is the factor by which each patient's prior odds get updated.",
-    "translatedText": "Par contre, la seule chose qui ne change pas entre tous ces cas, c'est le facteur par lequel les cotes a priori de chaque patient sont mises à jour.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 906.72,
-    "end": 914.66
-  },
-  {
-    "input": "And by the way, this whole time we've been using the prevalence of the disease, which is the proportion of people in a population who have it, as a substitute for the prior, the probability of having it before you see a test.",
-    "translatedText": "Et d'ailleurs, on a choisi comme probabilité a priori la prévalence de la maladie depuis tout à l’heure. C'est-à-dire la proportion de personnes malades au sein de la population.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 916.3,
-    "end": 926.88
-  },
-  {
-    "input": "However, that's not necessarily the case.",
-    "translatedText": "Mais ce n’est pas forcément toujours le cas.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 927.52,
-    "end": 929.46
-  },
-  {
-    "input": "If there are other known factors, things like symptoms, or in the case of a contagious disease, things like known contacts, those also factor into the prior, and they could potentially make a huge difference.",
-    "translatedText": "Si on connaît d’autres éléments, comme par exemple les symptômes, ou, dans le cas d'une maladie contagieuse, les personnes contact, ceux-ci peuvent être pris en compte dans l’a priori et potentiellement faire une énorme différence.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 929.78,
-    "end": 939.86
-  },
-  {
-    "input": "As another side note, so far we've only talked about positive test results, but way more often you would be seeing a negative test result.",
-    "translatedText": "Par ailleurs, jusqu'ici, on n’a parlé que de résultats de tests positifs, mais on observe bien plus de résultats négatifs en pratique.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 940.76,
-    "end": 947.46
-  },
-  {
-    "input": "The logic there is completely the same, but the Bayes factor that you compute is going to look different.",
-    "translatedText": "La logique reste exactement la même, mais le facteur de Bayes que vous calculez aura une allure différente.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 948.1,
-    "end": 952.32
-  },
-  {
-    "input": "Instead, you look at the probability of seeing this negative test result with the disease versus without the disease.",
-    "translatedText": "À la place on regardera la probabilité d’obtenir un résultat de test négatif en présence de la maladie, et (au contraire) en son absence.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 952.76,
-    "end": 958.64
-  },
-  {
-    "input": "So in our cancer example, this would have been the 10% false negative rate divided by the 91% specificity, or about 1 in 9.",
-    "translatedText": "Du coup, dans notre exemple sur le cancer, ça aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 958.64,
-    "end": 967.04
-  },
-  {
-    "input": "In other words, seeing a negative test result in that example would reduce your prior odds by about an order of magnitude.",
-    "translatedText": "Autrement dit, observer un résultat de test négatif dans cet exemple réduirait la cote a priori d’environ un ordre de grandeur.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 967.78,
-    "end": 974.46
-  },
-  {
-    "input": "When you write it all out as a formula, here's how it looks.",
-    "translatedText": "Si on l’exprime sous la forme d’une équation, voilà à quoi ça ressemble.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 975.9,
-    "end": 978.42
-  },
-  {
-    "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the Bayes factor.",
-    "translatedText": "Elle nous dit que le risque d'avoir une maladie compte tenu du résultat d'un test est égal au risque estimé avant de passer le test, la cote a priori, multiplié par le facteur de Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 978.76,
-    "end": 986.96
-  },
-  {
-    "input": "Now let's contrast this with the usual way Bayes' rule is written, which is a bit more complicated.",
-    "translatedText": "On peut comparer ça avec la manière dont on présente habituellement le théorème de Bayes, qui est un peu plus compliquée.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 986.96,
-    "end": 992.26
-  },
-  {
-    "input": "In case you haven't seen it before, it's essentially just what we were doing with sample populations, but you wrap it all up symbolically.",
-    "translatedText": "Si vous ne l’avez jamais vue, ça revient essentiellement à ce qu’on a fait avec nos populations fictives, mais exprimé de manière symbolique.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 993.06,
-    "end": 998.78
-  },
-  {
-    "input": "Remember how every time we were counting the number of true positives and then dividing it by the sum of the true positives and the false positives?",
-    "translatedText": "Vous vous souvenez qu’à chaque fois, on prenait le nombre de vrais positifs et qu’on le divisait par la somme des vrais positifs et des faux positifs ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 999.5,
-    "end": 1006.26
-  },
-  {
-    "input": "We do just that, except instead of talking about absolute amounts, we talk of each term as a proportion.",
-    "translatedText": "On va refaire la même chose, sauf qu’au lieu de parler de tailles d’échantillons, chaque terme désignera une proportion.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1006.8,
-    "end": 1012.26
-  },
-  {
-    "input": "So the proportion of true positives in the population comes from the prior probability of having the disease multiplied by the probability of seeing a positive test result in that case.",
-    "translatedText": "La proportion de vrais positifs dans la population est égale à la probabilité a priori d’être atteint de la maladie, multipliée par la probabilité d’observer un résultat de test positif dans ce cas-là.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1012.26,
-    "end": 1022.26
-  },
-  {
-    "input": "Then we copy that term down again into the denominator, and then the proportion of false positives comes from the prior probability of not having the disease times the probability of a positive test in that case.",
-    "translatedText": "On recopie ce terme au dénominateur, et on calcule la proportion de faux positifs comme la probabilité a priori de ne pas avoir la maladie multipliée par la probabilité d'un test positif dans ce cas-là.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1023,
-    "end": 1034.1
-  },
-  {
-    "input": "If you want, you could also write this down with words instead of symbols, if terms like sensitivity and false positive rate are more comfortable.",
-    "translatedText": "Vous pouvez aussi l'écrire en toutes lettres si les termes de sensibilité et de taux de faux positifs vous parlent plus.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1035.08,
-    "end": 1040.86
-  },
-  {
-    "input": "And this is one of those formulas where once you say it out loud it seems like a bit much, but it really is no different from what we were doing with sample populations.",
-    "translatedText": "Et c’est vrai que la formule a l’air un peu touffue, vue comme ça, mais ça correspond simplement à ce qu’on a vu tout à l’heure avec nos populations fictives.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1041.38,
-    "end": 1048.4
-  },
-  {
-    "input": "If you wanted to make the whole thing look simpler, you often see this entire denominator written just as the probability of seeing a positive test result, overall.",
-    "translatedText": "On peut rendre ça plus concis en décrivant le dénominateur comme la probabilité d’observer un résultat de test positif au global.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1049.22,
-    "end": 1057
-  },
-  {
-    "input": "While that does make for a really elegant little expression, if you intend to use this for calculations, it's a little disingenuous, because in practice, every single time you do this you need to break down that denominator into two separate parts, breaking down the cases.",
-    "translatedText": "Et même si ça nous donne une expression très élégante, c’est un peu trompeur, car dès qu’on voudra l’utiliser en pratique, il faudra décomposer le dénominateur en deux parties distinctes, qui décrivent chacune des situations.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1057.98,
-    "end": 1070.58
-  },
-  {
-    "input": "So taking this more honest representation of it, let's compare our two versions of Bayes' rule.",
-    "translatedText": "Gardons donc cette représentation un peu plus honnête et comparons les deux versions du théorème de Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1071.7,
-    "end": 1076.02
-  },
-  {
-    "input": "And again, maybe it looks nicer if we use the words sensitivity and false positive rate.",
-    "translatedText": "Et de nouveau, utilisons les termes de sensibilité et taux de faux positifs.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1076.82,
-    "end": 1080.28
-  },
-  {
-    "input": "If nothing else, it helps emphasize which parts of the formula are coming from statistics about the test accuracy.",
-    "translatedText": "Ça permet au minimum de souligner quels éléments dans les formules proviennent des caractéristiques de performance du test.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1080.66,
-    "end": 1085.64
-  },
-  {
-    "input": "I mean, this actually emphasizes one thing I really like about the framing with odds and a Bayes' factor, which is that it cleanly factors out the parts that have to do with the prior and the parts that have to do with the test accuracy.",
-    "translatedText": "Ce que j’apprécie dans cette manière de présenter à travers les cotes et le facteur de Bayes, c’est qu’elle sépare clairement ce qui a à voir avec l'a priori et ce qui a à voir avec la performance du test.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1085.64,
-    "end": 1095.84
-  },
-  {
-    "input": "But over in the usual formula, all of those are very intermingled together.",
-    "translatedText": "Alors que dans la formulation habituelle, tous ces éléments sont vraiment mélangés.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1096.66,
-    "end": 1100.2
-  },
-  {
-    "input": "And this has a very practical benefit.",
-    "translatedText": "Et ça a une conséquence très immédiate.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1100.58,
-    "end": 1102.36
-  },
-  {
-    "input": "It's really nice if you want to swap out different priors and easily see their effects.",
-    "translatedText": "C'est vraiment pratique pour changer la valeur de l’a priori et observer l’effet produit.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1102.48,
-    "end": 1106.26
-  },
-  {
-    "input": "This is what we were doing earlier.",
-    "translatedText": "C'est ce qu’on faisait plus tôt.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1106.6,
-    "end": 1107.9
-  },
-  {
-    "input": "But with the other formula, to do that, you have to recompute everything each time.",
-    "translatedText": "Mais avec l’autre formule, pour pouvoir faire ça, il faudrait tout recalculer à chaque fois.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1108.42,
-    "end": 1112.2
-  },
-  {
-    "input": "You can't leverage a precomputed Bayes' factor the same way.",
-    "translatedText": "On ne peut pas utiliser un facteur de Bayes pré-calculé de la même manière.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1112.38,
-    "end": 1115.36
-  },
-  {
-    "input": "The odds framing also makes things really nice if you want to do multiple different Bayesian updates based on multiple pieces of evidence.",
-    "translatedText": "La formulation avec les cotes est aussi très pratique lorsqu’on veut effectuer des mises à jour bayésiennes en série basées sur plusieurs observations.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1115.96,
-    "end": 1122.12
-  },
-  {
-    "input": "For example, let's say you took not one test, but two.",
-    "translatedText": "Par exemple, disons que vous n’avez pas passé un test, mais deux.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1122.74,
-    "end": 1124.86
-  },
-  {
-    "input": "Or you wanted to think about how the presence of symptoms plays into it.",
-    "translatedText": "Ou que vous voulez inclure une information concernant la présence de certains symptômes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1125.36,
-    "end": 1128.54
-  },
-  {
-    "input": "For each piece of new evidence you see, you always ask the question, how much more likely would you be to see that with the disease versus without the disease?",
-    "translatedText": "Dès qu’on obtient une nouvelle information, on va toujours se demander : dans quel cas est-ce qu’il est plus probable d’observer cette information, en présence de la maladie, ou non ?",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1129.12,
-    "end": 1136.62
-  },
-  {
-    "input": "Each answer to that question gives you a new Bayes' factor, a new thing that you multiply by your odds.",
-    "translatedText": "Chaque réponse successive nous donne un nouveau facteur de Bayes, par lequel on va pouvoir multiplier notre cote précédente.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1137.24,
-    "end": 1142
-  },
-  {
-    "input": "Beyond just making calculations easier, there's something I really like about attaching a number to test accuracy that doesn't even look like a probability.",
-    "translatedText": "Au-delà de simplifier les calculs, il y a quelque chose que j'aime vraiment dans le fait d’utiliser un nombre qui n’est pas une probabilité pour mesurer la performance d’un test.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1142.88,
-    "end": 1149.92
-  },
-  {
-    "input": "I mean, if you hear that a test has, for example, a 9% false positive rate, that's just such a disastrously ambiguous phrase.",
-    "translatedText": "Par exemple, si on nous dit qu’un test A a un taux de faux positifs de 9 %, c’est une assertion incroyablement ambiguë.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1150.74,
-    "end": 1157.34
-  },
-  {
-    "input": "It's so easy to misinterpret it to mean there's a 9% chance that your positive test result is false.",
-    "translatedText": "C’est très facile de se méprendre et penser qu'il y a 9 % de chances que votre résultat positif soit faux.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1157.78,
-    "end": 1162.58
-  },
-  {
-    "input": "But imagine if instead the number that we heard tacked on to test results was that the Bayes' factor for a positive test result is, say, 10.",
-    "translatedText": "Mais imaginons qu’à la place, on nous dise à propos du test que son facteur de Bayes pour un résultat positif est, par exemple, de 10.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1163.3,
-    "end": 1170.32
-  },
-  {
-    "input": "There's no room to confuse that for your probability of having a disease.",
-    "translatedText": "Là, on ne peut plus interpréter ça à tort comme la probabilité d’être atteint d’une maladie.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1170.82,
-    "end": 1174.14
-  },
-  {
-    "input": "The entire framing of what a Bayes' factor is, is that it's something that acts on a prior.",
-    "translatedText": "L’idée au cœur de la définition du facteur de Bayes, c'est qu’il prend un a priori et agit dessus.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1174.64,
-    "end": 1179.04
-  },
-  {
-    "input": "It forces your hand to acknowledge the prior as something that's separate entirely, and highly necessary to drawing any conclusion.",
-    "translatedText": "Et ça oblige à considérer cet priori comme quelque chose de complètement distinct, et absolument nécessaire pour pouvoir tirer une quelconque conclusion.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1179.5,
-    "end": 1185.44
-  },
-  {
-    "input": "All that said, the usual formula is definitely not without its merits.",
-    "translatedText": "Cela dit, la forme habituelle a clairement des avantages.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1187.26,
-    "end": 1190.74
-  },
-  {
-    "input": "If you view it not simply as something to plug numbers into, but as an encapsulation of the sample population idea that we've been using throughout, you could very easily argue that that's actually much better for your intuition.",
-    "translatedText": "Si on ne la voit pas juste comme une formule à évaluer avec des valeurs données, mais comme portant cette idée de population fictive qu’on a utilisée tout du long, on pourrait se dire qu’elle est en fait bien plus utile à notre intuition.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1191.08,
-    "end": 1201.98
-  },
-  {
-    "input": "After all, it's what we were routinely falling back on in order to check ourselves that the Bayes' factor computation even made sense in the first place.",
-    "translatedText": "Après tout, c’est sur cette formule qu’on se basait à chaque fois pour vérifier que nos calculs incluant un facteur Bayes avaient bien du sens.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1202.56,
-    "end": 1209.18
-  },
-  {
-    "input": "Like any design decision, there is no clear-cut objective best here.",
-    "translatedText": "Comme dans tout processus de conception, on n’a pas une solution clairement meilleure que l’autre.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1211.6,
-    "end": 1215.38
-  },
-  {
-    "input": "But it's almost certainly the case that giving serious consideration to that question will lead you to a better understanding of Bayes' rule.",
-    "translatedText": "Mais il est à peu sûr que le fait de réfléchir sérieusement à cette question vous permettra de mieux comprendre le sens du théorème de Bayes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1215.42,
-    "end": 1221.72
-  },
-  {
-    "input": "Also, since we're on the topic of kind of paradoxical things, a friend of mine, Matt Cook, recently wrote a book all about paradoxes.",
-    "translatedText": "Et puisqu’on parle de choses un peu paradoxales ; Matt Cook, un ami à moi, a récemment écrit un livre qui traite beaucoup de paradoxes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1230.1,
-    "end": 1236.12
-  },
-  {
-    "input": "I actually contributed a small chapter to it with thoughts on the question of whether math is invented or discovered.",
-    "translatedText": "Et j’y ai d’ailleurs écrit un petit chapitre sur la question d’est-ce que les maths ont été plutôt inventées ou découvertes.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1237.04,
-    "end": 1241.82
-  },
-  {
-    "input": "And the book as a whole is this really nice connection of thought-provoking paradoxical things ranging from philosophy to math and physics.",
-    "translatedText": "Et le livre tisse un lien entre différents concepts paradoxaux qui vous feront réfléchir, en passant par la philosophie, les maths et ou la physique.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1242.3,
-    "end": 1248.4
-  },
-  {
-    "input": "You can, of course, find all the details in the description.",
-    "translatedText": "Vous pouvez retrouver tous les détails dans la description.",
-    "model": "google_nmt",
-    "n_reviews": 1,
-    "start": 1248.82,
-    "end": 1251.04
-  }
+ {
+  "input": "Some of you may have heard this paradoxical fact about medical tests.",
+  "translatedText": "Vous avez peut-être déjà entendu parler d’un paradoxe concernant les tests de dépistage.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 0,
+  "end": 3.14
+ },
+ {
+  "input": "It's very commonly used to introduce the topic of Bayes' rule in probability.",
+  "translatedText": "C'est un exemple couramment utilisé pour présenter le théorème de Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 3.58,
+  "end": 6.74
+ },
+ {
+  "input": "The paradox is that you could take a test which is highly accurate, in the sense that it gives correct results to a large majority of the people taking it.",
+  "translatedText": "Voici le paradoxe : il est possible qu’un test soit très précis, au sens où il fournit des résultats corrects pour la grande majorité des personnes testées.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 7.5,
+  "end": 15.66
+ },
+ {
+  "input": "And yet, under the right circumstances, when assessing the probability that your particular test result is correct, you can still land on a very low number, arbitrarily low, in fact.",
+  "translatedText": "Mais que, sous certaines conditions, le résultat de votre dépistage en particulier n’ait qu’une probabilité infime — voire arbitrairement faible — d’être correct.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 16.04,
+  "end": 26.3
+ },
+ {
+  "input": "In short, an accurate test is not necessarily a very predictive test.",
+  "translatedText": "En résumé, un test précis n’a pas forcément une grande valeur prédictive.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 26.78,
+  "end": 31.82
+ },
+ {
+  "input": "Now when people think about math and formulas, they don't often think of it as a design process.",
+  "translatedText": "Généralement, les gens ne voient pas vraiment les maths et les équations en tant que processus de conception.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 33.06,
+  "end": 37.44
+ },
+ {
+  "input": "I mean, maybe in the case of notation it's easy to see that different choices are possible, but when it comes to the structure of the formulas themselves and how we use them, that's something that people typically view as fixed.",
+  "translatedText": "Concernant les notations, on a évidemment le choix. Mais on pourrait avoir tendance à voir la structure des équations et la manière dont on les utilise comme quelque chose d’immuable.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 38.08,
+  "end": 49.68
+ },
+ {
+  "input": "In this video, you and I will dig into this paradox, but instead of using it to talk about the usual version of Bayes' rule, I'd like to motivate an alternate version, an alternate design choice.",
+  "translatedText": "Dans cette vidéo, nous allons expliciter ce paradoxe, mais au lieu de présenter le théorème de Bayes sous sa forme forme habituelle, j'aimerais en profiter pour proposer une formulation alternative, conçue différemment.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 50.68,
+  "end": 60.56
+ },
+ {
+  "input": "Now, what's up on the screen now is a little bit abstract, which makes it difficult to justify that there really is a substantive difference here, especially when I haven't explained either one yet.",
+  "translatedText": "Bon, pour l’instant, ce qui est à l'écran est un peu abstrait. Ce n’est pas évident de vous convaincre qu’il y a une différence notable, surtout que je n'ai pas encore expliqué les formules.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 61.66,
+  "end": 70.54
+ },
+ {
+  "input": "To see what I'm talking about though, we should really start by spending some time a little more concretely, and just laying out what exactly this paradox is.",
+  "translatedText": "Pour bien comprendre de quoi je parle, prenons le temps de regarder concrètement en quoi consiste le paradoxe.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 71.04,
+  "end": 78.1
+ },
+ {
+  "input": "Picture a thousand women and suppose that 1% of them have breast cancer.",
+  "translatedText": "Prenons 100 femmes, et supposons qu’1 % d’entre elles aient un cancer du sein.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 84.02,
+  "end": 87.94
+ },
+ {
+  "input": "And let's say they all undergo a certain breast cancer screening, and that 9 of those with cancer correctly get positive results, and there's one false negative.",
+  "translatedText": "Imaginons qu’elles passent toutes un certain type de dépistage, et que pour les 10 femmes ayant un cancer, 9 test sont des vrais positifs, et un faux négatif.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 88.68,
+  "end": 96.68
+ },
+ {
+  "input": "And then suppose that among the remainder without cancer, 89 get false positives, and 901 correctly get negative results.",
+  "translatedText": "Et supposons que pour les femmes restantes, 89 obtiennent des faux positifs et 901 obtiennent des vrais négatifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 97.48,
+  "end": 104.92
+ },
+ {
+  "input": "So if all you know about a woman is that she does the screening and she gets a positive result, you don't have information about symptoms or anything like that, you know that she's either one of these 9 true positives or one of these 89 false positives.",
+  "translatedText": "Donc, si une femme effectue ce dépistage et obtient un résultat positif, en l’absence d’information complémentaire comme des symptômes, vous savez qu'elle fait soit partie des 9 vrais positifs, soit des 89 faux positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 105.72,
+  "end": 118.26
+ },
+ {
+  "input": "So the probability that she's in the cancer group given the test result is 9 divided by 9 plus 89, which is approximately 1 in 11.",
+  "translatedText": "La probabilité qu’elle fasse partie du groupe des personnes ayant un cancer, étant donné le résultat du test, est de 9 divisé par 9 plus 89, soit environ 1 sur 11.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 119.36,
+  "end": 128.14
+ },
+ {
+  "input": "In medical parlance, you would call this the positive predictive value of the test, or PPV, the number of true positives divided by the total number of positive test results.",
+  "translatedText": "Dans la terminologie médicale, on appelle ça la valeur prédictive positive du test (PPV), le nombre de vrais positifs divisé par le nombre total de résultats de test positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 129.08,
+  "end": 138.62
+ },
+ {
+  "input": "You can see where the name comes from.",
+  "translatedText": "On comprend d'où vient le nom :",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 138.62,
+  "end": 140.44
+ },
+ {
+  "input": "To what extent does a positive test result actually predict that you have the disease?",
+  "translatedText": "Dans quelle mesure un résultat de test positif prédit-il réellement que vous souffrez de la maladie?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 140.74,
+  "end": 145.36
+ },
+ {
+  "input": "Now, hopefully, as I've presented it this way where we're thinking concretely about a sample population, all of this makes perfect sense.",
+  "translatedText": "J'espère qu’en utilisant cet exemple concret d’un échantillon de 100 personnes, tout ça est clair.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 146.82,
+  "end": 153.46
+ },
+ {
+  "input": "But where it comes across as counterintuitive is if you just look at the accuracy of the test, present it to people as a statistic, and then ask them to make judgments about their test result.",
+  "translatedText": "Mais là où ça devient contre-intuitif, c’est que si vous prenez la performance du test, que vous la présentez aux gens sous forme de chiffre, et que vous leur demandez de réagir au résultat de leur test.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 153.96,
+  "end": 163.2
+ },
+ {
+  "input": "Test accuracy is not actually one number, but two.",
+  "translatedText": "La performance d’un test se mesure en fait avec deux chiffres.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 164.02,
+  "end": 166.26
+ },
+ {
+  "input": "First, you ask how often is the test correct on those with the disease.",
+  "translatedText": "D’abord, on veut savoir pour quelle proportion des personnes atteintes de la maladie le test est positif.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 166.26,
+  "end": 171.12
+ },
+ {
+  "input": "This is known as the test sensitivity, as in how sensitive is it to detecting the presence of the disease.",
+  "translatedText": "C’est ce qu’on appelle la sensibilité du test, c’est-à-dire : quelle est sa sensibilité pour détecter la présence de la maladie ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 171.7,
+  "end": 177.44
+ },
+ {
+  "input": "In our example, test sensitivity is 9 in 10, or 90%.",
+  "translatedText": "Dans notre exemple, la sensibilité du test est de 9 sur 10, soit 90 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 178.26,
+  "end": 181.26
+ },
+ {
+  "input": "And another way to say the same fact would be to say the false negative rate is 10 %.",
+  "translatedText": "Et une autre façon de dire la même chose serait de dire que le taux de faux négatifs est de 10 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 182.02,
+  "end": 186.68
+ },
+ {
+  "input": "And then a separate, not necessarily related number is how often it's correct for those without the disease, which is known as the test specificity, as in are positive results caused specifically by the disease, or are there confounding triggers giving false positives.",
+  "translatedText": "Un autre chiffre, pas nécessairement lié, est la fréquence à laquelle le test est correct pour les personnes non atteintes de la maladie. C’est ce que l'on appelle la spécificité du test : les résultats positifs sont-ils causés spécifiquement par la maladie, ou y a-t-il des facteurs de confusion entraînant des faux positifs ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 186.68,
+  "end": 202.06
+ },
+ {
+  "input": "In our example, the specificity is about 91%.",
+  "translatedText": "Dans notre exemple, la spécificité est d'environ 91 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 203.08,
+  "end": 206.58
+ },
+ {
+  "input": "Or another way to say the same fact would be to say the false positive rate is 9%.",
+  "translatedText": "Une autre manière de le dire est que le taux de faux positifs est de 9 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 206.58,
+  "end": 211.66
+ },
+ {
+  "input": "So the paradox here is that in one sense, the test is over 90% accurate.",
+  "translatedText": "Le paradoxe ici est donc que, d’un côté, le test est précis à plus de 90 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 211.66,
+  "end": 216.76
+ },
+ {
+  "input": "It gives correct results to over 90% of the patients who take it.",
+  "translatedText": "Il donne des résultats corrects à plus de 90 % des patients qui se font dépister.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 217.02,
+  "end": 220.66
+ },
+ {
+  "input": "And yet, if you learn that someone gets a positive result without any added information, there's actually only a 1 in 11 chance that that particular result is accurate.",
+  "translatedText": "Mais pourtant, si vous apprenez qu’une personne obtient un résultat positif sans détenir aucune information supplémentaire, il n’y a en réalité qu’une chance sur 11 pour que ce résultat particulier soit exact.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 220.66,
+  "end": 229.6
+ },
+ {
+  "input": "This is a bit of a problem, because of all of the places for math to be counterintuitive, medical tests are one area where it matters a lot.",
+  "translatedText": "C'est embêtant, car cela peut particulièrement impacter la lecture des résultats des dépistages.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 230.62,
+  "end": 237.18
+ },
+ {
+  "input": "In 2006 and 2007, the psychologist Gerd Gigerenzer gave a series of statistics seminars to practicing gynecologists, and he opened with the following example.",
+  "translatedText": "Entre 2006 et 2007, le psychologue Gerd Gigerenzer a donné une série de séminaires de statistiques à des gynécologues en activité, qu’il commençait avec l'exemple suivant :",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 237.94,
+  "end": 246.8
+ },
+ {
+  "input": "A 50-year-old woman, no symptoms, participates in a routine mammography screening.",
+  "translatedText": "Une femme de 50 ans, sans symptômes, effectue un dépistage de routine par mammographie.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 246.8,
+  "end": 251.74
+ },
+ {
+  "input": "She tests positive, is alarmed, and wants to know from you whether she has breast cancer for certain or what her chances are.",
+  "translatedText": "Son test est positif. Elle est inquiète et veut savoir s'il est certain qu’elle a un cancer du sein, ou quel est le risque que ce soit le cas.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 252.28,
+  "end": 258.38
+ },
+ {
+  "input": "Apart from the screening result, you know nothing else about this woman.",
+  "translatedText": "Hormis le résultat du dépistage, vous ne savez rien d’autre sur cette femme.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 258.88,
+  "end": 261.74
+ },
+ {
+  "input": "In that seminar, the doctors were then told that the prevalence of breast cancer for women of this age is about 1%, and then to suppose that the test sensitivity is 90% and that its specificity was 91%.",
+  "translatedText": "Les informations suivantes ont ensuite été données à l’audience : la prévalence du cancer du sein chez les femmes de cet âge est d'environ 1 %, et vous pouvez supposer que la sensibilité du test est de 90 % et que sa spécificité est de 91 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 262.58,
+  "end": 274.18
+ },
+ {
+  "input": "You might notice these are exactly the same numbers from the example that you and I just looked at.",
+  "translatedText": "Vous aurez peut-être remarqué que ce sont exactement les mêmes chiffres que précédemment.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 274.18,
+  "end": 278.18
+ },
+ {
+  "input": "This is where I got them.",
+  "translatedText": "C'est de là que je les tiens.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 278.36,
+  "end": 279.44
+ },
+ {
+  "input": "So, having already thought it through, you and I know the answer.",
+  "translatedText": "Vu qu’on vient juste d’y réfléchir, on connaît déjà la réponse.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 279.76,
+  "end": 282.6
+ },
+ {
+  "input": "It's about 1 in 11.",
+  "translatedText": "C'est environ 1 sur 11.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 282.88,
+  "end": 283.84
+ },
+ {
+  "input": "However, the doctors in this session were not primed with the suggestion to picture a concrete sample of a thousand individuals, the way that you and I had.",
+  "translatedText": "En revanche, on n’a pas proposé aux médecins présents lors de ces séminaires d’imaginer un échantillon de population concret comme on l’a fait ici.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 284.6,
+  "end": 291.54
+ },
+ {
+  "input": "All they saw were these numbers.",
+  "translatedText": "Tout ce qu’ils voyaient, c’était des chiffres.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 292.04,
+  "end": 293.34
+ },
+ {
+  "input": "They were then asked, how many women who test positive actually have breast cancer?",
+  "translatedText": "On leur a ensuite demandé combien de femmes dont le test était positif avaient réellement un cancer du sein ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 294.14,
+  "end": 298.42
+ },
+ {
+  "input": "What is the best answer?",
+  "translatedText": "Quelle est la meilleure réponse ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 298.62,
+  "end": 299.74
+ },
+ {
+  "input": "And they were presented with these four choices.",
+  "translatedText": "Parmi ces quatre propositions.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 299.9,
+  "end": 301.68
+ },
+ {
+  "input": "In one of the sessions, over half the doctors present said that the correct answer was 9 in 10, which is way off.",
+  "translatedText": "Au cours d’un des séminaires, plus de la moitié des médecins on proposé la réponse « 9 sur 10 », ce qui est très loin de la bonne réponse.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 301.68,
+  "end": 309.3
+ },
+ {
+  "input": "Only a fifth of them gave the correct answer, which is worse than what it would have been if everybody had randomly guessed.",
+  "translatedText": "Seul un cinquième d’entre eux ont donné la bonne réponse, ce qui est pire que si tout le monde avait voté au hasard.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 310.02,
+  "end": 315.38
+ },
+ {
+  "input": "It might seem a little extreme to be calling this a paradox.",
+  "translatedText": "Ça peut sembler un peu exagéré d’appeler ça un paradoxe.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 316.66,
+  "end": 319.28
+ },
+ {
+  "input": "I mean, it's just a fact.",
+  "translatedText": "En réalité, c'est juste un fait.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 319.76,
+  "end": 321.14
+ },
+ {
+  "input": "It's not something intrinsically self-contradictory.",
+  "translatedText": "Ce n’est pas intrinsèquement contradictoire.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 321.26,
+  "end": 323.5
+ },
+ {
+  "input": "But, as these seminars with Gigerenzer show, people, including doctors, definitely find it counterintuitive that a test with high accuracy can give you such a low predictive value.",
+  "translatedText": "Mais comme le montrent les séminaires de Gigerenzer, les gens, y compris les médecins, trouvent clairement contre-intuitif qu’un test d’une grande performance puisse fournir une valeur prédictive aussi faible.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 324.2,
+  "end": 334.24
+ },
+ {
+  "input": "We might call this a veridical paradox, which refers to facts that are provably true, but which nevertheless can feel false when phrased a certain way.",
+  "translatedText": "Nous pourrions appeler ça un « paradoxe véridique », qui fait référence à des faits dont la vérité est avérée, mais qui peuvent néanmoins sembler faux lorsqu’ils sont formulés d’une certaine manière.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 335.2,
+  "end": 343.8
+ },
+ {
+  "input": "It's sort of the softest form of a paradox, saying more about human psychology than about logic.",
+  "translatedText": "C’est un peu comme une version attenué d’un paradoxe, qui en dit plus sur la psychologie humaine que sur la logique.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 344.3,
+  "end": 348.72
+ },
+ {
+  "input": "The question is how we can combat this.",
+  "translatedText": "La question c’est : comment lutter contre ça ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 349.58,
+  "end": 351.98
+ },
+ {
+  "input": "Where we're going with this, by the way, is that I want you to be able to look at numbers like this and quickly estimate in your head that it means the predictive value of a positive test should be around 1 in 11.",
+  "translatedText": "Dans l’idée, j’aimerais que vous puissiez regarder ce genre de chiffres et rapidement estimer de tête que la valeur prédictive associée pour un test positif est d'à-peu-près 1 sur 11.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 353.8,
+  "end": 364.14
+ },
+ {
+  "input": "Or, if I changed things and asked, what if it was 10% of the population who had breast cancer?",
+  "translatedText": "Et si je modifie les valeurs, et vous demande ce qu’il en serait si la prévalence du cancer du sein était de 10 %",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 364.76,
+  "end": 369.72
+ },
+ {
+  "input": "You should be able to quickly turn around and say that the final answer would be a little over 50%.",
+  "translatedText": "Vous devriez pouvoir rapidement modifier votre réponse et me dire que la valeur prédictive serait d'un peu plus que 50 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 370.12,
+  "end": 374.98
+ },
+ {
+  "input": "Or, if I said imagine a really low prevalence, something like 0.1% of patients having cancer, you should again quickly estimate that the predictive value of the test is around 1 in 100,",
+  "translatedText": "Ou, disons que je vous donne une prévalence très faible, comme 0,1 % de patients atteints de cancer, vous devriez là encore pouvoir estimer rapidement que la valeur prédictive du test est d'environ 1 sur 100.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 375.92,
+  "end": 386.14
+ },
+ {
+  "input": "that 1 in 100 of those with positive test results in that case would have cancer.",
+  "translatedText": "C’est-à-dire qu’une personne sur 100 avec des résultats positifs aurait un cancer.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 386.76,
+  "end": 390.6
+ },
+ {
+  "input": "Or, let's say we go back to the 1% prevalence, but I make the test more accurate.",
+  "translatedText": "Ou, en revenant à une prévalence de 1 %, mais en rendant le test plus précis.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 391.58,
+  "end": 395.24
+ },
+ {
+  "input": "I tell you to imagine the specificity is 99%.",
+  "translatedText": "Imaginons que la spécificité soit de 99 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 395.44,
+  "end": 398.4
+ },
+ {
+  "input": "There, you should be able to relatively quickly estimate that the answer is a little less than 50%.",
+  "translatedText": "Là, vous devriez pouvoir estimer assez rapidement que la réponse est un peu inférieure à 50 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 398.4,
+  "end": 403.8
+ },
+ {
+  "input": "The hope is that you're doing all of this with minimal calculations in your head.",
+  "translatedText": "Le but est que vous puissiez faire tout ça de tête, avec un minimum de calculs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 404.32,
+  "end": 407.74
+ },
+ {
+  "input": "Now, the goals of quick calculations might feel very different from the goals of addressing whatever misconception underlies this paradox, but they actually go hand in hand.",
+  "translatedText": "L’objectif de ces estimations rapides pourrait sembler très différent du fait de corriger les idées qui sous-tendent ce paradoxe, mais les deux sont liés.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 408.54,
+  "end": 416.5
+ },
+ {
+  "input": "Let me show you what I mean.",
+  "translatedText": "Regardons ça plus en détail.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 416.9,
+  "end": 417.68
+ },
+ {
+  "input": "On the side of addressing misconceptions, what would you tell to the people in that seminar who answered 9 and 10?",
+  "translatedText": "Du côté des idées erronnées, qu’auriez-vous envie de dire aux médecins qui ont répondu « 9 sur 10 » lors de la conférence ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 418.46,
+  "end": 423.98
+ },
+ {
+  "input": "What fundamental misconception are they revealing?",
+  "translatedText": "En quoi leur raisonnement est-il fondamentalement faux ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 424.48,
+  "end": 426.9
+ },
+ {
+  "input": "What I might tell them is that in much the same way that you shouldn't think of tests as telling you deterministically whether you have a disease, you shouldn't even think of them as telling you your chances of having a disease.",
+  "translatedText": "On pourrait leur dire que, de la même manière qu’on ne devrait pas considérer que les tests peuvent déterminer si quelqu’un est malade ou pas, on ne devrait même pas considérer qu’ils nous donnent le risque que cette personne soit malade.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 428.18,
+  "end": 438.6
+ },
+ {
+  "input": "Instead, the healthy view of what tests do is that they update your chances.",
+  "translatedText": "Une description plus exacte est que les test nous permettent de mettre à jour nos estimations.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 439.56,
+  "end": 444.46
+ },
+ {
+  "input": "In our example, before taking the test, a patient's chances of having cancer were 1 in 100.",
+  "translatedText": "Dans notre exemple, avant de passer le test, le risque d’avoir un cancer était de 1 sur 100.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 446.04,
+  "end": 450.68
+ },
+ {
+  "input": "In Bayesian terms, we call this the prior probability.",
+  "translatedText": "En termes bayésiens, on appelle ça la probabilité a priori.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 451.12,
+  "end": 453.64
+ },
+ {
+  "input": "The effect of this test was to update that prior by almost an order of magnitude, up to around 1 in 11.",
+  "translatedText": "L’effet de ce test a été de mettre à jour cet a priori par quasiment un facteur 10, à 1 sur 11.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 454.38,
+  "end": 460.36
+ },
+ {
+  "input": "The accuracy of a test is telling us about the strength of this updating.",
+  "translatedText": "La performance d’un test se traduit dans la taille de cette mise à jour.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 461.02,
+  "end": 464.82
+ },
+ {
+  "input": "It's not telling us a final answer.",
+  "translatedText": "Elle ne nous donne pas de réponse définitive.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 465.12,
+  "end": 466.74
+ },
+ {
+  "input": "What does this have to do with quick approximations?",
+  "translatedText": "Du coup, quel rapport avec nos estimations rapides ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 467.9,
+  "end": 469.64
+ },
+ {
+  "input": "Well, a key number for those approximations is something called the Bayes factor, and the very act of defining this number serves to reinforce this central lesson about reframing what it is the tests do.",
+  "translatedText": "Eh bien, un élément clé pour ces estimations est ce qu’on appelle le facteur de Bayes. Et le fait même de définir ce nombre vient consolider notre compréhension de ce que disent réellement les tests.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 470.3,
+  "end": 481.4
+ },
+ {
+  "input": "You see, one of the things that makes test statistics so very confusing is that there are at least 4 numbers that you'll hear associated with them.",
+  "translatedText": "Une des choses qui génère de la confusion concernant la performance des tests est qu’on parle généralement d’au moins 4 chiffres différents. ",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 482.42,
+  "end": 488.9
+ },
+ {
+  "input": "For those with the disease, there's the sensitivity and the false negative rate, and then for those without, there's the specificity and the false positive rate, and none of these numbers actually tell you the thing you want to know.",
+  "translatedText": "La sensibilité et le taux de faux négatifs pour les personnes atteintes de la maladie ; la spécificité et le taux de faux positifs pour celles qui ne le sont pas. Mais aucun de ces chiffres ne nous dit vraiment ce qu’on veut savoir.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 488.9,
+  "end": 498.8
+ },
+ {
+  "input": "Luckily, if you want to interpret a positive test result, you can pull out just one number to focus on from all this.",
+  "translatedText": "Heureusement, si on veut interpréter un résultat de test positif, il y a un chiffre sur lequel on peut se concentrer.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 499.5,
+  "end": 505.62
+ },
+ {
+  "input": "Take the sensitivity divided by the false positive rate.",
+  "translatedText": "Prenez la sensibilité divisée par le taux de faux positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 506.04,
+  "end": 508.6
+ },
+ {
+  "input": "In other words, how much more likely are you to see the positive test result with cancer versus without?",
+  "translatedText": "Autrement dit, dans quelle mesure a-t-on plus de chances de voir un résultat de test positif entre un cas ayant un cancer et un cas sans ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 509.16,
+  "end": 514.74
+ },
+ {
+  "input": "In our example, this number is 10.",
+  "translatedText": "Dans notre exemple, ce nombre est égal à 10.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 514.74,
+  "end": 517.14
+ },
+ {
+  "input": "This is the Bayes factor, also sometimes called the likelihood ratio.",
+  "translatedText": "Il s’agit du facteur de Bayes, aussi parfois appelé rapport de vraisemblance.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 517.9,
+  "end": 521.72
+ },
+ {
+  "input": "A very handy rule of thumb is that to update a small prior, or at least to approximate the answer, you simply multiply it by the Bayes factor.",
+  "translatedText": "Voici une approximation très pratique pour mettre à jour une probabilité a priori lorsqu’elle est faible : il vous suffit de la multiplier par le facteur Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 523.1,
+  "end": 530.02
+ },
+ {
+  "input": "So in our example, where the prior was 1 in 100, you would estimate that the final answer should be around 1 in 10, which is in fact slightly above the true correct answer.",
+  "translatedText": "Avec une probabilité a priori de 1 sur 100, vous pouvez donc estimer que la probabilité a posteriori sera d'environ 1 sur 10, ce qui est effectivement légèrement au-dessus de la valeur réelle.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 530.76,
+  "end": 538.82
+ },
+ {
+  "input": "So based on this rule of thumb, if I asked you what would happen if the prior from our example was instead 1 in 1000, you could quickly estimate that the effect of the test should be to update those chances to around 1 in 100.",
+  "translatedText": "Donc, si je vous demande ce qui se passerait si la probabilité a priori de notre exemple était plutôt de 1 sur 1000, vous devriez pouvoir estimer rapidement que le résultat du test a pour conséquence de mettre à jour cette probabilité à environ 1 sur 100.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 539.4,
+  "end": 551.42
+ },
+ {
+  "input": "And in fact, take a moment to check yourself by thinking through a sample population.",
+  "translatedText": "Prenez donc un moment pour vérifier que vous avez bien compris en imaginant une population.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 552.36,
+  "end": 555.72
+ },
+ {
+  "input": "In this case, you might picture 10,000 patients where only 10 of them really have cancer.",
+  "translatedText": "Vous pourriez imaginer 10000 patients, parmi lesquels 10 d’entre eux sont atteints d’un cancer.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 556.7,
+  "end": 560.88
+ },
+ {
+  "input": "And then based on that 90% sensitivity, we would expect 9 of those cancer cases to give true positives.",
+  "translatedText": "Et, en partant sur une sensibilité de 90 %, on s’attend à ce que sur les 10 cas de cancer, 9 résultats de tests soient des vrais positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 562.14,
+  "end": 567.9
+ },
+ {
+  "input": "And on the other side, a 91% specificity means that 9% of those without cancer are getting false positives.",
+  "translatedText": "D’un autre côté, une spécificité de 91 % signifie que 9 % des personnes sans cancer obtiennent des résultats faux positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 569,
+  "end": 575.76
+ },
+ {
+  "input": "So we'd expect 9% of the remaining patients, which is around 900, to give false positive results.",
+  "translatedText": "On s’attend donc à ce que 9 % des patients restants, soit environ 900, aient des résultats faussement positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 576.66,
+  "end": 581.86
+ },
+ {
+  "input": "Here, with such a low prevalence, the false positives really do dominate the true positives.",
+  "translatedText": "Ici, avec une prévalence aussi faible, les faux positifs dominent vraiment les vrais positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 582.7,
+  "end": 587.82
+ },
+ {
+  "input": "So the probability that a randomly chosen positive case from this population actually has cancer is only around 1%, just like the rule of thumb predicted.",
+  "translatedText": "Donc, la probabilité qu’un cas positif choisi au hasard dans cette population soit réellement atteint d’un cancer n’est que d’environ 1 %, tout comme le prédisait l’approximation.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 587.9,
+  "end": 597.02
+ },
+ {
+  "input": "Now, this rule of thumb clearly cannot work for higher priors.",
+  "translatedText": "Or, cette approximation ne fonctionne clairement pas pour des valeurs d’a priori plus élevées.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 598.7,
+  "end": 601.92
+ },
+ {
+  "input": "For example, it would predict that a prior of 10% gets updated all the way to 100% certainty.",
+  "translatedText": "Par exemple, elle prédirait qu'un a priori de 10 % serait mis à jour vers une valeur de 100 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 602.42,
+  "end": 607.86
+ },
+ {
+  "input": "But that can't be right.",
+  "translatedText": "Mais ça n’a pas de sens.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 608.36,
+  "end": 609.32
+ },
+ {
+  "input": "In fact, take a moment to think through what the answer should be, again, using a sample population.",
+  "translatedText": "Prenons un moment pour réfléchir à ce que devrait être la vraie valeur, en utilisant toujours une population fictive.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 610.02,
+  "end": 614.5
+ },
+ {
+  "input": "Maybe this time we picture 10 out of 100 having cancer.",
+  "translatedText": "Cette fois, imaginons que 10 personnes sur 100 ont un cancer.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 615.06,
+  "end": 617.86
+ },
+ {
+  "input": "Again, based on the 90% sensitivity of the test, we'd expect 9 of those true cancer cases to get positive results.",
+  "translatedText": "De nouveau, en prenant une sensibilité de 90 % du test, nous nous attendons à ce que 9 des véritables cas de cancer fournissent des résultats positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 618.54,
+  "end": 624.92
+ },
+ {
+  "input": "But what about the false positives?",
+  "translatedText": "Mais concernant les faux positifs,",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 624.92,
+  "end": 626.6
+ },
+ {
+  "input": "How many do we expect there?",
+  "translatedText": "Combien va-t-on en trouver ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 626.98,
+  "end": 628.1
+ },
+ {
+  "input": "About 9% of the remaining 90. About 8.",
+  "translatedText": "Environ 9 % des 90 restants, soit environ 8.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 629.88,
+  "end": 632.62
+ },
+ {
+  "input": "So, upon seeing a positive test result, it tells you that you're either one of these 9 true positives or one of the 8 false positives.",
+  "translatedText": "Donc, quand vous voyez un résultat de test positif, vous avez devant vous soit l'un des 9 vrais positifs, soit l'un des 8 faux positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 633.82,
+  "end": 641.14
+ },
+ {
+  "input": "So this means the chances are a little over 50%, roughly 9 out of 17, or 53%.",
+  "translatedText": "On a donc un peu plus d’une chance sur deux. 9 sur 17, soit à peu près 53 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 641.86,
+  "end": 646.92
+ },
+ {
+  "input": "At this point, having dared to dream that Bayesian updating could look as simple as multiplication, you might tear down your hopes and pragmatically acknowledge that sometimes life is just more complicated than that.",
+  "translatedText": "À ce stade, tout espoir que cette mise à jour bayésienne puisse être aussi simple qu’une multiplication à l’air perdu, et on se dit que parfois ce n’est pas aussi simple qu’on aimerait.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 648.02,
+  "end": 657.7
+ },
+ {
+  "input": "Except it's not.",
+  "translatedText": "Sauf que ce n'est pas le cas !",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 659.92,
+  "end": 661.12
+ },
+ {
+  "input": "This rule of thumb turns into a precise mathematical fact as long as we shift away from talking about probabilities to instead talking about odds.",
+  "translatedText": "Cette approximation peut devenir exacte, à condition que l’on ne considère plus des probabilités, mais des cotes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 661.62,
+  "end": 669
+ },
+ {
+  "input": "If you've ever heard someone talk about the chances of an event being 1 to 1 or 2 to 1, things like that, you already know about odds.",
+  "translatedText": "Si vous avez déjà entendu quelqu'un dire quelque chose comme : « 1 pour 1 », ou « à 2 contre 1 », vous savez déjà ce que c’est qu’une cote.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 670.32,
+  "end": 677.06
+ },
+ {
+  "input": "With probability, we're taking the ratio of the number of positive cases out of all possible cases, right?",
+  "translatedText": "Pour une probabilité, on prend le rapport entre le nombre de cas positifs et l’ensemble des cas.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 677.06,
+  "end": 683.06
+ },
+ {
+  "input": "Things like 1 in 5 or 1 in 10.",
+  "translatedText": "Par exemple 1 sur 5, ou 1 sur 10.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 683.4,
+  "end": 685.28
+ },
+ {
+  "input": "With odds, what you do is take the ratio of all positive cases to all negative cases.",
+  "translatedText": "Avec les cotes, on fait le rapport entre tous les cas positifs et tous les cas négatifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 685.88,
+  "end": 690.32
+ },
+ {
+  "input": "You commonly see odds written with a colon to emphasize the distinction, but it's still just a fraction, just a number.",
+  "translatedText": "Généralement, on note les cotes en utilisant deux points pour les distinguer d’une probabilité, mais ça reste bien une fraction, un nombre.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 691.54,
+  "end": 697.06
+ },
+ {
+  "input": "So an event with a 50% probability would be described as having 1 to 1 odds. A 10% probability is the same as 1 to 9 odds. An 80% probability is the same as 4 to 1 odds. You get the point.",
+  "translatedText": "Du coup, un événement avec une probabilité de 50 % a une cote de 1 pour 1, une probabilité de 10 % équivaut à une cote de 1 pour 9, une probabilité de 80 %, une cote de 4 pour 1. Vous voyez l’idée.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 697.94,
+  "end": 710.46
+ },
+ {
+  "input": "It's the same information. It still describes the chances of a random event, but it's presented a little differently, like a different unit system.",
+  "translatedText": "C'est la même information : on décrit toujours les chances qu'un événement aléatoire se produise, mais avec une échelle un peu différente.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 711.48,
+  "end": 718.34
+ },
+ {
+  "input": "Probabilities are constrained between 0 and 1, with even chances sitting at 0.5.",
+  "translatedText": "Une probabilité est un nombre entre 0 et 1. On a autant de chances d’avoir un résultat que l’autre à 0,5.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 719.32,
+  "end": 723.68
+ },
+ {
+  "input": "But odds range from 0 up to infinity, with even chances sitting at the number 1.",
+  "translatedText": "Mais une cote va de 0 à l’infini, et un partage équitable des chances se situe alors à 1.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 724.8,
+  "end": 729.54
+ },
+ {
+  "input": "The beauty here is that a completely accurate, not even approximating things way to frame Bayes' rule is to say, express your prior using odds, and then just multiply by the Bayes' factor.",
+  "translatedText": "Ce qui est beau ici, c’est que cette description du théorème de Bayes est tout à fait exacte : écrivez votre a priori comme une cote, et multipliez le simplement par le facteur de Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 731.88,
+  "end": 742.36
+ },
+ {
+  "input": "Think about what the prior odds are really saying.",
+  "translatedText": "Réfléchissez à ce que veut vraiment dire une cote a priori.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 743.44,
+  "end": 745.22
+ },
+ {
+  "input": "It's the number of people with cancer divided by the number without it.",
+  "translatedText": "C'est le nombre de personnes malades divisé par le nombre de personnes saines.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 745.58,
+  "end": 749.26
+ },
+ {
+  "input": "Here, let's just write that down as a normal fraction for a moment so we can multiply it.",
+  "translatedText": "Mettons-le sous forme de fraction pour pouvoir le multiplier.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 749.7,
+  "end": 753.36
+ },
+ {
+  "input": "When you filter down just to those with positive test results, the number of people with cancer gets scaled down, scaled down by the probability of seeing a positive test result given that someone has cancer.",
+  "translatedText": "Si on ne regarde que les personnes ayant un test positif, l’ensemble de celles qui ont un cancer a diminué par rapport au groupe initial d’un facteur égal à la probabilité d’obtenir un test positif pour une personne malade.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 753.36,
+  "end": 764.42
+ },
+ {
+  "input": "And then similarly, the number of people without cancer also gets scaled down, this time by the probability of seeing a positive test result, but in that case.",
+  "translatedText": "De la même manière, l’ensemble des personnes saines a également diminué, mais cette fois par un facteur égal à la probabilité qu’une personne saine obtienne un résultat positif.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 765.12,
+  "end": 773.44
+ },
+ {
+  "input": "So the ratio between these two counts, the new odds upon seeing the test, looks just like the prior odds except multiplied by this term here, which is exactly the Bayes' factor.",
+  "translatedText": "Le rapport des effectifs de ces groupes, qui est la nouvelle cote a posteriori, a la même forme que la cote pre-tests, mais multipliée par ce terme, qui est précisément le facteur de Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 774.18,
+  "end": 784.76
+ },
+ {
+  "input": "Look back at our example, where the Bayes' factor was 10.",
+  "translatedText": "Reprenons notre exemple, où le facteur de Bayes était de 10.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 787.8,
+  "end": 790.5
+ },
+ {
+  "input": "And as a reminder, this came from the 90% sensitivity divided by the 9% false positive rate.",
+  "translatedText": "Qu’on peut calculer, pour rappel, comme le rapport d’une sensibilité de 90 % sur un taux de faux positifs de 9 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 791,
+  "end": 796.56
+ },
+ {
+  "input": "How much more likely are you to see a positive result with cancer versus without?",
+  "translatedText": "Quand est-ce plus probable d’avoir un résultat positif pour une personne malade plutôt que saine ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 796.88,
+  "end": 800.74
+ },
+ {
+  "input": "If the prior is 1%, expressed as odds, this looks like 1 to 99.",
+  "translatedText": "Si l'a priori est de 1 %, ça nous donne une cote de 1 pour 99.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 801.72,
+  "end": 805.94
+ },
+ {
+  "input": "So by our rule, this gets updated to 10 to 99, which if you want you could convert back to a probability.",
+  "translatedText": "Donc, d’après notre règle, la cote est mise à jour à 10 pour 99. Et vous pouvez la reconvertir en probabilité au besoin.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 806.9,
+  "end": 813.4
+ },
+ {
+  "input": "It would be 10 divided by 10 plus 99, or about 1 in 11.",
+  "translatedText": "Ça nous donnerait 10 divisé par 10 plus 99, soit environ 1 sur 11.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 813.66,
+  "end": 817.22
+ },
+ {
+  "input": "If instead, the prior was 10%, which was the example that tripped up our rule of thumb earlier, expressed as odds, this looks like 1 to 9.",
+  "translatedText": "Si l'a priori était plutôt de 10 %, comme dans l’exemple qui faisait dérailler notre approximation tout à l’heure, on aurait une cote de 1 pour 9.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 818.2,
+  "end": 826.26
+ },
+ {
+  "input": "By our simple rule, this gets updated to 10 to 9, which you can already read off pretty intuitively.",
+  "translatedText": "D’après notre règle, cette cote passe à 10 pour 9, que vous pouvez déjà interpréter de manière assez intuitive.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 826.94,
+  "end": 832.44
+ },
+ {
+  "input": "It's a little above even chances, a little above 1 to 1.",
+  "translatedText": "C'est un peu au-dessus d’un partage équitable des chances, un peu au-dessus de 1 pour 1.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 832.44,
+  "end": 835.66
+ },
+ {
+  "input": "If you prefer, you can convert it back to a probability.",
+  "translatedText": "Si vous préférez, on peut reconvertir cette cote en probabilité.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 836.34,
+  "end": 838.84
+ },
+ {
+  "input": "You would write it as 10 out of 19, or about 53%.",
+  "translatedText": "Ça nous donnerait 10 sur 19, soit environ 53 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 839.18,
+  "end": 843.28
+ },
+ {
+  "input": "And indeed, that is what we already found by thinking things through with a sample population.",
+  "translatedText": "Et c’est d’ailleurs ce qu’on avait déjà trouvé en réfléchissant à notre population fictive.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 843.28,
+  "end": 847.22
+ },
+ {
+  "input": "Let's say we go back to the 1% prevalence, but I make the test more accurate.",
+  "translatedText": "Disons qu’on reprend une prévalence de 1 %, mais que le test est plus précis.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 848.3,
+  "end": 851.7
+ },
+ {
+  "input": "Now what if I told you to imagine that the false positive rate was only 1% instead of 9%?",
+  "translatedText": "Imaginons maintenant que le taux de faux positifs n’est que de 1 %, plutôt que 9 %",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 852.06,
+  "end": 856.64
+ },
+ {
+  "input": "What that would mean is that our Bayes factor is 90 instead of 10.",
+  "translatedText": "Ça voudrait dire que notre facteur de Bayes est de 90 au lieu de 10.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 857.12,
+  "end": 860.52
+ },
+ {
+  "input": "The test is doing more work for us.",
+  "translatedText": "Le test nous aide plus.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 860.84,
+  "end": 862.46
+ },
+ {
+  "input": "In this case, with the more accurate test, it gets updated to 90 to 99, which is a little less than even chances, something a little under 50%.",
+  "translatedText": "Dans ce cas, avec un test plus précis, la cote se déplace à 90 pour 99, ce qui est un peu moins que 50 % de chances.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 863.16,
+  "end": 871.58
+ },
+ {
+  "input": "To be more precise, you could make the conversion back to probability and work out that it's around 48%.",
+  "translatedText": "Plus précisément, on peut la convertir en probabilité et trouver qu'elle est à peu près égale à 48 %.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 871.58,
+  "end": 877.56
+ },
+ {
+  "input": "But honestly, if you're just going for a gut feel, it's fine to stick with the odds.",
+  "translatedText": "Mais honnêtement, si vous voulez juste vous faire une idée, une cote est amplement suffisante.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 877.56,
+  "end": 881.4
+ },
+ {
+  "input": "Do you see what I mean about how just defining this number helps to combat potential misconceptions?",
+  "translatedText": "Est-ce que vous voyez le rapport entre la simple définition de ce facteur et le fait d’éviter d’éventuelles confusions ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 882.22,
+  "end": 887.44
+ },
+ {
+  "input": "For anybody who's a little hasty in connecting test accuracy directly to your probability of having a disease, it's worth emphasizing that you could administer the same test with the same accuracy to multiple different patients who all get the same exact result, but if they're coming from different contexts, that result can mean wildly different things.",
+  "translatedText": "Si une personne est tentée d’associer un peu trop vite le résultat d’un test à la probabilité d’avoir une maladie, on peut lui montrer qu’il est possible de faire passer exactement le même test, avec la même précision, à plusieurs patients différents, que ces patients obtiennent tous exactement le même résultat. Pourtant, en fonction du contexte, ces résultats peuvent signifier des choses incroyablement différentes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 888.24,
+  "end": 906.72
+ },
+ {
+  "input": "However, the one thing that does stay constant in every case is the factor by which each patient's prior odds get updated.",
+  "translatedText": "Par contre, la seule chose qui ne change pas entre tous ces cas, c'est le facteur par lequel les cotes a priori de chaque patient sont mises à jour.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 906.72,
+  "end": 914.66
+ },
+ {
+  "input": "And by the way, this whole time we've been using the prevalence of the disease, which is the proportion of people in a population who have it, as a substitute for the prior, the probability of having it before you see a test.",
+  "translatedText": "Et d'ailleurs, on a choisi comme probabilité a priori la prévalence de la maladie depuis tout à l’heure. C'est-à-dire la proportion de personnes malades au sein de la population.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 916.3,
+  "end": 926.88
+ },
+ {
+  "input": "However, that's not necessarily the case.",
+  "translatedText": "Mais ce n’est pas forcément toujours le cas.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 927.52,
+  "end": 929.46
+ },
+ {
+  "input": "If there are other known factors, things like symptoms, or in the case of a contagious disease, things like known contacts, those also factor into the prior, and they could potentially make a huge difference.",
+  "translatedText": "Si on connaît d’autres éléments, comme par exemple les symptômes, ou, dans le cas d'une maladie contagieuse, les personnes contact, ceux-ci peuvent être pris en compte dans l’a priori et potentiellement faire une énorme différence.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 929.78,
+  "end": 939.86
+ },
+ {
+  "input": "As another side note, so far we've only talked about positive test results, but way more often you would be seeing a negative test result.",
+  "translatedText": "Par ailleurs, jusqu'ici, on n’a parlé que de résultats de tests positifs, mais on observe bien plus de résultats négatifs en pratique.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 940.76,
+  "end": 947.46
+ },
+ {
+  "input": "The logic there is completely the same, but the Bayes factor that you compute is going to look different.",
+  "translatedText": "La logique reste exactement la même, mais le facteur de Bayes que vous calculez aura une allure différente.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 948.1,
+  "end": 952.32
+ },
+ {
+  "input": "Instead, you look at the probability of seeing this negative test result with the disease versus without the disease.",
+  "translatedText": "À la place on regardera la probabilité d’obtenir un résultat de test négatif en présence de la maladie, et (au contraire) en son absence.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 952.76,
+  "end": 958.64
+ },
+ {
+  "input": "So in our cancer example, this would have been the 10% false negative rate divided by the 91% specificity, or about 1 in 9.",
+  "translatedText": "Du coup, dans notre exemple sur le cancer, ça aurait été le taux de faux négatifs de 10 % divisé par la spécificité de 91 %, soit environ 1 sur 9.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 958.64,
+  "end": 967.04
+ },
+ {
+  "input": "In other words, seeing a negative test result in that example would reduce your prior odds by about an order of magnitude.",
+  "translatedText": "Autrement dit, observer un résultat de test négatif dans cet exemple réduirait la cote a priori d’environ un ordre de grandeur.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 967.78,
+  "end": 974.46
+ },
+ {
+  "input": "When you write it all out as a formula, here's how it looks.",
+  "translatedText": "Si on l’exprime sous la forme d’une équation, voilà à quoi ça ressemble.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 975.9,
+  "end": 978.42
+ },
+ {
+  "input": "It says your odds of having a disease given a test result equals your odds before taking the test, the prior odds, times the Bayes factor.",
+  "translatedText": "Elle nous dit que le risque d'avoir une maladie compte tenu du résultat d'un test est égal au risque estimé avant de passer le test, la cote a priori, multiplié par le facteur de Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 978.76,
+  "end": 986.96
+ },
+ {
+  "input": "Now let's contrast this with the usual way Bayes' rule is written, which is a bit more complicated.",
+  "translatedText": "On peut comparer ça avec la manière dont on présente habituellement le théorème de Bayes, qui est un peu plus compliquée.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 986.96,
+  "end": 992.26
+ },
+ {
+  "input": "In case you haven't seen it before, it's essentially just what we were doing with sample populations, but you wrap it all up symbolically.",
+  "translatedText": "Si vous ne l’avez jamais vue, ça revient essentiellement à ce qu’on a fait avec nos populations fictives, mais exprimé de manière symbolique.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 993.06,
+  "end": 998.78
+ },
+ {
+  "input": "Remember how every time we were counting the number of true positives and then dividing it by the sum of the true positives and the false positives?",
+  "translatedText": "Vous vous souvenez qu’à chaque fois, on prenait le nombre de vrais positifs et qu’on le divisait par la somme des vrais positifs et des faux positifs ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 999.5,
+  "end": 1006.26
+ },
+ {
+  "input": "We do just that, except instead of talking about absolute amounts, we talk of each term as a proportion.",
+  "translatedText": "On va refaire la même chose, sauf qu’au lieu de parler de tailles d’échantillons, chaque terme désignera une proportion.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1006.8,
+  "end": 1012.26
+ },
+ {
+  "input": "So the proportion of true positives in the population comes from the prior probability of having the disease multiplied by the probability of seeing a positive test result in that case.",
+  "translatedText": "La proportion de vrais positifs dans la population est égale à la probabilité a priori d’être atteint de la maladie, multipliée par la probabilité d’observer un résultat de test positif dans ce cas-là.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1012.26,
+  "end": 1022.26
+ },
+ {
+  "input": "Then we copy that term down again into the denominator, and then the proportion of false positives comes from the prior probability of not having the disease times the probability of a positive test in that case.",
+  "translatedText": "On recopie ce terme au dénominateur, et on calcule la proportion de faux positifs comme la probabilité a priori de ne pas avoir la maladie multipliée par la probabilité d'un test positif dans ce cas-là.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1023,
+  "end": 1034.1
+ },
+ {
+  "input": "If you want, you could also write this down with words instead of symbols, if terms like sensitivity and false positive rate are more comfortable.",
+  "translatedText": "Vous pouvez aussi l'écrire en toutes lettres si les termes de sensibilité et de taux de faux positifs vous parlent plus.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1035.08,
+  "end": 1040.86
+ },
+ {
+  "input": "And this is one of those formulas where once you say it out loud it seems like a bit much, but it really is no different from what we were doing with sample populations.",
+  "translatedText": "Et c’est vrai que la formule a l’air un peu touffue, vue comme ça, mais ça correspond simplement à ce qu’on a vu tout à l’heure avec nos populations fictives.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1041.38,
+  "end": 1048.4
+ },
+ {
+  "input": "If you wanted to make the whole thing look simpler, you often see this entire denominator written just as the probability of seeing a positive test result, overall.",
+  "translatedText": "On peut rendre ça plus concis en décrivant le dénominateur comme la probabilité d’observer un résultat de test positif au global.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1049.22,
+  "end": 1057
+ },
+ {
+  "input": "While that does make for a really elegant little expression, if you intend to use this for calculations, it's a little disingenuous, because in practice, every single time you do this you need to break down that denominator into two separate parts, breaking down the cases.",
+  "translatedText": "Et même si ça nous donne une expression très élégante, c’est un peu trompeur, car dès qu’on voudra l’utiliser en pratique, il faudra décomposer le dénominateur en deux parties distinctes, qui décrivent chacune des situations.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1057.98,
+  "end": 1070.58
+ },
+ {
+  "input": "So taking this more honest representation of it, let's compare our two versions of Bayes' rule.",
+  "translatedText": "Gardons donc cette représentation un peu plus honnête et comparons les deux versions du théorème de Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1071.7,
+  "end": 1076.02
+ },
+ {
+  "input": "And again, maybe it looks nicer if we use the words sensitivity and false positive rate.",
+  "translatedText": "Et de nouveau, utilisons les termes de sensibilité et taux de faux positifs.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1076.82,
+  "end": 1080.28
+ },
+ {
+  "input": "If nothing else, it helps emphasize which parts of the formula are coming from statistics about the test accuracy.",
+  "translatedText": "Ça permet au minimum de souligner quels éléments dans les formules proviennent des caractéristiques de performance du test.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1080.66,
+  "end": 1085.64
+ },
+ {
+  "input": "I mean, this actually emphasizes one thing I really like about the framing with odds and a Bayes' factor, which is that it cleanly factors out the parts that have to do with the prior and the parts that have to do with the test accuracy.",
+  "translatedText": "Ce que j’apprécie dans cette manière de présenter à travers les cotes et le facteur de Bayes, c’est qu’elle sépare clairement ce qui a à voir avec l'a priori et ce qui a à voir avec la performance du test.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1085.64,
+  "end": 1095.84
+ },
+ {
+  "input": "But over in the usual formula, all of those are very intermingled together.",
+  "translatedText": "Alors que dans la formulation habituelle, tous ces éléments sont vraiment mélangés.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1096.66,
+  "end": 1100.2
+ },
+ {
+  "input": "And this has a very practical benefit.",
+  "translatedText": "Et ça a une conséquence très immédiate.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1100.58,
+  "end": 1102.36
+ },
+ {
+  "input": "It's really nice if you want to swap out different priors and easily see their effects.",
+  "translatedText": "C'est vraiment pratique pour changer la valeur de l’a priori et observer l’effet produit.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1102.48,
+  "end": 1106.26
+ },
+ {
+  "input": "This is what we were doing earlier.",
+  "translatedText": "C'est ce qu’on faisait plus tôt.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1106.6,
+  "end": 1107.9
+ },
+ {
+  "input": "But with the other formula, to do that, you have to recompute everything each time.",
+  "translatedText": "Mais avec l’autre formule, pour pouvoir faire ça, il faudrait tout recalculer à chaque fois.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1108.42,
+  "end": 1112.2
+ },
+ {
+  "input": "You can't leverage a precomputed Bayes' factor the same way.",
+  "translatedText": "On ne peut pas utiliser un facteur de Bayes pré-calculé de la même manière.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1112.38,
+  "end": 1115.36
+ },
+ {
+  "input": "The odds framing also makes things really nice if you want to do multiple different Bayesian updates based on multiple pieces of evidence.",
+  "translatedText": "La formulation avec les cotes est aussi très pratique lorsqu’on veut effectuer des mises à jour bayésiennes en série basées sur plusieurs observations.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1115.96,
+  "end": 1122.12
+ },
+ {
+  "input": "For example, let's say you took not one test, but two.",
+  "translatedText": "Par exemple, disons que vous n’avez pas passé un test, mais deux.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1122.74,
+  "end": 1124.86
+ },
+ {
+  "input": "Or you wanted to think about how the presence of symptoms plays into it.",
+  "translatedText": "Ou que vous voulez inclure une information concernant la présence de certains symptômes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1125.36,
+  "end": 1128.54
+ },
+ {
+  "input": "For each piece of new evidence you see, you always ask the question, how much more likely would you be to see that with the disease versus without the disease?",
+  "translatedText": "Dès qu’on obtient une nouvelle information, on va toujours se demander : dans quel cas est-ce qu’il est plus probable d’observer cette information, en présence de la maladie, ou non ?",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1129.12,
+  "end": 1136.62
+ },
+ {
+  "input": "Each answer to that question gives you a new Bayes' factor, a new thing that you multiply by your odds.",
+  "translatedText": "Chaque réponse successive nous donne un nouveau facteur de Bayes, par lequel on va pouvoir multiplier notre cote précédente.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1137.24,
+  "end": 1142
+ },
+ {
+  "input": "Beyond just making calculations easier, there's something I really like about attaching a number to test accuracy that doesn't even look like a probability.",
+  "translatedText": "Au-delà de simplifier les calculs, il y a quelque chose que j'aime vraiment dans le fait d’utiliser un nombre qui n’est pas une probabilité pour mesurer la performance d’un test.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1142.88,
+  "end": 1149.92
+ },
+ {
+  "input": "I mean, if you hear that a test has, for example, a 9% false positive rate, that's just such a disastrously ambiguous phrase.",
+  "translatedText": "Par exemple, si on nous dit qu’un test A a un taux de faux positifs de 9 %, c’est une assertion incroyablement ambiguë.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1150.74,
+  "end": 1157.34
+ },
+ {
+  "input": "It's so easy to misinterpret it to mean there's a 9% chance that your positive test result is false.",
+  "translatedText": "C’est très facile de se méprendre et penser qu'il y a 9 % de chances que votre résultat positif soit faux.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1157.78,
+  "end": 1162.58
+ },
+ {
+  "input": "But imagine if instead the number that we heard tacked on to test results was that the Bayes' factor for a positive test result is, say, 10.",
+  "translatedText": "Mais imaginons qu’à la place, on nous dise à propos du test que son facteur de Bayes pour un résultat positif est, par exemple, de 10.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1163.3,
+  "end": 1170.32
+ },
+ {
+  "input": "There's no room to confuse that for your probability of having a disease.",
+  "translatedText": "Là, on ne peut plus interpréter ça à tort comme la probabilité d’être atteint d’une maladie.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1170.82,
+  "end": 1174.14
+ },
+ {
+  "input": "The entire framing of what a Bayes' factor is, is that it's something that acts on a prior.",
+  "translatedText": "L’idée au cœur de la définition du facteur de Bayes, c'est qu’il prend un a priori et agit dessus.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1174.64,
+  "end": 1179.04
+ },
+ {
+  "input": "It forces your hand to acknowledge the prior as something that's separate entirely, and highly necessary to drawing any conclusion.",
+  "translatedText": "Et ça oblige à considérer cet priori comme quelque chose de complètement distinct, et absolument nécessaire pour pouvoir tirer une quelconque conclusion.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1179.5,
+  "end": 1185.44
+ },
+ {
+  "input": "All that said, the usual formula is definitely not without its merits.",
+  "translatedText": "Cela dit, la forme habituelle a clairement des avantages.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1187.26,
+  "end": 1190.74
+ },
+ {
+  "input": "If you view it not simply as something to plug numbers into, but as an encapsulation of the sample population idea that we've been using throughout, you could very easily argue that that's actually much better for your intuition.",
+  "translatedText": "Si on ne la voit pas juste comme une formule à évaluer avec des valeurs données, mais comme portant cette idée de population fictive qu’on a utilisée tout du long, on pourrait se dire qu’elle est en fait bien plus utile à notre intuition.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1191.08,
+  "end": 1201.98
+ },
+ {
+  "input": "After all, it's what we were routinely falling back on in order to check ourselves that the Bayes' factor computation even made sense in the first place.",
+  "translatedText": "Après tout, c’est sur cette formule qu’on se basait à chaque fois pour vérifier que nos calculs incluant un facteur Bayes avaient bien du sens.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1202.56,
+  "end": 1209.18
+ },
+ {
+  "input": "Like any design decision, there is no clear-cut objective best here.",
+  "translatedText": "Comme dans tout processus de conception, on n’a pas une solution clairement meilleure que l’autre.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1211.6,
+  "end": 1215.38
+ },
+ {
+  "input": "But it's almost certainly the case that giving serious consideration to that question will lead you to a better understanding of Bayes' rule.",
+  "translatedText": "Mais il est à peu sûr que le fait de réfléchir sérieusement à cette question vous permettra de mieux comprendre le sens du théorème de Bayes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1215.42,
+  "end": 1221.72
+ },
+ {
+  "input": "Also, since we're on the topic of kind of paradoxical things, a friend of mine, Matt Cook, recently wrote a book all about paradoxes.",
+  "translatedText": "Et puisqu’on parle de choses un peu paradoxales ; Matt Cook, un ami à moi, a récemment écrit un livre qui traite beaucoup de paradoxes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1230.1,
+  "end": 1236.12
+ },
+ {
+  "input": "I actually contributed a small chapter to it with thoughts on the question of whether math is invented or discovered.",
+  "translatedText": "Et j’y ai d’ailleurs écrit un petit chapitre sur la question d’est-ce que les maths ont été plutôt inventées ou découvertes.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1237.04,
+  "end": 1241.82
+ },
+ {
+  "input": "And the book as a whole is this really nice connection of thought-provoking paradoxical things ranging from philosophy to math and physics.",
+  "translatedText": "Et le livre tisse un lien entre différents concepts paradoxaux qui vous feront réfléchir, en passant par la philosophie, les maths et ou la physique.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1242.3,
+  "end": 1248.4
+ },
+ {
+  "input": "You can, of course, find all the details in the description.",
+  "translatedText": "Vous pouvez retrouver tous les détails dans la description.",
+  "model": "google_nmt",
+  "n_reviews": 1,
+  "start": 1248.82,
+  "end": 1251.04
+ }
 ]

--- a/2020/better-bayes/french/title.json
+++ b/2020/better-bayes/french/title.json
@@ -1,5 +1,5 @@
 {
- "input": "The medical test paradox, and redesigning Bayes' rule",
- "translatedText": "Le paradoxe des tests médicaux et la refonte de la règle de Bayes",
- "n_reviews": 0
+  "input": "The medical test paradox, and redesigning Bayes' rule",
+  "translatedText": "Le paradoxe des tests de dépistage, et repenser le théorème de Bayes",
+  "n_reviews": 1
 }

--- a/2020/better-bayes/french/title.json
+++ b/2020/better-bayes/french/title.json
@@ -1,5 +1,5 @@
 {
-  "input": "The medical test paradox, and redesigning Bayes' rule",
-  "translatedText": "Le paradoxe des tests de dépistage, et une reformulation du théorème de Bayes",
-  "n_reviews": 1
+ "input": "The medical test paradox, and redesigning Bayes' rule",
+ "translatedText": "Le paradoxe des tests de dépistage, et une reformulation du théorème de Bayes",
+ "n_reviews": 1
 }

--- a/2020/better-bayes/french/title.json
+++ b/2020/better-bayes/french/title.json
@@ -1,5 +1,5 @@
 {
   "input": "The medical test paradox, and redesigning Bayes' rule",
-  "translatedText": "Le paradoxe des tests de dépistage, et repenser le théorème de Bayes",
+  "translatedText": "Le paradoxe des tests de dépistage, et une reformulation du théorème de Bayes",
   "n_reviews": 1
 }


### PR DESCRIPTION
This is a complete review of the automatic translations for the `better-bayes` video.

Notes:
- I tried to make the whole script consistent in terms of formality, e.g. through the use of the "on" pronoun.
- I preferred the word "performance" in french over "précision" when talking about test statistics, since it has — as in English — also the meaning of the `TP / (TP + FP)` ratio.