### PR TITLE
Add support for RTL languages

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -254,10 +254,6 @@ input[type="checkbox"] {
   height: 1em;
 }
 
-.rtl {
-  direction: rtl;
-}
-
 .spin {
   animation: spin 1s linear infinite;
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -254,6 +254,10 @@ input[type="checkbox"] {
   height: 1em;
 }
 
+.rtl {
+  direction: rtl;
+}
+
 .spin {
   animation: spin 1s linear infinite;
 }

--- a/app/src/pages/edit/Footer.tsx
+++ b/app/src/pages/edit/Footer.tsx
@@ -86,7 +86,7 @@ function Footer() {
               label="Show legacy translations"
               value={getShowLegacy}
               onChange={setShowLegacy}
-              data-tooltip="Show community contributed translations from back when YouTube had that feature built-in. For reference or copy/pasting.<br/><br/><b>Note:</b> The way they are split is different and they may apply to one or more adjacent entries."
+              data-tooltip={legacyTooltip}
             />
           )}
       </div>
@@ -139,3 +139,6 @@ function Footer() {
 }
 
 export default Footer;
+
+export const legacyTooltip =
+  "Community contributed translations from back when YouTube had that feature built-in. For reference or copy/pasting.<br/><br/><b>Note:</b> The way they are split is different and they may apply to one or more adjacent entries.";

--- a/app/src/pages/edit/Row.module.css
+++ b/app/src/pages/edit/Row.module.css
@@ -56,16 +56,11 @@
   color: var(--error);
 }
 
-.legacy {
-  display: flex;
+.legacyLabel {
+  grid-column: 1 / 2;
+  width: min-content;
+}
+
+.legacyText {
   grid-column: 2 / 3;
-  gap: 10px;
-}
-
-.legacy > :first-child {
-  flex-shrink: 0;
-}
-
-.legacy > :last-child {
-  flex-grow: 1;
 }

--- a/app/src/pages/edit/Row.module.css
+++ b/app/src/pages/edit/Row.module.css
@@ -18,7 +18,7 @@
   gap: 20px;
 }
 
-.playWarningWrapper {
+.playWrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -47,20 +47,15 @@
 }
 
 .warning {
+  border-width: 2px;
   border-style: dashed;
   border-color: var(--error);
-  border-width: 2px;
 }
 
-.warningTriangle {
-  marginLeft: '8px';
+.warningIcon {
   color: var(--error);
 }
 
 .legacy {
   grid-column: 2 / 3;
-}
-
-.rtl {
-  direction: rtl;
 }

--- a/app/src/pages/edit/Row.module.css
+++ b/app/src/pages/edit/Row.module.css
@@ -60,3 +60,7 @@
 .legacy {
   grid-column: 2 / 3;
 }
+
+.rtl {
+  direction: rtl;
+}

--- a/app/src/pages/edit/Row.module.css
+++ b/app/src/pages/edit/Row.module.css
@@ -57,5 +57,15 @@
 }
 
 .legacy {
+  display: flex;
   grid-column: 2 / 3;
+  gap: 10px;
+}
+
+.legacy > :first-child {
+  flex-shrink: 0;
+}
+
+.legacy > :last-child {
+  flex-grow: 1;
 }

--- a/app/src/pages/edit/Row.tsx
+++ b/app/src/pages/edit/Row.tsx
@@ -157,9 +157,9 @@ function Row({ index, entries }: Props) {
       <Textarea
         className={classNames(
           classes.edit,
-          rtlLanguage && "rtl",
           translationWarning && classes.warning,
         )}
+        dir={rtlLanguage ? "rtl" : "ltr"}
         value={currentTranslation}
         onChange={(value) => setEntry({ currentTranslation: value })}
         data-tooltip={"Edit translated text"}
@@ -206,9 +206,7 @@ function Row({ index, entries }: Props) {
       {legacyTranslation && getShowLegacy && getCompletion < 1 && (
         <div className={classes.legacy}>
           <strong>Legacy Translation</strong>
-          <span className={classNames(rtlLanguage && "rtl")}>
-            {legacyTranslation}
-          </span>
+          <span dir={rtlLanguage ? "rtl" : "ltr"}>{legacyTranslation}</span>
         </div>
       )}
     </div>

--- a/app/src/pages/edit/Row.tsx
+++ b/app/src/pages/edit/Row.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { FaExclamationTriangle } from "react-icons/fa";
 import {
   FaArrowsRotate,
   FaFlag,
@@ -7,7 +8,6 @@ import {
   FaStop,
   FaThumbsUp,
 } from "react-icons/fa6";
-import { FaExclamationTriangle } from 'react-icons/fa';
 import { Link, useParams } from "react-router-dom";
 import classNames from "classnames";
 import { useAtom, useAtomValue } from "jotai";
@@ -25,6 +25,7 @@ import {
   title,
 } from "@/pages/Edit";
 import { glow, scrollIntoView } from "@/util/dom";
+import { isRtl } from "@/util/language";
 import { formatTime } from "@/util/string";
 import classes from "./Row.module.css";
 
@@ -84,9 +85,8 @@ function Row({ index, entries }: Props) {
     currentTranslation.length >= translationMax(entry, language);
   const originalWarning = currentOriginal.length >= originalMax(entry);
 
-  /** right to left languages need special styling, and the "legacy translation" label needs to be translated for them */
-  const rtlLanguage = ["arabic", "hebrew", "persian", "urdu"].includes(language);
-  const legacyLabel = rtlLanguage ? { "hebrew": "תרגום עבר", "arabic": "الترجمة القديمة", "persian": "ترجمه قدیمی", "urdu": "پرانا ترجمہ" }[language] : "Legacy translation";
+  /** right to left languages need special styling */
+  const rtlLanguage = isRtl(language);
 
   /** issue url params */
   const issueTitle = `${lesson}/${language}`;
@@ -101,7 +101,10 @@ function Row({ index, entries }: Props) {
   return (
     <div
       ref={ref}
-      className={classNames(classes.row, (edited || upvoted || reviews > 0) && classes.edited)}
+      className={classNames(
+        classes.row,
+        (edited || upvoted || reviews > 0) && classes.edited,
+      )}
     >
       {/* actions */}
       <div className={classes.actions}>
@@ -113,10 +116,10 @@ function Row({ index, entries }: Props) {
           <span>{edited ? 1 : reviews + Number(upvoted)}</span>
         </button>
 
-        <div className={classes.playWarningWrapper}>
+        <div className={classes.playWrapper}>
           {translationWarning && (
-            <FaExclamationTriangle 
-              className={classes.warningTriangle}
+            <FaExclamationTriangle
+              className={classes.warningIcon}
               data-tooltip="This translation may be too long to fit in the time slot"
             />
           )}
@@ -136,7 +139,9 @@ function Row({ index, entries }: Props) {
 
                   /** expand header */
                   const expand = innerHeight / 3;
-                  if (parseFloat(window.getComputedStyle(header).height) < expand)
+                  if (
+                    parseFloat(window.getComputedStyle(header).height) < expand
+                  )
                     header.style.height = expand + "px";
                 }
               }}
@@ -152,7 +157,7 @@ function Row({ index, entries }: Props) {
       <Textarea
         className={classNames(
           classes.edit,
-          rtlLanguage && classes.rtl,
+          rtlLanguage && "rtl",
           translationWarning && classes.warning,
         )}
         value={currentTranslation}
@@ -168,7 +173,9 @@ function Row({ index, entries }: Props) {
         )}
         value={entry.currentOriginal}
         onChange={(value) => setEntry({ currentOriginal: value })}
-        data-tooltip={"Original English text. If you see a significant problem, click to edit."}
+        data-tooltip={
+          "Original English text. If you see a significant problem, click to edit."
+        }
       />
 
       {/* secondary actions */}
@@ -197,11 +204,8 @@ function Row({ index, entries }: Props) {
 
       {/* legacy translation */}
       {legacyTranslation && getShowLegacy && getCompletion < 1 && (
-          <div className={classNames(
-              classes.legacy,
-              rtlLanguage && classes.rtl,
-          )}>
-          <strong>{legacyLabel}</strong>: {legacyTranslation}
+        <div className={classNames(classes.legacy, rtlLanguage && "rtl")}>
+          <strong>Legacy Translation</strong> {legacyTranslation}
         </div>
       )}
     </div>

--- a/app/src/pages/edit/Row.tsx
+++ b/app/src/pages/edit/Row.tsx
@@ -204,10 +204,15 @@ function Row({ index, entries }: Props) {
 
       {/* legacy translation */}
       {legacyTranslation && getShowLegacy && getCompletion < 1 && (
-        <div className={classes.legacy}>
-          <strong>Legacy Translation</strong>
-          <span dir={rtlLanguage ? "rtl" : "ltr"}>{legacyTranslation}</span>
-        </div>
+        <>
+          <strong className={classes.legacyLabel}>Legacy:</strong>
+          <span
+            className={classes.legacyText}
+            dir={rtlLanguage ? "rtl" : "ltr"}
+          >
+            {legacyTranslation}
+          </span>
+        </>
       )}
     </div>
   );

--- a/app/src/pages/edit/Row.tsx
+++ b/app/src/pages/edit/Row.tsx
@@ -84,6 +84,10 @@ function Row({ index, entries }: Props) {
     currentTranslation.length >= translationMax(entry, language);
   const originalWarning = currentOriginal.length >= originalMax(entry);
 
+  /** right to left languages need special styling, and the "legacy translation" label needs to be translated for them */
+  const rtlLanguage = ["arabic", "hebrew", "persian", "urdu"].includes(language);
+  const legacyLabel = rtlLanguage ? { "hebrew": "תרגום עבר", "arabic": "الترجمة القديمة", "persian": "ترجمه قدیمی", "urdu": "پرانا ترجمہ" }[language] : "Legacy translation";
+
   /** issue url params */
   const issueTitle = `${lesson}/${language}`;
   const issueBody = [
@@ -148,6 +152,7 @@ function Row({ index, entries }: Props) {
       <Textarea
         className={classNames(
           classes.edit,
+          rtlLanguage && classes.rtl,
           translationWarning && classes.warning,
         )}
         value={currentTranslation}
@@ -192,8 +197,11 @@ function Row({ index, entries }: Props) {
 
       {/* legacy translation */}
       {legacyTranslation && getShowLegacy && getCompletion < 1 && (
-        <div className={classes.legacy}>
-          <strong>Legacy translation</strong>: {legacyTranslation}
+          <div className={classNames(
+              classes.legacy,
+              rtlLanguage && classes.rtl,
+          )}>
+          <strong>{legacyLabel}</strong>: {legacyTranslation}
         </div>
       )}
     </div>

--- a/app/src/pages/edit/Row.tsx
+++ b/app/src/pages/edit/Row.tsx
@@ -24,6 +24,7 @@ import {
   showLegacy,
   title,
 } from "@/pages/Edit";
+import { legacyTooltip } from "@/pages/edit/Footer";
 import { glow, scrollIntoView } from "@/util/dom";
 import { isRtl } from "@/util/language";
 import { formatTime } from "@/util/string";
@@ -205,7 +206,9 @@ function Row({ index, entries }: Props) {
       {/* legacy translation */}
       {legacyTranslation && getShowLegacy && getCompletion < 1 && (
         <>
-          <strong className={classes.legacyLabel}>Legacy:</strong>
+          <strong className={classes.legacyLabel} data-tooltip={legacyTooltip}>
+            Legacy:
+          </strong>
           <span
             className={classes.legacyText}
             dir={rtlLanguage ? "rtl" : "ltr"}

--- a/app/src/pages/edit/Row.tsx
+++ b/app/src/pages/edit/Row.tsx
@@ -204,8 +204,11 @@ function Row({ index, entries }: Props) {
 
       {/* legacy translation */}
       {legacyTranslation && getShowLegacy && getCompletion < 1 && (
-        <div className={classNames(classes.legacy, rtlLanguage && "rtl")}>
-          <strong>Legacy Translation</strong> {legacyTranslation}
+        <div className={classes.legacy}>
+          <strong>Legacy Translation</strong>
+          <span className={classNames(rtlLanguage && "rtl")}>
+            {legacyTranslation}
+          </span>
         </div>
       )}
     </div>

--- a/app/src/util/language.ts
+++ b/app/src/util/language.ts
@@ -1,0 +1,4 @@
+/** is language right-to-left */
+export function isRtl(language: string) {
+  return ["arabic", "hebrew", "persian", "urdu"].includes(language);
+}


### PR DESCRIPTION
RTL languages include: Hebrew, Arabic, Persian and Urdu (let me know if I missed any)

The text area for right to left languages needs special styling (`direction: rtl`), otherwise editing sentences in these languages is a rather miserable experience (especially when mixing numbers / English phrases which are written left to right).

Also the "legacy translation" div needs to be right to left as well. And its short label has to be translated to the respective language, since its concatenated on the right, and it looks awkward when it's in English.

I've relied on Google Translate / copliot to translate the "legacy translation" label to Arabic, Persian and Urdu, so I'm not actually sure they're accurate or make any sense, feel free to offer alternative phrasing.
