### PR TITLE
Only allow vertical resizing of edit textarea

### DIFF
--- a/app/src/pages/edit/Row.module.css
+++ b/app/src/pages/edit/Row.module.css
@@ -32,7 +32,7 @@
   max-width: 50vw;
   height: 1lh;
   min-height: 1lh;
-  resize: both;
+  resize: vertical;
 }
 
 .original {


### PR DESCRIPTION
Manual horizontal resizing completely messes up the page structure, and it's very easy for a user to accidentally do horizontal resizing while trying to perform vertical resizing with their cursor. Vertical-only resize prevents that.